### PR TITLE
fix(slack): make slash commands work inside threads

### DIFF
--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -16,6 +16,7 @@ import { runTriage } from "./triage.js";
 import { ConversationTracker } from "./conversation-tracker.js";
 import { AgentsCanvasUpdater } from "./agents-canvas.js";
 import { extractGoalCondition, shouldExtractGoal } from "./goal-extractor.js";
+import { startsWithSlashCommand } from "../../sessions/manager.js";
 import type { SlackTriageConfig } from "../../shared/types.js";
 import { TMP_DIR } from "../../shared/paths.js";
 import { logger } from "../../shared/logger.js";
@@ -380,6 +381,13 @@ export class SlackConnector implements Connector {
         }
       }
 
+      // Slash commands (/new, /status, …) are control directives the session
+      // manager parses by exact string match. Wrapping them in the
+      // "[Thread context — …]" preamble below silently breaks that parsing,
+      // so a command typed inside a Slack thread would never be intercepted.
+      // Commands don't need conversation context anyway — pass them verbatim.
+      const text = startsWithSlashCommand(rawText) ? rawText : parentContext + rawText;
+
       const msg: IncomingMessage = {
         connector: this.name,
         source: "slack",
@@ -390,7 +398,7 @@ export class SlackConnector implements Connector {
         thread: (event as any).thread_ts,
         user: (event as any).user,
         userId: (event as any).user,
-        text: parentContext + rawText,
+        text,
         attachments,
         raw: event,
         transportMeta: {

--- a/packages/jimmy/src/sessions/__tests__/slash-commands.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/slash-commands.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+
+import { SLASH_COMMANDS, startsWithSlashCommand } from "../manager.js";
+
+describe("startsWithSlashCommand", () => {
+  it("matches a bare slash command", () => {
+    expect(startsWithSlashCommand("/new")).toBe(true);
+    expect(startsWithSlashCommand("/status")).toBe(true);
+  });
+
+  it("matches a slash command with arguments", () => {
+    expect(startsWithSlashCommand("/model opus")).toBe(true);
+    expect(startsWithSlashCommand("/cron list")).toBe(true);
+  });
+
+  it("tolerates leading whitespace", () => {
+    expect(startsWithSlashCommand("  /new")).toBe(true);
+  });
+
+  it("does NOT match a command buried after a thread-context preamble", () => {
+    // Regression: the Slack connector prepended "[Thread context — …]" to every
+    // threaded message, pushing the command out of first position so that
+    // SessionManager.handleCommand() never intercepted it.
+    expect(
+      startsWithSlashCommand('[Thread context — parent message: "x"]\n\n/new'),
+    ).toBe(false);
+  });
+
+  it("does not match ordinary messages or unknown commands", () => {
+    expect(startsWithSlashCommand("hello")).toBe(false);
+    expect(startsWithSlashCommand("/unknown")).toBe(false);
+    expect(startsWithSlashCommand("/newsletter")).toBe(false);
+  });
+
+  it("covers every command the session manager handles", () => {
+    for (const cmd of SLASH_COMMANDS) {
+      expect(startsWithSlashCommand(cmd)).toBe(true);
+    }
+  });
+});

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -37,6 +37,20 @@ export interface RouteOptions {
   title?: string;
 }
 
+/**
+ * Control slash commands handled by {@link SessionManager.handleCommand}.
+ * Connectors should treat a message that begins with one of these as a bare
+ * command and NOT wrap it with conversation context — handleCommand() matches
+ * them by exact string / prefix, so any preamble breaks the parsing.
+ */
+export const SLASH_COMMANDS = ["/new", "/status", "/model", "/doctor", "/cron"] as const;
+
+/** True when `text` begins with a control slash command (see {@link SLASH_COMMANDS}). */
+export function startsWithSlashCommand(text: string): boolean {
+  const t = text.trimStart();
+  return SLASH_COMMANDS.some((cmd) => t === cmd || t.startsWith(`${cmd} `));
+}
+
 function maybeRevertEngineOverride(session: Session): Session {
   const meta = (session.transportMeta || {}) as Record<string, unknown>;
   const override = meta["engineOverride"] as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Problem

Slash commands (`/new`, `/status`, `/model`, `/doctor`, `/cron`) were **silently ignored** for any message sent inside a Slack thread.

The Slack connector prepends a `[Thread context — parent message: "…"]` preamble to every threaded message before handing it to the session manager. `SessionManager.handleCommand()` detects commands by exact string match (`text === "/new"`), so the preamble pushed the command out of first position — the command was never intercepted and fell through to the engine as an ordinary message.

The user-visible symptom: `/new` typed in a long-lived DM thread never reset the session. The thread kept resuming its original engine session forever, so e.g. changing `engines.default` had no effect on that conversation — a fresh session was never created.

Confirmed from a stored transcript — the message that reached `handleCommand()` was literally:
```
[Thread context — parent message: "新しいアシスタントスレッド"]\n\n/new
```

## Change

- Detect slash commands on the **raw user text** and skip the thread-context preamble for them. A control directive needs no conversation context.
- Add an exported `SLASH_COMMANDS` / `startsWithSlashCommand()` helper in `sessions/manager.ts` so the connector and the session manager agree on what counts as a command (no duplicated literals).

## Test

- `tsc --noEmit` passes.
- 130 tests pass (8 files), including a new `slash-commands.test.ts` with a regression case for the buried-command bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)