### PR TITLE
fix(sessions): resume 不能なトランスクリプトを新規セッションで自動復旧する

### DIFF
--- a/packages/jimmy/src/engines/__tests__/claude.resume-fallback.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude.resume-fallback.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../shared/logger.js", () => ({
+  logger: { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../shared/resolveBin.js", () => ({
+  resolveBin: (bin: string) => `/usr/local/bin/${bin}`,
+  formatSpawnError: (label: string, bin: string, err: Error) => `Failed to spawn ${label} (${bin}): ${err.message}`,
+}));
+
+import { spawn } from "node:child_process";
+import { ClaudeEngine } from "../claude.js";
+import { isUnresumableTranscriptError } from "../../shared/rateLimit.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+function createMockProcess() {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn(), on: vi.fn() };
+  proc.pid = 12345;
+  proc.exitCode = null;
+  proc.killed = false;
+  proc.kill = vi.fn(() => { proc.killed = true; });
+  return proc;
+}
+
+function emit(proc: any, obj: unknown) {
+  proc.stdout.emit("data", Buffer.from(JSON.stringify(obj) + "\n"));
+}
+
+// The exact API 400 the CLI surfaces when resuming a transcript whose latest
+// assistant turn carries thinking blocks that no longer round-trip.
+const THINKING_400 =
+  "API Error: 400 messages.19.content.1: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.";
+
+describe("ClaudeEngine — unresumable transcript on --resume", () => {
+  let engine: ClaudeEngine;
+
+  beforeEach(() => { engine = new ClaudeEngine(); });
+  afterEach(() => { vi.restoreAllMocks(); mockSpawn.mockReset(); });
+
+  it("surfaces the thinking-block 400 as an unresumable-transcript error even when a rate_limit_event (status 'allowed') is streamed first", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc as any);
+
+    const p = engine.run({
+      prompt: "ping",
+      cwd: "/tmp",
+      sessionId: "s-resume",
+      resumeSessionId: "poisoned-engine-session",
+      model: "opus",
+    });
+
+    // The CLI emits a rate_limit_event on ordinary requests — this is the trap:
+    // a blanket rateLimit?.status guard would swallow the real failure below.
+    emit(proc, { type: "rate_limit_event", rate_limit_info: { status: "allowed" } });
+    // The resumed conversation reports its full prior turn count (19), so the
+    // zero-work dead-session heuristic deliberately ignores it.
+    emit(proc, {
+      type: "result",
+      subtype: "error",
+      is_error: true,
+      result: THINKING_400,
+      session_id: "poisoned-engine-session",
+      num_turns: 19,
+      total_cost_usd: 0,
+    });
+    proc.exitCode = 1;
+    proc.emit("close", 1);
+
+    const result = await p;
+
+    // The error text is preserved, the rate_limit status is attached (the trap),
+    // and the turn count is non-zero — yet it must still be classified as
+    // unresumable so the manager drops the --resume ID and restarts fresh.
+    expect(result.error).toContain("cannot be modified");
+    expect(result.rateLimit?.status).toBe("allowed");
+    expect(result.numTurns).toBe(19);
+    expect(isUnresumableTranscriptError(result)).toBe(true);
+  });
+});

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -42,7 +42,7 @@ import { logger } from "../shared/logger.js";
 import { getSttStatus, downloadModel, transcribe as sttTranscribe, resolveLanguages, WHISPER_LANGUAGES } from "../stt/stt.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { resolveEffort } from "../shared/effort.js";
-import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit } from "../shared/rateLimit.js";
+import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit, isDeadSessionError, isUnresumableTranscriptError } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, recordClaudeRateLimit } from "../shared/usageAwareness.js";
 import { loadJobs, saveJobs } from "../cron/jobs.js";
 import { reloadScheduler } from "../cron/scheduler.js";
@@ -2210,9 +2210,30 @@ async function runWebSession(
       })()
       : prompt;
 
-    const result = await engine.run({
+    const onStreamDelta = (delta: import("../shared/types.js").StreamDelta) => {
+      const now = Date.now();
+      if (now - lastHeartbeatAt >= 2000) {
+        lastHeartbeatAt = now;
+        updateSession(currentSession.id, {
+          status: "running",
+          lastActivity: new Date(now).toISOString(),
+        });
+      }
+      try {
+        context.emit("session:delta", {
+          sessionId: currentSession.id,
+          type: delta.type,
+          content: delta.content,
+          toolName: delta.toolName,
+        });
+      } catch (err) {
+        logger.warn(`Failed to emit stream delta for session ${currentSession.id}: ${err instanceof Error ? err.message : err}`);
+      }
+    };
+
+    const runOnce = (resumeSessionId: string | undefined) => engine.run({
       prompt: promptToRun,
-      resumeSessionId: currentSession.engineSessionId ?? undefined,
+      resumeSessionId,
       systemPrompt,
       cwd: JINN_HOME,
       bin: engineConfig.bin,
@@ -2223,33 +2244,59 @@ async function runWebSession(
       remoteCwd: employee?.remoteCwd,
       attachments: attachments?.length ? attachments : undefined,
       sessionId: currentSession.id,
-      onStream: (delta) => {
-        const now = Date.now();
-        if (now - lastHeartbeatAt >= 2000) {
-          lastHeartbeatAt = now;
-          updateSession(currentSession.id, {
-            status: "running",
-            lastActivity: new Date(now).toISOString(),
-          });
-        }
-        try {
-          context.emit("session:delta", {
-            sessionId: currentSession.id,
-            type: delta.type,
-            content: delta.content,
-            toolName: delta.toolName,
-          });
-        } catch (err) {
-          logger.warn(`Failed to emit stream delta for session ${currentSession.id}: ${err instanceof Error ? err.message : err}`);
-        }
-      },
-    }).finally(() => {
+      onStream: onStreamDelta,
+    });
+
+    let result = await runOnce(currentSession.engineSessionId ?? undefined).finally(() => {
       clearInterval(runHeartbeat);
     });
 
     if (!getSession(currentSession.id)) {
       logger.info(`Skipping completion for deleted web session ${currentSession.id}`);
       return;
+    }
+
+    // Fresh-session recovery: when the resume target is unusable — a dead/expired
+    // engine session (zero work done) or an unresumable transcript (e.g. thinking
+    // blocks in the latest assistant message cannot be modified) — clear the stale
+    // engine session id and retry once from scratch. Without this, a follow-up that
+    // lands on a poisoned --resume id surfaces the raw engine error to the user
+    // instead of a real answer. The connector path does the same in SessionManager.
+    const interruptedEarly = result.error?.startsWith("Interrupted");
+    if (
+      !interruptedEarly &&
+      currentSession.engineSessionId &&
+      (isDeadSessionError(result) || isUnresumableTranscriptError(result))
+    ) {
+      const reason = isUnresumableTranscriptError(result) ? "unresumable transcript" : "dead session";
+      logger.warn(`${reason} detected for web session ${currentSession.id} — clearing stale engine ID and retrying fresh`);
+
+      const meta = { ...(currentSession.transportMeta || {}) } as Record<string, unknown>;
+      delete meta["engineSessions"];
+      delete meta["engineOverride"];
+      updateSession(currentSession.id, {
+        engineSessionId: null,
+        transportMeta: meta as any,
+        status: "running",
+        lastActivity: new Date().toISOString(),
+      });
+      // Mutate the in-memory reference so any downstream code (rate-limit
+      // fallback, completion persistence) no longer sees the poisoned resume id.
+      currentSession.engineSessionId = null;
+      currentSession.transportMeta = meta as any;
+
+      const retryHeartbeat = setInterval(() => {
+        updateSession(currentSession.id, {
+          status: "running",
+          lastActivity: new Date().toISOString(),
+        });
+      }, 5000);
+      result = await runOnce(undefined).finally(() => clearInterval(retryHeartbeat));
+
+      if (!getSession(currentSession.id)) {
+        logger.info(`Skipping completion for deleted web session ${currentSession.id}`);
+        return;
+      }
     }
 
     const wasInterrupted = result.error?.startsWith("Interrupted");

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -23,7 +23,7 @@ import { SessionQueue } from "./queue.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { logger } from "../shared/logger.js";
 import { resolveEffort } from "../shared/effort.js";
-import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit, isDeadSessionError } from "../shared/rateLimit.js";
+import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit, isDeadSessionError, isUnresumableTranscriptError } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, isLikelyNearClaudeUsageLimit, recordClaudeRateLimit } from "../shared/usageAwareness.js";
 import { loadJobs } from "../cron/jobs.js";
 import { setCronJobEnabled, triggerCronJob } from "../cron/scheduler.js";
@@ -403,13 +403,20 @@ export class SessionManager {
 
       let wasInterrupted = result.error?.startsWith("Interrupted");
 
-      // Dead session detection: if the engine session ID is stale (expired/invalid),
-      // clear cached engine sessions from transportMeta so the next attempt starts fresh.
-      // Also sets a flag so we skip the rate-limit retry loop below (a dead session
-      // error can contain text like "429" that would otherwise match RATE_LIMIT_ERROR_RE).
-      let isDead = !wasInterrupted && isDeadSessionError(result);
-      if (isDead) {
-        logger.warn(`Dead session detected for ${session.id} — clearing stale engine IDs`);
+      // Fresh-session detection: clear the stale engine session ID and restart from
+      // scratch when the resume target is no longer usable. Two distinct cases:
+      //   - dead session (expired/invalid --resume ID; zero work done), and
+      //   - unresumable transcript (e.g. thinking blocks in the latest assistant
+      //     message cannot be modified — a non-zero-turn 400 the dead-session
+      //     heuristic deliberately ignores).
+      // Either way we clear cached engine sessions from transportMeta so the next
+      // attempt starts fresh, and set a flag so we skip the rate-limit retry loop
+      // below (these errors can contain text like "429" that would otherwise match
+      // RATE_LIMIT_ERROR_RE).
+      let needsFreshSession = !wasInterrupted && (isDeadSessionError(result) || isUnresumableTranscriptError(result));
+      if (needsFreshSession) {
+        const reason = isUnresumableTranscriptError(result) ? "unresumable transcript" : "dead session";
+        logger.warn(`${reason} detected for ${session.id} — clearing stale engine IDs`);
         const meta = { ...(session.transportMeta || {}) } as Record<string, unknown>;
         delete meta["engineSessions"];
         delete meta["engineOverride"];
@@ -441,18 +448,19 @@ export class SessionManager {
         });
 
         // Re-evaluate the flags against the retry result. If the retry also
-        // comes back dead, something deeper is wrong — log and fall through to
-        // normal error handling (which will post the error to the user).
+        // comes back needing a fresh session, something deeper is wrong — log and
+        // fall through to normal error handling (which will post the error to the
+        // user).
         wasInterrupted = result.error?.startsWith("Interrupted");
-        isDead = !wasInterrupted && isDeadSessionError(result);
-        if (isDead) {
-          logger.error(`Retry with fresh session for ${session.id} also reported dead-session; giving up`);
+        needsFreshSession = !wasInterrupted && (isDeadSessionError(result) || isUnresumableTranscriptError(result));
+        if (needsFreshSession) {
+          logger.error(`Retry with fresh session for ${session.id} still unusable; giving up`);
         }
       }
 
       // Detect rate limit / usage limit errors and auto-retry.
-      // Skip entirely for dead sessions — they are not rate limits.
-      const rateLimit = (!wasInterrupted && !isDead) ? detectRateLimit(result) : { limited: false as const };
+      // Skip entirely when a fresh session was needed — those are not rate limits.
+      const rateLimit = (!wasInterrupted && !needsFreshSession) ? detectRateLimit(result) : { limited: false as const };
       if (rateLimit.limited) {
         recordClaudeRateLimit(rateLimit.resetsAt);
 

--- a/packages/jimmy/src/shared/__tests__/rateLimit.test.ts
+++ b/packages/jimmy/src/shared/__tests__/rateLimit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { EngineResult } from "../types.js";
-import { isDeadSessionError, detectRateLimit } from "../rateLimit.js";
+import { isDeadSessionError, detectRateLimit, isUnresumableTranscriptError } from "../rateLimit.js";
 
 function makeResult(overrides: Partial<EngineResult> = {}): EngineResult {
   return {
@@ -118,5 +118,65 @@ describe("isDeadSessionError", () => {
     });
     expect(detectRateLimit(rateLimited).limited).toBe(true);
     expect(isDeadSessionError(rateLimited)).toBe(false);
+  });
+});
+
+describe("isUnresumableTranscriptError", () => {
+  // The exact API 400 surfaced when resuming a transcript whose latest assistant
+  // turn carries thinking blocks that no longer round-trip.
+  const THINKING_400 =
+    "API Error: 400 messages.19.content.1: thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.";
+
+  it("detects the thinking-block 400 even with a non-zero turn count", () => {
+    // This is the crux: a resumed conversation reports the full prior turn count,
+    // so isDeadSessionError ignores it — but the transcript is still unresumable.
+    const result = makeResult({ error: THINKING_400, cost: 0, numTurns: 19 });
+    expect(isUnresumableTranscriptError(result)).toBe(true);
+    expect(isDeadSessionError(result)).toBe(false);
+  });
+
+  it("detects the error when wrapped in a generic 'exited with code 1' message", () => {
+    const result = makeResult({
+      error: `Claude exited with code 1: ${THINKING_400}`,
+      cost: 0.04,
+      numTurns: 19,
+    });
+    expect(isUnresumableTranscriptError(result)).toBe(true);
+  });
+
+  it("detects redacted_thinking phrasing", () => {
+    const result = makeResult({
+      error: "400 redacted_thinking blocks in the latest assistant message cannot be modified",
+    });
+    expect(isUnresumableTranscriptError(result)).toBe(true);
+  });
+
+  it("returns false when there is no error", () => {
+    expect(isUnresumableTranscriptError(makeResult({ result: "ok" }))).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isUnresumableTranscriptError(makeResult({ error: "Claude exited with code 1" }))).toBe(false);
+    expect(isUnresumableTranscriptError(makeResult({ error: "session not found" }))).toBe(false);
+  });
+
+  it("returns false when an actual rate limit (rejected) is present", () => {
+    const result = makeResult({
+      error: THINKING_400,
+      rateLimit: { status: "rejected" },
+    });
+    expect(isUnresumableTranscriptError(result)).toBe(false);
+  });
+
+  it("still detects when a non-rejected rate_limit_event is attached (CLI streams status 'allowed')", () => {
+    // Regression: the Claude CLI emits a rate_limit_event with status "allowed"
+    // on ordinary requests, so a blanket rateLimit?.status guard would wrongly
+    // swallow the real 400 and skip the fresh-session fallback.
+    const result = makeResult({
+      error: THINKING_400,
+      rateLimit: { status: "allowed" },
+      numTurns: 19,
+    });
+    expect(isUnresumableTranscriptError(result)).toBe(true);
   });
 });

--- a/packages/jimmy/src/shared/rateLimit.ts
+++ b/packages/jimmy/src/shared/rateLimit.ts
@@ -18,6 +18,20 @@ const DEAD_SESSION_PATTERNS = [
 ];
 
 /**
+ * Patterns indicating the persisted transcript can no longer be replayed via
+ * `--resume`, independent of how much work the original session did. The most
+ * common case is an API 400 when the latest assistant turn contains
+ * thinking/redacted_thinking blocks that no longer round-trip (e.g. the model
+ * or thinking config changed between turns). Unlike a dead session, these come
+ * back WITH a non-zero turn count (the resumed conversation length), so they
+ * must be matched by message text rather than the zero-work heuristic.
+ */
+const UNRESUMABLE_TRANSCRIPT_PATTERNS = [
+  /(thinking|redacted_thinking)[\s\S]{0,80}blocks?[\s\S]{0,80}(cannot be modified|must remain)/i,
+  /blocks in the latest assistant message cannot be modified/i,
+];
+
+/**
  * Detect whether an engine result indicates a dead/expired session rather than
  * a transient or rate-limit error. A dead session is one where the engine exited
  * with an error but did zero work (no cost, no turns) and there is no rate-limit
@@ -41,6 +55,25 @@ export function isDeadSessionError(result: EngineResult): boolean {
   if (zeroCost && DEAD_SESSION_PATTERNS.some((p) => p.test(result.error!))) return true;
 
   return false;
+}
+
+/**
+ * Detect whether the engine failed specifically because the persisted transcript
+ * can no longer be resumed (e.g. thinking/redacted_thinking blocks in the latest
+ * assistant message cannot be modified). The remedy is identical to a dead
+ * session — drop the stale `--resume` ID and start fresh — but unlike
+ * {@link isDeadSessionError} this is NOT gated on zero cost/turns, because a
+ * resumed conversation reports the full prior turn count even when it fails
+ * before doing any new work.
+ */
+export function isUnresumableTranscriptError(result: EngineResult): boolean {
+  if (!result.error) return false;
+  // An actual rate limit is a transient capacity signal, not a poisoned
+  // transcript. Match detectRateLimit's definition (status "rejected") — the CLI
+  // streams a rate_limit_event with status "allowed" on ordinary requests too,
+  // so a broader `result.rateLimit?.status` check would swallow real failures.
+  if (result.rateLimit?.status === "rejected") return false;
+  return UNRESUMABLE_TRANSCRIPT_PATTERNS.some((p) => p.test(result.error!));
 }
 
 export function detectRateLimit(result: EngineResult): RateLimitDetection {


### PR DESCRIPTION
## 概要

Claude セッションの **resume が失敗したとき、生のエラーをユーザーに出さず、新規セッションで自動復旧** するようにします。

特に Web ダッシュボード経由で発生していた次の 400 エラーが対象です:

> `API Error: 400 messages.N.content.M: ` `` `thinking` `` ` or ` `` `redacted_thinking` `` ` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.`

## 原因

保存済みトランスクリプトの最後の assistant ターンに含まれる `thinking` ブロックが round-trip しなくなると（ターン間でモデルや thinking 設定が変化した等）、`--resume` 時に上記 400 が返ります。

既存の dead-session フォールバックではこれを拾えませんでした:

- resume した会話は**過去ターン数（`num_turns >= 1`）をそのまま報告**するため、`isDeadSessionError()` の「ゼロワークなら dead」というヒューリスティックが意図的に無視する
- rate limit でも transient error でもないため、汚染された `--resume` ID をクリアする経路が存在せず、**再試行のたびに同じ 400 を踏み続ける**
- さらに調査の結果、**`runWebSession()`（Web/API 経路）には dead-session 復旧が元々一切無く**、rate-limit 処理のみだった。報告された不具合はこの経路で発生

## 変更内容

- `shared/rateLimit.ts` に **`isUnresumableTranscriptError()`** を追加
  - エラー文面で判定し、`cost`/`turns` には依存しない（resume 会話は turns 非ゼロのため）
  - rate-limit ガードは `detectRateLimit()` と同じ `status === "rejected"` のみで弾く。CLI は通常リクエストでも `status: "allowed"` の `rate_limit_event` を流すため、`rateLimit.status` 全般で弾くと本物の 400 まで握りつぶしてしまう（実機で踏んだ罠）
- ターンの2つの入口に組み込み、stale な engine session ID を破棄 → fresh なセッションで1回だけ再実行:
  - `SessionManager.runSession()`（Slack / Discord / コネクタ経路）— 既存の dead-session 経路を一般化
  - `runWebSession()`（Web ダッシュボード / API 経路）— 復旧処理を新規追加

## スコープ外（follow-up）

usage-limit 後の再試行サブ経路（`manager.ts` / `api.ts` 内）は引き続き元 ID を resume します。別件かつ稀なエッジケースのため、本 PR では扱いません。

## テスト

- `rateLimit.test.ts` — 検出関数の単体テスト（実際の 400 文字列 / `"allowed"` `rate_limit_event` の罠 / `rejected` / `redacted_thinking` / ラップ済みメッセージ）
- `claude.resume-fallback.test.ts`（新規）— 実際のストリーム形状（`rate_limit_event` allowed + `is_error` result + `num_turns: 19` + exit 1）を end-to-end で再現するエンジン統合テスト
- パッケージ全体: `pnpm typecheck` / `vitest run` ともにグリーン（398 tests passed）
- **稼働中ゲートウェイで実機確認**: 使用不能な resume ID を指すセッションが ID をクリアして fresh で再実行 → 新 ID を永続化 → 正答を返し、`status` が `idle` に復帰

```
[WARN] dead session detected for web session ... — clearing stale engine ID and retrying fresh
[INFO] Claude engine (one-shot) starting: ... (resume: none)
[INFO] Claude engine (one-shot) exited with code 0
[INFO] Web session ... completed in 1942ms ($0.1317)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)