### PR TITLE
fix(engine): raise interactive turn timeout 15m→90m + silence cron no-connector warn

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.6.5",
+  "version": "2026.6.6",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/connectors/cron/index.ts
+++ b/packages/jimmy/src/connectors/cron/index.ts
@@ -75,6 +75,16 @@ export class CronConnector implements Connector {
   private async forward(target: Target, text: string, asReply: boolean): Promise<string | void> {
     if (!this.delivery) return undefined;
 
+    // No connector configured. An empty defaultDelivery ({}) is the intentional
+    // "jobs self-deliver via curl" case — stay silent. But a delivery that names a
+    // channel yet omits the connector is a real misconfig worth surfacing.
+    if (!this.delivery.connector) {
+      if (this.delivery.channel) {
+        logger.warn(`Cron delivery has channel "${this.delivery.channel}" but no connector — skipping delivery`);
+      }
+      return undefined;
+    }
+
     const connector = this.connectors.get(this.delivery.connector);
     if (!connector) {
       logger.warn(`Cron delivery connector "${this.delivery.connector}" not found`);

--- a/packages/jimmy/src/engines/claude-interactive.ts
+++ b/packages/jimmy/src/engines/claude-interactive.ts
@@ -311,8 +311,9 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
      *  while still alive (e.g. a wedged upstream request, a boot-time race) would
      *  never resolve and would zombie the session as status:"running" forever. This
      *  deadline force-settles such a turn with an error so manager.ts runs its normal
-     *  completion/recovery path. Default 15 min. */
-    private turnTimeoutMs = 15 * 60 * 1000,
+     *  completion/recovery path. Default 90 min — long enough for heavy autonomous
+     *  batch runs (e.g. the seminar-demo generator) to complete in a single turn. */
+    private turnTimeoutMs = 90 * 60 * 1000,
   ) {}
 
   async run(opts: EngineRunOpts): Promise<EngineResult> {

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -191,7 +191,7 @@ export async function startGateway(
       claudeLifecycle,
       hookRegistry,
       claudeEngine,
-      config.engines?.claude?.interactiveTurnTimeoutMs ?? 15 * 60 * 1000,
+      config.engines?.claude?.interactiveTurnTimeoutMs ?? 90 * 60 * 1000,
     );
     copyHookRelayAsset();
     // Pre-trust JINN_HOME in the real ~/.claude.json so PTY-spawned Claude (cwd =

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -479,7 +479,8 @@ export interface JinnConfig {
       maxLivePtys?: number;
       /** Hard ceiling (ms) on a single interactive turn before it is force-settled
        *  as timed out. Guards against a hung-but-alive PTY zombying a session.
-       *  Default 900000 (15 min). */
+       *  Default 5400000 (90 min) — accommodates long autonomous batch runs that
+       *  legitimately occupy one turn (e.g. the seminar-demo generator). */
       interactiveTurnTimeoutMs?: number;
     };
     codex: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string };


### PR DESCRIPTION
## 背景
`InteractiveClaudeEngine`（claude を PTY で起動）の watchdog は、1ターンが `turnTimeoutMs` を超えると `resolver.interrupt()` + `lifecycle.releaseSession()` で PTY ごと強制終了する（`force-settling` → `read EIO`）。デフォルト **15分** が長時間自律バッチ（`seminar-demo-generator`）を起動18分で打ち切る原因だった（2026-06-04 `slack:C0B46P78SBZ` が Phase 1 付近で停止）。

## 変更
- `interactiveTurnTimeoutMs` デフォルト 15分→90分（`claude-interactive.ts` / `gateway/server.ts` / `shared/types.ts`）。config で上書き可。
- cron の `delivery connector "undefined" not found` ノイズ抑制（空 `defaultDelivery` は無音、`channel` ありで `connector` 欠落は warn 維持＝codex指摘反映）。
- openryoko 2026.6.5→2026.6.6

## レビュー
codex レビュー済み（LGTM）。

## デプロイ
実機 `ryoko.service` に 2026.6.6 install 済み・稼働確認済み。

## Test plan
- [x] tsc ビルド通過 / 実機再起動・7777 listen・0エラー
- [ ] seminar-demo-generator 実機再実行で15分超完走を確認