### PR TITLE
fix(web): IME変換中のEnterで誤送信されないようにする

### DIFF
--- a/packages/web/src/components/chat/chat-input.tsx
+++ b/packages/web/src/components/chat/chat-input.tsx
@@ -263,6 +263,10 @@ export function ChatInput({
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Skip all handling while IME composition is in progress (Japanese/Chinese/Korean input).
+    // Without this, pressing Enter to confirm a conversion would submit the message.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return
+
     // Command autocomplete navigation
     if (showCommands && filteredCommands.length > 0) {
       const max = filteredCommands.length


### PR DESCRIPTION
## 概要
チャット入力欄で日本語（CJK）のIME変換を確定するEnterが、そのまま送信として扱われていた問題を修正しました。

## 症状
「これで修正完了したかな」と1文入力して変換→Enterを押すと、
「これで修正」「これで修正完了したかな」「完了したかな」のように
複数のメッセージに分割されて送信される。

## 原因
`chat-input.tsx` の `handleKeyDown` が `e.nativeEvent.isComposing` を見ずに Enter を送信扱いしていた。

## 修正
`handleKeyDown` の先頭で IME 変換中のキーイベント（`isComposing` または `keyCode === 229`）を早期returnでスキップ。

## 動作確認
- [x] Chrome + Google日本語入力で「これで修正完了したかな」を入力 → 1メッセージとして送信されることを確認
- [x] Shift+Enter の改行、Enter送信（非IME時）が従来通り動くことを確認
- [x] スラッシュコマンド / @メンション補完のEnter選択が従来通り動くことを確認