### PR TITLE
fix(deps): restore node-pty spawn-helper +x via root postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=22"
   },
   "scripts": {
+    "postinstall": "chmod +x node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true",
     "build": "turbo build && rm -rf packages/jimmy/dist/web && cp -r packages/web/out packages/jimmy/dist/web",
     "dev": "turbo dev",
     "lint": "turbo lint",


### PR DESCRIPTION
## 概要

上流 `hristo2612/jinn` の修正 `1c5fe98` を cherry-pick し、node-pty の prebuilt `spawn-helper` に実行ビットを復元する root postinstall を追加します。上流 main には既に入っていますが、本フォークには未取り込みでした。

## 症状

interactive PTY エンジン（`engines.claude.interactive: true`）を有効化すると、**初回の PTY spawn で `posix_spawnp failed` が発生**し、Claude エンジンのターンが即座に失敗します（v2026.6.5 で確認）。

```
[INFO] InteractiveClaudeEngine spawning claude (resume: ..., sseProxy: ...)
[ERROR] Session ... error: posix_spawnp failed.
```

## 原因

node-pty 1.1.0 の prebuilt バイナリ `prebuilds/<platform>/spawn-helper` が、配布物の時点で実行ビットを持っておらず（`-rw-r--r--`）、pnpm install 後も非実行のまま。node-pty はこの helper を `posix_spawn` で起動するため、`posix_spawnp failed` となる。node-pty 自身の postinstall は `build/Release/`（ソースビルド経路）のみ対象で、prebuild 経路の `prebuilds/` には触れない。

## 修正

root `package.json` に postinstall を追加し、pnpm ストア内の spawn-helper に `chmod +x` する（上流 `1c5fe98` と同一）。

```json
"postinstall": "chmod +x node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true",
```

## 検証（ローカル / darwin-arm64）

- spawn-helper を 644 に落とす → `pnpm install` の postinstall が 755 に復元することを確認
- node-pty 経由で `claude` を PTY 起動できることを確認（exit 0）
- interactive エンジンのターンが `posix_spawnp failed` なしで spawn 成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
