### PR TITLE
fix(sessions): recover from poisoned --resume transcripts (corrupted thinking blocks)

### DIFF
--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -23,7 +23,7 @@ import { SessionQueue } from "./queue.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { logger } from "../shared/logger.js";
 import { resolveEffort } from "../shared/effort.js";
-import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit, isDeadSessionError } from "../shared/rateLimit.js";
+import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit, isDeadSessionError, isPoisonedTranscriptError } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, isLikelyNearClaudeUsageLimit, recordClaudeRateLimit } from "../shared/usageAwareness.js";
 import { loadJobs } from "../cron/jobs.js";
 import { setCronJobEnabled, triggerCronJob } from "../cron/scheduler.js";
@@ -403,11 +403,44 @@ export class SessionManager {
 
       let wasInterrupted = result.error?.startsWith("Interrupted");
 
+      // Poisoned transcript: the persisted engine history is corrupted (e.g.
+      // collapsed extended-thinking blocks) so every --resume of this engine
+      // session replays it and fails with the same 400. Clear the engine session
+      // id so the NEXT message starts on a clean session, but deliberately do NOT
+      // auto-replay the current prompt: the failed run may already have executed
+      // tools with side effects, and a fresh rerun would duplicate them (a
+      // resumed `claude -p` reports cumulative cost/turns, so "no work was done"
+      // cannot be reliably detected here). Ask the user to resend instead.
+      const isPoisoned = !wasInterrupted && isPoisonedTranscriptError(result);
+      if (isPoisoned) {
+        logger.warn(`Poisoned transcript for ${session.id} — clearing engine session id; not auto-retrying to avoid duplicate side effects`);
+        const meta = { ...(session.transportMeta || {}) } as Record<string, unknown>;
+        delete meta["engineSessions"];
+        delete meta["engineOverride"];
+        updateSession(session.id, { engineSessionId: null, transportMeta: meta as any });
+        session = { ...session, engineSessionId: null, transportMeta: meta as any };
+        // Blank the returned sessionId so the post-run persistence below does not
+        // re-attach the poisoned engine session id, drop any partial result text
+        // and intermediate turns (otherwise the reply path would surface those
+        // stale fragments instead of the reset notice), and replace the raw 400
+        // with an actionable message for the user.
+        result = {
+          ...result,
+          sessionId: "",
+          result: "",
+          turns: [],
+          error:
+            "⚠️ 直前の会話履歴が壊れていたため（thinking ブロックの破損）、このセッションをリセットしました。お手数ですが同じ内容をもう一度送ってください。次回からは正常に応答できます。",
+        };
+      }
+
       // Dead session detection: if the engine session ID is stale (expired/invalid),
       // clear cached engine sessions from transportMeta so the next attempt starts fresh.
       // Also sets a flag so we skip the rate-limit retry loop below (a dead session
       // error can contain text like "429" that would otherwise match RATE_LIMIT_ERROR_RE).
-      let isDead = !wasInterrupted && isDeadSessionError(result);
+      // (Poisoned transcripts are handled above and excluded here — unlike a stale
+      // resume id, they must not trigger an automatic prompt replay.)
+      let isDead = !wasInterrupted && !isPoisoned && isDeadSessionError(result);
       if (isDead) {
         logger.warn(`Dead session detected for ${session.id} — clearing stale engine IDs`);
         const meta = { ...(session.transportMeta || {}) } as Record<string, unknown>;
@@ -451,8 +484,8 @@ export class SessionManager {
       }
 
       // Detect rate limit / usage limit errors and auto-retry.
-      // Skip entirely for dead sessions — they are not rate limits.
-      const rateLimit = (!wasInterrupted && !isDead) ? detectRateLimit(result) : { limited: false as const };
+      // Skip entirely for dead/poisoned sessions — they are not rate limits.
+      const rateLimit = (!wasInterrupted && !isDead && !isPoisoned) ? detectRateLimit(result) : { limited: false as const };
       if (rateLimit.limited) {
         recordClaudeRateLimit(rateLimit.resetsAt);
 

--- a/packages/jimmy/src/shared/__tests__/rateLimit.test.ts
+++ b/packages/jimmy/src/shared/__tests__/rateLimit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { EngineResult } from "../types.js";
-import { isDeadSessionError, detectRateLimit } from "../rateLimit.js";
+import { isDeadSessionError, detectRateLimit, isPoisonedTranscriptError } from "../rateLimit.js";
 
 function makeResult(overrides: Partial<EngineResult> = {}): EngineResult {
   return {
@@ -118,5 +118,45 @@ describe("isDeadSessionError", () => {
     });
     expect(detectRateLimit(rateLimited).limited).toBe(true);
     expect(isDeadSessionError(rateLimited)).toBe(false);
+  });
+});
+
+describe("isPoisonedTranscriptError", () => {
+  // The exact 400 surfaced from Anthropic when a resumed transcript has a
+  // corrupted assistant turn (collapsed thinking blocks).
+  const REAL_ERROR =
+    "API Error: 400 messages.1.content.13: thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.";
+
+  it("returns true for the real corrupted-thinking 400", () => {
+    expect(isPoisonedTranscriptError(makeResult({ error: REAL_ERROR }))).toBe(true);
+  });
+
+  it("returns true even when real work was done (non-zero cost/turns)", () => {
+    // The whole point: this happens AFTER a long successful tool loop, so the
+    // zeroCost gate of isDeadSessionError would miss it.
+    const result = makeResult({ error: REAL_ERROR, cost: 0.42, numTurns: 40 });
+    expect(isPoisonedTranscriptError(result)).toBe(true);
+    expect(isDeadSessionError(result)).toBe(false);
+  });
+
+  it("matches the redacted_thinking variant", () => {
+    const result = makeResult({
+      error: "400 redacted_thinking blocks ... cannot be modified",
+    });
+    expect(isPoisonedTranscriptError(result)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isPoisonedTranscriptError(makeResult({ error: "rate limit exceeded" }))).toBe(false);
+    expect(isPoisonedTranscriptError(makeResult({ error: "Claude exited with code 1" }))).toBe(false);
+    expect(isPoisonedTranscriptError(makeResult({}))).toBe(false);
+  });
+
+  it("does not treat a rate-limited result as poisoned", () => {
+    const result = makeResult({
+      error: REAL_ERROR,
+      rateLimit: { status: "rejected", resetsAt: 9999999999 },
+    });
+    expect(isPoisonedTranscriptError(result)).toBe(false);
   });
 });

--- a/packages/jimmy/src/shared/rateLimit.ts
+++ b/packages/jimmy/src/shared/rateLimit.ts
@@ -18,6 +18,35 @@ const DEAD_SESSION_PATTERNS = [
 ];
 
 /**
+ * Anthropic rejects a `--resume` request whose transcript contains a corrupted
+ * assistant turn — most commonly when extended-thinking blocks no longer match
+ * the original signed response (e.g. a long tool loop that got collapsed under a
+ * single message id, or a turn that was killed mid-stream). The 400 looks like:
+ *   "messages.1.content.13: thinking or redacted_thinking blocks in the latest
+ *    assistant message cannot be modified. These blocks must remain as they were
+ *    in the original response."
+ * Unlike a rate limit or a transient failure, this error is *baked into the
+ * persisted transcript*: every subsequent resume of the same engine session
+ * replays the poisoned history and fails identically. The only recovery is to
+ * abandon the engine session id and start a fresh one — and crucially this can
+ * happen *after* real work was done, so it is NOT gated on zeroCost the way
+ * isDeadSessionError is.
+ */
+const POISONED_TRANSCRIPT_RE =
+  /(thinking|redacted_thinking)\b[\s\S]*?blocks[\s\S]*?(cannot be modified|must remain as they were)/i;
+
+/**
+ * Detect whether an engine result indicates the persisted transcript can no
+ * longer be resumed (see POISONED_TRANSCRIPT_RE). Caller should clear the engine
+ * session id and retry with a fresh session, identically to a dead session.
+ */
+export function isPoisonedTranscriptError(result: EngineResult): boolean {
+  if (!result.error) return false;
+  if (result.rateLimit?.status) return false;
+  return POISONED_TRANSCRIPT_RE.test(result.error);
+}
+
+/**
  * Detect whether an engine result indicates a dead/expired session rather than
  * a transient or rate-limit error. A dead session is one where the engine exited
  * with an error but did zero work (no cost, no turns) and there is no rate-limit


### PR DESCRIPTION
## 背景 / 症状

Slack で Ryoko が突然このエラーを繰り返すようになった（しかも時間を空けても一字一句同じ）:

```
API Error: 400 messages.1.content.13: thinking or redacted_thinking blocks in the
latest assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

## 根本原因（実トランスクリプトで確認）

該当セッションの Claude Code トランスクリプトを解析したところ、**約3分・40ステップ分のツールループ（thinking + tool_use）が、すべて同一の message id / 同一 requestId に潰れて記録**されていた。Anthropic API の1リクエストが40回もツール往復を返すことは原理上ありえず、トランスクリプトが破損している。

その状態を `--resume` で replay すると、`messages[1]` が thinking と tool_use を14個以上含む巨大な単一 assistant メッセージになり、その14個目（content[13]）の thinking ブロックが「単一の署名済みレスポンスの先頭 thinking」と一致しないため 400 で拒否される。**エラーが破損トランスクリプトに焼き付いて永続化**されるため、以降このエンジンセッションを resume するたびに同じエラーで固着する。

## なぜ既存の回復ロジックが効かなかったか

`isDeadSessionError` は `zeroCost && zeroTurns`（＝何も仕事せず死んだ場合）のときしかエンジンセッション ID をクリアしない。今回は**40ターン分の仕事を成功させた後**の継続呼び出しで 400 になったため `cost>0 / turns>0` となり、dead 判定が false → ID リセット＆フレッシュ再試行に入らず、破損セッションを延々 resume し続けた。

## 修正

- `isPoisonedTranscriptError()` を追加（破損 thinking の 400 にマッチ。**cost/turns でゲートしない**）。
- セッションマネージャで poisoned 検出時:
  - エンジンセッション ID をクリア（次のメッセージはクリーンなセッションで開始）。
  - 返ってきた `sessionId` / `result` / `turns` を空にし、後段の永続化が破損 ID を再付与したり中間断片を返したりしないようにする。
  - **意図的に自動リプレイはしない** — 失敗したランが既にツールを実行して副作用を起こしている可能性があり、resume 後の `claude -p` は cost/turns を累積で返すため「何も実行していない」を確実に判定できない。ユーザーには再送をお願いする文面を返す。
- `isPoisonedTranscriptError` のテスト追加（`isDeadSessionError` が意図的に取りこぼす「仕事をした後」のケースを含む）。

## 検証

- `tsc --noEmit` クリーン
- `vitest run` 全 395 件パス（新規 6 件含む）
- **Codex レビュー 2 周**: P1（副作用の二重実行リスク → 自動リプレイ廃止で解消）、P2（multi-turn の stale `turns` が reset 通知を上書き → `turns`/`result` クリアで解消）を反映。最終パスで actionable な指摘なし。

## デプロイ注意

本番 `ryoko.service` は現在 `ef838b2 (Release 2026.5.29)` 起動で、main の `#4 (SSH remote 実行)` は**未デプロイ**。main をそのまま反映すると #4 も本番投入される点に注意。稼働中ゲートウェイへの反映（dist 更新 + restart）は別途必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)