### PR TITLE
fix(slack): handle free_team_canvas_tab_already_exists in agents-canvas

### DIFF
--- a/packages/jimmy/src/connectors/slack/__tests__/agents-canvas.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/agents-canvas.test.ts
@@ -405,3 +405,112 @@ describe("renderCanvasMarkdown — user-controlled string defang", () => {
     expect(md).toContain("\\#");
   });
 });
+
+describe("AgentsCanvasUpdater — free_team_canvas_tab_already_exists recovery", () => {
+  // Regression coverage: on free Slack workspaces the create call (either
+  // conversations.canvases.create or canvases.create) fails with
+  // `free_team_canvas_tab_already_exists`. The updater must adopt the existing
+  // canvas if it can be located, and otherwise stop the timer instead of
+  // looping every poll interval.
+
+  function makeSlackError(code: string): Error & { data: { error: string } } {
+    const err = new Error(`An API error occurred: ${code}`) as Error & {
+      data: { error: string };
+    };
+    err.data = { error: code };
+    return err;
+  }
+
+  function makeFakeApp(apiCall: (method: string, payload: unknown) => unknown) {
+    return { client: { apiCall: vi.fn(apiCall) } } as unknown as ConstructorParameters<
+      typeof AgentsCanvasUpdater
+    >[0];
+  }
+
+  it("adopts the existing channel canvas when create returns free_team_canvas_tab_already_exists", async () => {
+    const calls: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const app = makeFakeApp(async (method, payload) => {
+      calls.push({ method, payload: payload as Record<string, unknown> });
+      if (method === "conversations.canvases.create") {
+        throw makeSlackError("free_team_canvas_tab_already_exists");
+      }
+      if (method === "conversations.info") {
+        return { channel: { properties: { canvas: { file_id: "F_EXISTING" } } } };
+      }
+      if (method === "canvases.edit") {
+        return { ok: true };
+      }
+      throw new Error(`unexpected api call ${method}`);
+    });
+
+    const updater = new AgentsCanvasUpdater(app, {
+      enabled: true,
+      channelId: "C123",
+      pollIntervalMs: 5_000,
+    });
+    await (updater as unknown as { tick(): Promise<void> }).tick();
+
+    const methods = calls.map((c) => c.method);
+    expect(methods).toContain("conversations.canvases.create");
+    expect(methods).toContain("conversations.info");
+    const edit = calls.find((c) => c.method === "canvases.edit");
+    expect(edit?.payload.canvas_id).toBe("F_EXISTING");
+  });
+
+  it("falls back to files.list when the channel does not own the existing canvas", async () => {
+    const calls: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const app = makeFakeApp(async (method, payload) => {
+      calls.push({ method, payload: payload as Record<string, unknown> });
+      if (method === "conversations.canvases.create") {
+        throw makeSlackError("free_team_canvas_tab_already_exists");
+      }
+      if (method === "conversations.info") {
+        return { channel: {} };
+      }
+      if (method === "files.list") {
+        return { files: [{ id: "F_STANDALONE", title: "Ryoko Agents View" }] };
+      }
+      if (method === "canvases.edit") {
+        return { ok: true };
+      }
+      throw new Error(`unexpected api call ${method}`);
+    });
+
+    const updater = new AgentsCanvasUpdater(app, {
+      enabled: true,
+      channelId: "C123",
+      pollIntervalMs: 5_000,
+    });
+    await (updater as unknown as { tick(): Promise<void> }).tick();
+
+    const methods = calls.map((c) => c.method);
+    expect(methods).toContain("files.list");
+    const edit = calls.find((c) => c.method === "canvases.edit");
+    expect(edit?.payload.canvas_id).toBe("F_STANDALONE");
+  });
+
+  it("stops the updater after one log when no existing canvas can be located", async () => {
+    const app = makeFakeApp(async (method) => {
+      if (method === "conversations.canvases.create") {
+        throw makeSlackError("free_team_canvas_tab_already_exists");
+      }
+      if (method === "conversations.info") return { channel: {} };
+      if (method === "files.list") return { files: [] };
+      throw new Error(`unexpected api call ${method}`);
+    });
+
+    const updater = new AgentsCanvasUpdater(app, {
+      enabled: true,
+      channelId: "C123",
+      pollIntervalMs: 5_000,
+    });
+    await (updater as unknown as { tick(): Promise<void> }).tick();
+
+    // Second tick must be a no-op now that the timer has been stopped — i.e.
+    // no further apiCalls should happen on subsequent invocations.
+    const fakeClient = (app as unknown as { client: { apiCall: ReturnType<typeof vi.fn> } }).client;
+    const callsBefore = fakeClient.apiCall.mock.calls.length;
+    await (updater as unknown as { tick(): Promise<void> }).tick();
+    expect(fakeClient.apiCall.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/packages/jimmy/src/connectors/slack/agents-canvas.ts
+++ b/packages/jimmy/src/connectors/slack/agents-canvas.ts
@@ -376,35 +376,83 @@ export class AgentsCanvasUpdater {
         }
         this.canvasId = canvasId;
       } catch (err) {
-        // If the channel already has a Canvas (created previously by us, by
-        // another instance, or manually), Slack returns `channel_canvas_already_exists`.
-        // Recover by reading the existing canvas id from conversations.info and
-        // editing that one instead of bailing out.
-        if (isChannelCanvasAlreadyExistsError(err)) {
-          const existingId = await this.fetchExistingChannelCanvasId(this.config.channelId);
-          if (!existingId) {
-            throw err;
+        // Recover from two Slack failure modes:
+        //   - `channel_canvas_already_exists`: this channel already has a canvas.
+        //   - `free_team_canvas_tab_already_exists`: free plan has used its one
+        //     allowed canvas (anywhere in the workspace).
+        // For both, find the existing canvas and edit it instead of looping.
+        if (isChannelCanvasAlreadyExistsError(err) || isFreeTeamCanvasAlreadyExistsError(err)) {
+          const existingId =
+            (await this.fetchExistingChannelCanvasId(this.config.channelId))
+            ?? (await this.findExistingStandaloneCanvasId());
+          if (existingId) {
+            logger.info(`[agents-canvas] adopting existing canvas ${existingId}`);
+            this.canvasId = existingId;
+            saveState({ canvasId: existingId, channelId: this.config.channelId });
+            await this.editCanvas(existingId, markdown);
+            return;
           }
-          logger.info(`[agents-canvas] adopting existing channel canvas ${existingId}`);
-          this.canvasId = existingId;
-          await this.editCanvas(existingId, markdown);
-        } else {
-          throw err;
+          logger.error(
+            "[agents-canvas] canvas already exists per Slack but none could be located — disabling updates to stop the retry loop.",
+          );
+          this.stop();
+          return;
         }
+        throw err;
       }
     } else {
-      const res = await this.client.apiCall("canvases.create", {
-        title: this.config.title,
-        document_content: documentContent,
-      });
-      const canvasId = extractCanvasId(res);
-      if (!canvasId) {
-        throw new Error(`canvases.create returned no canvas_id: ${JSON.stringify(res).slice(0, 200)}`);
+      try {
+        const res = await this.client.apiCall("canvases.create", {
+          title: this.config.title,
+          document_content: documentContent,
+        });
+        const canvasId = extractCanvasId(res);
+        if (!canvasId) {
+          throw new Error(`canvases.create returned no canvas_id: ${JSON.stringify(res).slice(0, 200)}`);
+        }
+        this.canvasId = canvasId;
+      } catch (err) {
+        // Free Slack workspaces are limited to a single standalone canvas. If
+        // one already exists (e.g. left over from a previous run), adopt it
+        // instead of looping forever on the create call.
+        if (isFreeTeamCanvasAlreadyExistsError(err)) {
+          const existingId = await this.findExistingStandaloneCanvasId();
+          if (existingId) {
+            logger.info(`[agents-canvas] adopting existing standalone canvas ${existingId}`);
+            this.canvasId = existingId;
+            saveState({ canvasId: existingId, channelId: this.config.channelId });
+            await this.editCanvas(existingId, markdown);
+            return;
+          }
+          logger.error(
+            "[agents-canvas] free workspace standalone canvas limit reached and no existing canvas matched by title — disabling updates. Set agentsCanvas.channelId to host the canvas in a channel instead.",
+          );
+          this.stop();
+          return;
+        }
+        throw err;
       }
-      this.canvasId = canvasId;
     }
     saveState({ canvasId: this.canvasId, channelId: this.config.channelId });
     logger.info(`[agents-canvas] created canvas ${this.canvasId}`);
+  }
+
+  private async findExistingStandaloneCanvasId(): Promise<string | null> {
+    try {
+      const res = await this.client.apiCall("files.list", {
+        types: "canvases",
+        count: 100,
+      });
+      const files = res.files as Array<Record<string, unknown>> | undefined;
+      if (!Array.isArray(files)) return null;
+      const match = files.find((f) => typeof f.title === "string" && f.title === this.config.title)
+        ?? files.find((f) => typeof f.name === "string" && f.name === this.config.title);
+      const id = match?.id;
+      return typeof id === "string" && id ? id : null;
+    } catch (err) {
+      logger.warn(`[agents-canvas] failed to look up existing standalone canvas: ${err}`);
+      return null;
+    }
   }
 
   private async fetchExistingChannelCanvasId(channelId: string): Promise<string | null> {
@@ -457,4 +505,12 @@ function isCanvasNotFoundError(err: unknown): boolean {
   if (code && /(?:not_found|notfound|missing|deleted)/i.test(code)) return true;
   const msg = err instanceof Error ? err.message : String(err);
   return /(?:canvas|file).*(?:not_found|not found|missing|deleted)|(?:not_found|not found|missing|deleted).*(?:canvas|file)/i.test(msg);
+}
+
+function isFreeTeamCanvasAlreadyExistsError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const data = (err as { data?: { error?: string } }).data;
+  if (data?.error === "free_team_canvas_tab_already_exists") return true;
+  const msg = err instanceof Error ? err.message : String(err);
+  return /free_team_canvas_tab_already_exists/.test(msg);
 }


### PR DESCRIPTION
## Summary
- agents-canvas updater が 30秒ごとに `tick failed: free_team_canvas_tab_already_exists` を吐き続ける問題を修正
- channel-canvas / standalone-canvas どちらのパスでも同エラーをハンドルし、既存 canvas を adopt
- 既存 canvas が見つからない場合は1回だけ ERROR ログを出して updater を停止(無限リトライ防止)

## Problem
フリープランの Slack workspace で agents-canvas が有効な場合、`conversations.canvases.create` (channelId 指定時) または `canvases.create` (standalone) が `free_team_canvas_tab_already_exists` を返す。

これまでの実装は channel-canvas 側で `channel_canvas_already_exists` しか catch しておらず、free 制限エラーは tick() の catch まで伝播 → 毎 tick 失敗 → 30秒間隔で WARN ログが永遠に流れる状態でした。

実機ログ抜粋:
```
2026-05-22T02:30:54.416Z [WARN] [agents-canvas] tick failed: Error: An API error occurred: free_team_canvas_tab_already_exists
2026-05-22T02:31:24.385Z [WARN] [agents-canvas] tick failed: Error: An API error occurred: free_team_canvas_tab_already_exists
...
```
(数時間で 1000 行超)

## Solution
`free_team_canvas_tab_already_exists` を `channel_canvas_already_exists` と同様に扱う:
1. `conversations.info` で channel 上の既存 canvas を探す
2. 見つからなければ `files.list?types=canvases` でタイトル一致の standalone canvas を探す
3. 見つかれば adopt して `canvases.edit` で内容更新
4. それでも見つからなければ ERROR を 1 回出して `stop()` でタイマー停止

## Test plan
- [x] `pnpm typecheck` 全パッケージ pass
- [x] `pnpm --filter @openryoko/jimmy test` 335/335 pass(新規 3 件追加: 各分岐の単体テスト)
- [x] 実機 (`ryoko start`) を再起動後、`gateway.log` にエラーループが出ないことを確認

> Note: `@openryoko/web` のテスト失敗は本変更前から発生する pre-existing で本 PR とは無関係です。