### PR TITLE
fix(agents-canvas): self-disable after consecutive tick failures

### DIFF
--- a/packages/jimmy/src/connectors/slack/__tests__/agents-canvas.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/agents-canvas.test.ts
@@ -235,6 +235,69 @@ describe("AgentsCanvasUpdater", () => {
     expect(apiCall.mock.calls.filter(([method]) => method === "canvases.create")).toHaveLength(2);
     expect(apiCall.mock.calls.filter(([method]) => method === "canvases.edit")).toHaveLength(1);
   });
+
+  it("self-disables after 10 consecutive tick failures and stops calling Slack", async () => {
+    const apiCall = vi.fn(async (method: string) => {
+      if (method === "canvases.create") {
+        const err = new Error("canvas_tab_creation_failed");
+        (err as any).data = { error: "canvas_tab_creation_failed" };
+        throw err;
+      }
+      return {};
+    });
+    const updater = new AgentsCanvasUpdater(
+      { client: { apiCall } } as any,
+      { enabled: true, pollIntervalMs: 5_000 },
+    );
+
+    // 10 consecutive failures → the loop should give up and stop itself.
+    for (let i = 0; i < 10; i++) {
+      await (updater as any).tick();
+    }
+    expect((updater as any).stopped).toBe(true);
+    const createsAtDisable = apiCall.mock.calls.filter(([m]) => m === "canvases.create").length;
+    expect(createsAtDisable).toBe(10);
+
+    // Further ticks are no-ops — a self-disabled loop must not keep hitting Slack.
+    await (updater as any).tick();
+    await (updater as any).tick();
+    expect(apiCall.mock.calls.filter(([m]) => m === "canvases.create").length).toBe(createsAtDisable);
+  });
+
+  it("resets the failure counter after a successful tick", async () => {
+    let failCreate = true;
+    let n = 0;
+    const apiCall = vi.fn(async (method: string) => {
+      if (method === "canvases.create") {
+        if (failCreate) {
+          const err = new Error("canvas_tab_creation_failed");
+          (err as any).data = { error: "canvas_tab_creation_failed" };
+          throw err;
+        }
+        return { canvas_id: "F1" };
+      }
+      return {};
+    });
+    const updater = new AgentsCanvasUpdater(
+      { client: { apiCall } } as any,
+      { enabled: true, pollIntervalMs: 5_000 },
+    );
+    // Vary sessions every tick so the no-op short-circuit never fires.
+    vi.mocked(listSessions).mockImplementation(() => [
+      makeSession({ id: `s${n++}`, status: "running", title: `s${n}` }),
+    ]);
+
+    // 9 consecutive create failures — one short of the limit.
+    for (let i = 0; i < 9; i++) await (updater as any).tick();
+    expect((updater as any).consecutiveFailures).toBe(9);
+    expect((updater as any).stopped).toBe(false);
+
+    // A successful tick clears the counter, so a transient outage never trips the limit.
+    failCreate = false;
+    await (updater as any).tick();
+    expect((updater as any).consecutiveFailures).toBe(0);
+    expect((updater as any).stopped).toBe(false);
+  });
 });
 
 describe("renderCanvasMarkdown — user-controlled string defang", () => {

--- a/packages/jimmy/src/connectors/slack/agents-canvas.ts
+++ b/packages/jimmy/src/connectors/slack/agents-canvas.ts
@@ -44,6 +44,14 @@ const DEFAULT_TITLE = "Ryoko Agents View";
 const DEFAULT_POLL_MS = 30_000;
 const MIN_POLL_MS = 5_000;
 const DEFAULT_MAX_PER_GROUP = 10;
+/**
+ * Self-disable the canvas loop after this many consecutive tick failures.
+ * At the default 30s interval this is ~5 minutes of solid failures — long
+ * enough to ride out transient Slack hiccups, short enough that a genuinely
+ * broken canvas (missing scope, deleted channel, etc.) stops spamming the
+ * logs and Slack API instead of failing every 30s forever.
+ */
+const MAX_CONSECUTIVE_FAILURES = 10;
 
 type SessionStateGroup = "running" | "waiting" | "interrupted" | "error" | "idle";
 
@@ -241,6 +249,8 @@ export class AgentsCanvasUpdater {
   private timer: ReturnType<typeof setInterval> | null = null;
   private inflight = false;
   private stopped = false;
+  /** Consecutive tick() failures — resets to 0 on any successful tick. */
+  private consecutiveFailures = 0;
   private canvasId: string | null = null;
   private lastMarkdown: string | null = null;
   private readonly client: SlackClientLike;
@@ -272,6 +282,7 @@ export class AgentsCanvasUpdater {
     }
     if (this.timer) return; // already running — make start() idempotent
     this.stopped = false;
+    this.consecutiveFailures = 0;
     logger.info(
       `[agents-canvas] starting (interval=${this.config.pollIntervalMs}ms, channel=${this.config.channelId || "standalone"})`,
     );
@@ -300,15 +311,29 @@ export class AgentsCanvasUpdater {
         maxPerGroup: this.config.maxPerGroup,
       });
       // Skip no-op updates to spare Slack API calls + avoid edit churn.
-      if (markdown === this.lastMarkdown) return;
+      if (markdown === this.lastMarkdown) {
+        this.consecutiveFailures = 0;
+        return;
+      }
       // stop() may have fired while we were rendering — bail before any I/O.
       if (this.stopped) return;
       const published = await this.publish(markdown);
       if (published) {
         this.lastMarkdown = markdown;
       }
+      this.consecutiveFailures = 0;
     } catch (err) {
-      logger.warn(`[agents-canvas] tick failed: ${err}`);
+      this.consecutiveFailures++;
+      logger.warn(
+        `[agents-canvas] tick failed (${this.consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES}): ${err}`,
+      );
+      if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        logger.error(
+          `[agents-canvas] disabling after ${this.consecutiveFailures} consecutive failures — ` +
+            `last error: ${err}. Fix the cause and restart the gateway to re-enable.`,
+        );
+        this.stop();
+      }
     } finally {
       this.inflight = false;
     }


### PR DESCRIPTION
## Problem

The Agents View canvas loop (`AgentsCanvasUpdater`) retried every 30s **indefinitely** when canvas creation failed — e.g. `canvas_tab_creation_failed` from a missing Slack scope or an unsupported channel. This silently spammed the logs and the Slack API forever (observed: 121 failures/hour) with no signal to the operator.

## Change

- Track consecutive `tick()` failures and **self-disable the loop after 10 in a row** (~5 min at the default 30s interval) with an `ERROR`-level log.
- The counter resets on any successful tick, so transient outages don't trip it.
- `start()` re-arms the counter, so a gateway restart re-enables the loop once the underlying cause is fixed.

## Test

- `tsc --noEmit` passes.
- 21 tests pass (19 existing + 2 new):
  - self-disables after 10 consecutive failures and stops calling Slack
  - resets the failure counter after a successful tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)