### PR TITLE
fix(codex): deliver only the final agent_message, not interim narration

### DIFF
--- a/packages/jimmy/src/engines/__tests__/codex.test.ts
+++ b/packages/jimmy/src/engines/__tests__/codex.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+import { CodexEngine } from "../codex.js";
+import type { StreamDelta } from "../../shared/types.js";
+
+// Mock child_process.spawn
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+const mockSpawn = vi.mocked(spawn);
+
+/** Creates a mock ChildProcess that emits events and has controllable stdout/stderr */
+function createMockProcess() {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { end: vi.fn() };
+  proc.pid = 12345;
+  proc.exitCode = null;
+  proc.killed = false;
+  proc.kill = vi.fn(() => { proc.killed = true; });
+  return proc;
+}
+
+describe("CodexEngine", () => {
+  let engine: CodexEngine;
+
+  beforeEach(() => {
+    engine = new CodexEngine();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("run() — agent_message handling", () => {
+    it("delivers only the final agent_message, not interim progress narration", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as any);
+
+      const resultPromise = engine.run({ prompt: "what model are you?", cwd: "/tmp" });
+
+      // gpt-5.5 emits an interim "I'll do X first" message, then its real answer.
+      proc.stdout.emit("data", Buffer.from(
+        JSON.stringify({ type: "thread.started", thread_id: "th-1" }) + "\n" +
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "I'll check the boot files first, then answer." } }) + "\n" +
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "I'm running on gpt-5.5." } }) + "\n" +
+        JSON.stringify({ type: "turn.completed" }) + "\n",
+      ));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await resultPromise;
+      // Regression: interim agent_messages used to be concatenated into the reply.
+      expect(result.result).toBe("I'm running on gpt-5.5.");
+      expect(result.result).not.toContain("boot files");
+      expect(result.sessionId).toBe("th-1");
+      expect(result.error).toBeUndefined();
+    });
+
+    it("still surfaces every agent_message to onStream for live progress", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as any);
+
+      const deltas: StreamDelta[] = [];
+      const resultPromise = engine.run({
+        prompt: "hi",
+        cwd: "/tmp",
+        onStream: (d) => deltas.push(d),
+      });
+
+      proc.stdout.emit("data", Buffer.from(
+        JSON.stringify({ type: "thread.started", thread_id: "th-2" }) + "\n" +
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "working…" } }) + "\n" +
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "done." } }) + "\n" +
+        JSON.stringify({ type: "turn.completed" }) + "\n",
+      ));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await resultPromise;
+      expect(result.result).toBe("done.");
+      expect(deltas.filter((d) => d.type === "text").map((d) => d.content)).toEqual([
+        "working…",
+        "done.",
+      ]);
+    });
+
+    it("keeps a single agent_message intact", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as any);
+
+      const resultPromise = engine.run({ prompt: "hi", cwd: "/tmp" });
+
+      proc.stdout.emit("data", Buffer.from(
+        JSON.stringify({ type: "thread.started", thread_id: "th-3" }) + "\n" +
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "single answer" } }) + "\n" +
+        JSON.stringify({ type: "turn.completed" }) + "\n",
+      ));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await resultPromise;
+      expect(result.result).toBe("single answer");
+    });
+  });
+});

--- a/packages/jimmy/src/engines/codex.ts
+++ b/packages/jimmy/src/engines/codex.ts
@@ -104,7 +104,13 @@ export class CodexEngine implements InterruptibleEngine {
               if (onStream) onStream(parsed.delta);
               break;
             case "text":
-              resultText += parsed.delta.content;
+              // Each codex "text" event is a *complete* agent_message, not a
+              // streaming delta. gpt-5.5 routinely emits an interim progress
+              // message ("I'll check X first…") before its tool calls and a
+              // separate final message afterwards. Keep only the latest so the
+              // interim narration doesn't leak into the delivered reply; live
+              // progress is still surfaced via onStream below.
+              resultText = parsed.delta.content;
               if (onStream) onStream(parsed.delta);
               break;
             case "error":
@@ -151,7 +157,9 @@ export class CodexEngine implements InterruptibleEngine {
                 threadId = parsed.threadId;
                 break;
               case "text":
-                resultText += parsed.delta.content;
+                // See the stdout handler above — keep only the final
+                // agent_message, never concatenate interim ones.
+                resultText = parsed.delta.content;
                 break;
               case "usage":
                 numTurns++;


### PR DESCRIPTION
## Problem

The Codex engine concatenated **every** `agent_message` into the result text (`resultText += …`). A codex `text` event carries a *complete* `agent_message` (from `item.completed`), not a streaming delta — so when gpt-5.5 emits an interim progress message before its tool calls and a separate final message afterwards, both got glued together and delivered.

Observed in a real DM session — the user asked "あなたのモデルは？" and gpt-5.5 emitted two agent_messages:

1. `最初の起動手順に従って、まず自己定義とブートストラップ状態を確認します。終わったら、モデル情報とオンボーディング確認を簡潔に返します。` (interim "I'll do X first" narration)
2. the actual answer

The delivered reply was message 1 + message 2 — the model's progress narration leaked into the user-facing reply.

## Change

Keep only the **latest** `agent_message` as the result (last wins), in both the streaming stdout handler and the trailing-line handler at process close. Live progress is still surfaced via `onStream`, unchanged.

The Gemini engine's `text` events *are* streaming deltas (verified by its existing tests — `"Hello " + "world!"` → `"Hello world!"`), so its `+=` accumulation is correct and is deliberately left untouched.

## Test

- `tsc --noEmit` passes.
- New `engines/__tests__/codex.test.ts` (3 tests, all passing) drives `run()` with a mocked codex process:
  - interim agent_message is dropped, only the final answer is delivered (regression test)
  - every agent_message is still streamed to `onStream`
  - a lone agent_message is delivered intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)