### PR TITLE
feat(slack): give each DM thread its own session

### DIFF
--- a/packages/jimmy/src/connectors/slack/__tests__/threads.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/threads.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+
+import { deriveSessionKey, buildReplyContext, isOldSlackMessage } from "../threads.js";
+
+describe("deriveSessionKey", () => {
+  it("keys a non-threaded DM message to one long-lived session per user", () => {
+    expect(
+      deriveSessionKey({ channel: "D1", user: "U1", ts: "100.0", channel_type: "im" }),
+    ).toBe("slack:dm:U1");
+  });
+
+  it("keys a threaded DM message to its own per-thread session", () => {
+    expect(
+      deriveSessionKey({
+        channel: "D1",
+        user: "U1",
+        ts: "200.0",
+        thread_ts: "100.0",
+        channel_type: "im",
+      }),
+    ).toBe("slack:dm:U1:100.0");
+  });
+
+  it("keeps two DM threads on separate sessions", () => {
+    const a = deriveSessionKey({ channel: "D1", user: "U1", ts: "201.0", thread_ts: "100.0", channel_type: "im" });
+    const b = deriveSessionKey({ channel: "D1", user: "U1", ts: "301.0", thread_ts: "300.0", channel_type: "im" });
+    expect(a).not.toBe(b);
+  });
+
+  it("keys a channel root message by its own ts", () => {
+    expect(
+      deriveSessionKey({ channel: "C1", user: "U1", ts: "100.0", channel_type: "channel" }),
+    ).toBe("slack:C1:100.0");
+  });
+
+  it("keys a channel thread reply by thread_ts so it matches the root", () => {
+    expect(
+      deriveSessionKey({ channel: "C1", user: "U1", ts: "200.0", thread_ts: "100.0", channel_type: "channel" }),
+    ).toBe("slack:C1:100.0");
+  });
+});
+
+describe("buildReplyContext", () => {
+  it("replies on the main timeline for a non-threaded DM", () => {
+    const ctx = buildReplyContext({ channel: "D1", user: "U1", ts: "100.0", channel_type: "im" });
+    expect(ctx).toMatchObject({ channel: "D1", thread: null, messageTs: "100.0" });
+  });
+
+  it("replies inside the thread for a threaded DM", () => {
+    const ctx = buildReplyContext({
+      channel: "D1",
+      user: "U1",
+      ts: "200.0",
+      thread_ts: "100.0",
+      channel_type: "im",
+    });
+    expect(ctx).toMatchObject({ channel: "D1", thread: "100.0", messageTs: "200.0" });
+  });
+
+  it("threads channel replies under the root message", () => {
+    const root = buildReplyContext({ channel: "C1", user: "U1", ts: "100.0", channel_type: "channel" });
+    expect(root).toMatchObject({ thread: "100.0" });
+    const reply = buildReplyContext({ channel: "C1", user: "U1", ts: "200.0", thread_ts: "100.0", channel_type: "channel" });
+    expect(reply).toMatchObject({ thread: "100.0" });
+  });
+});
+
+describe("isOldSlackMessage", () => {
+  it("treats a message older than boot time as old", () => {
+    expect(isOldSlackMessage("100.0", 200_000)).toBe(true);
+  });
+
+  it("treats a message newer than boot time as not old", () => {
+    expect(isOldSlackMessage("300.0", 200_000)).toBe(false);
+  });
+
+  it("returns false for a missing ts", () => {
+    expect(isOldSlackMessage(undefined, 200_000)).toBe(false);
+  });
+});

--- a/packages/jimmy/src/connectors/slack/threads.ts
+++ b/packages/jimmy/src/connectors/slack/threads.ts
@@ -10,6 +10,12 @@ export interface SlackMessageEventLike {
 
 export function deriveSessionKey(event: SlackMessageEventLike): string {
   if (event.channel_type === "im") {
+    // A threaded DM message gets its own per-thread session, so opening a
+    // new thread starts a fresh conversation — same as channels. The
+    // non-threaded DM timeline stays one long-lived session per user.
+    if (event.thread_ts && event.thread_ts !== event.ts) {
+      return `slack:dm:${event.user || "unknown"}:${event.thread_ts}`;
+    }
     return `slack:dm:${event.user || "unknown"}`;
   }
 
@@ -23,11 +29,13 @@ export function deriveSessionKey(event: SlackMessageEventLike): string {
 }
 
 export function buildReplyContext(event: SlackMessageEventLike): ReplyContext {
-  // For DMs, don't set thread (DMs don't support threading the same way)
+  // For DMs: a threaded message → reply inside that thread so the per-thread
+  // session's replies stay in their thread; a non-threaded message → reply on
+  // the DM's main timeline (thread: null).
   if (event.channel_type === "im") {
     return {
       channel: event.channel,
-      thread: null,
+      thread: event.thread_ts && event.thread_ts !== event.ts ? event.thread_ts : null,
       messageTs: event.ts ?? null,
     };
   }


### PR DESCRIPTION
## Problem

Every message in a Slack DM — across *all* threads — collapsed into a single `slack:dm:<user>` session that lived forever. Opening a new thread in a DM did nothing; the only way to start a fresh conversation was `/new`.

This is surprising and inconsistent: in **channels**, a new thread already means a new session (`slack:<channel>:<thread_ts>`). Users reasonably expect "new thread = new chat" to work in DMs too. It also means a DM session grows unboundedly — a real instance accumulated 1700+ turns over a month.

## Change

- `deriveSessionKey`: a threaded DM message is keyed `slack:dm:<user>:<thread_ts>`, so opening a new thread in a DM starts a fresh conversation. The non-threaded DM timeline stays one long-lived session per user (`slack:dm:<user>`).
- `buildReplyContext`: threaded DM messages now carry their `thread`, so the bot replies *inside* the thread instead of dumping the reply on the DM's main timeline.

No migration needed — existing `slack:dm:<user>` sessions keep serving the main timeline; only threaded messages route to new per-thread sessions.

## Test

- `tsc --noEmit` passes.
- 133 slack tests pass, including a new `threads.test.ts` covering DM threaded/non-threaded keying, two-thread isolation, channel parity, and reply-context threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)