### PR TITLE
fix(web): polyfill crypto.randomUUID for insecure (http) contexts

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('openryoko-theme')||localStorage.getItem('jinn-theme')||'ryoko';if(t==='system'){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'ryoko'}document.documentElement.setAttribute('data-theme',t)}catch(e){}})()`,
+            __html: `(function(){try{var c=(typeof crypto!=='undefined'&&crypto)||(typeof window!=='undefined'&&window.crypto);if(c&&typeof c.randomUUID!=='function'&&typeof c.getRandomValues==='function'){var hx=[];for(var i=0;i<256;i++){hx[i]=(i+256).toString(16).slice(1)}c.randomUUID=function(){var b=c.getRandomValues(new Uint8Array(16));b[6]=(b[6]&15)|64;b[8]=(b[8]&63)|128;return hx[b[0]]+hx[b[1]]+hx[b[2]]+hx[b[3]]+'-'+hx[b[4]]+hx[b[5]]+'-'+hx[b[6]]+hx[b[7]]+'-'+hx[b[8]]+hx[b[9]]+'-'+hx[b[10]]+hx[b[11]]+hx[b[12]]+hx[b[13]]+hx[b[14]]+hx[b[15]]}}}catch(e){}})();(function(){try{var t=localStorage.getItem('openryoko-theme')||localStorage.getItem('jinn-theme')||'ryoko';if(t==='system'){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'ryoko'}document.documentElement.setAttribute('data-theme',t)}catch(e){}})()`,
           }}
         />
       </head>


### PR DESCRIPTION
## 問題
Web UI は `crypto.randomUUID()` を ~13 箇所（`chat-pane.tsx`, `kanban/store.ts`）で ID 生成に使っている。ブラウザは `crypto.randomUUID` を **secure context（https または `http://localhost`）でしか公開しない**。

ゲートウェイを **LAN の生IP や `.local`(mDNS) ホスト名 + 平文 http** で開くと origin が非secure扱いになり `crypto.randomUUID` が `undefined`。メッセージ送信時に：

```
TypeError: crypto.randomUUID is not a function
    at onKeyDown ...
```

が出て、チャットが無反応に見える（WebSocket は繋がるが送信だけ落ちる）。セルフホスト／LAN 越し http アクセスで誰でも踏む。

## 修正
`<head>` 最先頭のインライン script（アプリコードより前に実行）に小さな polyfill を追加：

- ネイティブ `crypto.randomUUID` があれば**何もしない**（no-op）
- 無ければ、**非secure context でも使える** `crypto.getRandomValues` から正しい **UUIDv4** を生成して `crypto.randomUUID` に代入

これで https も SSH トンネルも不要で、http のまま LAN/セルフホストアクセスが動く。全 13 箇所の呼び出しが無改修で救われる。

## 確認
- `pnpm build` 通過、生成された全ページHTMLの head に polyfill が入ることを確認
- `http://<host>.local:7777` で `crypto.randomUUID is not a function` が解消、メッセージ送信が正常化
- secure context（localhost / https）ではネイティブ実装が使われ挙動不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)