### PR TITLE
fix(engine): treat PTY socket error (EIO) as terminal — evict warm + settle turn (#18)

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.6.6",
+  "version": "2026.6.7",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/engines/__tests__/claude-interactive-race.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude-interactive-race.test.ts
@@ -13,7 +13,11 @@ interface FakePty {
   write: (d: string) => void;
   resize: (c: number, r: number) => void;
   on: (event: string, cb: (...a: any[]) => void) => void;
+  _errorCb?: (err: Error) => void;
   fireExit: () => void;
+  /** Fire a PTY-master socket error (e.g. EIO) WITHOUT firing onExit — the
+   *  issue #18 failure mode where the transport dies but the proc never exits. */
+  fireError: (err?: Error) => void;
 }
 const ptys: FakePty[] = [];
 function makeFakePty(): FakePty {
@@ -26,8 +30,9 @@ function makeFakePty(): FakePty {
     kill() { p._killCalled = true; }, // signal sent; real exit is async (fireExit)
     write() {},
     resize() {},
-    on() {},
+    on(event, cb) { if (event === "error") p._errorCb = cb as (err: Error) => void; },
     fireExit() { p._exitCode = 0; p._exitCb?.({ exitCode: 0 }); },
+    fireError(err) { p._errorCb?.(err ?? Object.assign(new Error("read EIO"), { code: "EIO" })); },
   };
   return p;
 }
@@ -112,5 +117,81 @@ describe("InteractiveClaudeEngine — kill->respawn race (Item C)", () => {
     ptyC.fireExit(); // current PTY dies mid-turn with no Stop hook
     const r = await p;
     expect(r.error).toMatch(/claude process exited/);
+  });
+});
+
+describe("InteractiveClaudeEngine — PTY socket error / EIO (issue #18)", () => {
+  let lifecycle: PtyLifecycleManager;
+  let hookCb: ((h: any) => void) | undefined;
+  let engine: InteractiveClaudeEngine;
+
+  beforeEach(() => {
+    ptys.length = 0;
+    hookCb = undefined;
+    lifecycle = new PtyLifecycleManager({ maxLivePtys: 10 });
+    const hookRegistry = {
+      register: (_id: string, cb: (h: any) => void) => { hookCb = cb; },
+      unregister: () => {},
+    } as any;
+    engine = new InteractiveClaudeEngine(lifecycle, hookRegistry);
+  });
+
+  const completeTurn = (sid: string) => {
+    hookCb!({ hook_event_name: "SessionStart", session_id: sid });
+    hookCb!({ hook_event_name: "Stop", last_assistant_message: "ok" });
+  };
+
+  it("an EIO with no onExit still interrupts the active turn AND evicts the warm handle", async () => {
+    const p = engine.run({ sessionId: "s3", prompt: "x", cwd: "/tmp" } as any);
+    await flush();
+    const pty = ptys[0];
+    expect(lifecycle.getWarm("s3")).toBeDefined();
+
+    pty.fireError(); // socket dies (EIO); onExit is NOT fired
+    const r = await p;
+
+    // Turn settles (no hang until the watchdog) and the corpse is evicted so the
+    // next turn can't reuse it.
+    expect(r.error).toMatch(/socket error/);
+    expect(lifecycle.getWarm("s3")).toBeUndefined();
+    expect(pty._killCalled).toBe(true);
+  });
+
+  it("a warm PTY killed by EIO is not reused — the next turn cold-spawns a new PTY", async () => {
+    // Turn 1 completes; PTY stays warm.
+    const p1 = engine.run({ sessionId: "s4", prompt: "a", cwd: "/tmp" } as any);
+    await flush();
+    const ptyA = ptys[0];
+    completeTurn("c1");
+    await p1;
+    expect(lifecycle.getWarm("s4")).toBeDefined();
+
+    // EIO kills the idle warm PTY without onExit → must be evicted.
+    ptyA.fireError();
+    await flush();
+    expect(lifecycle.getWarm("s4")).toBeUndefined();
+
+    // Next turn must cold-spawn a brand-new PTY, NOT inject into the corpse.
+    let r2: any;
+    void engine.run({ sessionId: "s4", prompt: "b", cwd: "/tmp" } as any).then((v) => { r2 = v; });
+    await flush();
+    const ptyB = ptys[1];
+    expect(ptyB).toBeDefined();
+    expect(ptyB).not.toBe(ptyA);
+    completeTurn("c2");
+    await flush();
+    expect(r2.result).toBe("ok");
+    expect(r2.error).toBeUndefined();
+  });
+
+  it("EIO followed by a late onExit is idempotent (first cause wins, no double-settle)", async () => {
+    const p = engine.run({ sessionId: "s5", prompt: "x", cwd: "/tmp" } as any);
+    await flush();
+    const pty = ptys[0];
+    pty.fireError();             // EIO settles + evicts
+    pty.fireExit();             // late exit must be a no-op (already handled)
+    const r = await p;
+    expect(r.error).toMatch(/socket error/); // not overwritten by "process exited"
+    expect(lifecycle.getWarm("s5")).toBeUndefined();
   });
 });

--- a/packages/jimmy/src/engines/claude-interactive.ts
+++ b/packages/jimmy/src/engines/claude-interactive.ts
@@ -298,6 +298,11 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
    *  apply only at spawn, so a mid-chat switch must cold-respawn rather than reuse
    *  the warm PTY (which would keep running the old model). */
   private spawnParams = new Map<string, { model?: string; effortLevel?: string }>();
+  /** PTY handles already torn down by handlePtyDeath(). A socket `error` (EIO) and
+   *  the proc's `onExit` can both fire for the same PTY (in either order, or only
+   *  one of them), and run()'s warm-reuse guard may also report it dead — so death
+   *  handling must be idempotent. Membership = "already handled"; checked first. */
+  private deadHandles = new WeakSet<PtyHandle>();
 
   constructor(
     private lifecycle: PtyLifecycleManager,
@@ -373,18 +378,36 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       }
     });
 
+    // Liveness guard: a socket error (EIO) between getWarm() above and here may have
+    // already torn this handle down (handlePtyDeath → deadHandles + evict). Never inject
+    // into a corpse — fall through to a cold respawn. This is the silent-drop / queue-
+    // stall path of issue #18 (warm reuse of a dead PTY → no SessionStart/Stop → hang).
+    if (warm && (this.deadHandles.has(warm) || warm.killed)) {
+      warm = undefined;
+    }
     if (warm) {
-      // Mark the turn started BEFORE injecting so the sweep timer can't
-      // theoretically release the PTY mid-paste if its grace window expired
-      // between getWarm() above and the proc.write() inside injectPrompt.
-      this.lifecycle.turnStarted(jinnSessionId);
-      this.injectPrompt(warm, opts);
+      logger.info(`InteractiveClaudeEngine reusing warm PTY for ${jinnSessionId}`);
+      // Bind the proc BEFORE injecting: handlePtyDeath only interrupts the active turn
+      // when entry.boundProc === proc, so a death during/around inject must find it set.
       entry.boundProc = (warm as any)._proc as pty.IPty | undefined;
+      // Mark the turn started BEFORE injecting so the sweep timer can't release the PTY
+      // mid-paste if its grace window expired between getWarm() and the proc.write().
+      this.lifecycle.turnStarted(jinnSessionId);
+      try {
+        this.injectPrompt(warm, opts);
+      } catch (err) {
+        // Writing to a dead PTY socket throws — treat as a PTY death so the turn settles
+        // (and the corpse is evicted) instead of hanging until the turn watchdog.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (entry.boundProc) this.handlePtyDeath(jinnSessionId, entry.boundProc, warm, `PTY inject failed (${msg})`);
+      }
     } else {
       const handle = await this.spawn(jinnSessionId, opts, settingsPath);
+      // Bind the proc before adopt/turnStarted so an early error/exit (before the
+      // watchdog arms) still settles the turn via handlePtyDeath's boundProc gate.
+      entry.boundProc = (handle as any)._proc as pty.IPty | undefined;
       this.lifecycle.adopt(jinnSessionId, handle);
       this.lifecycle.turnStarted(jinnSessionId);
-      entry.boundProc = (handle as any)._proc as pty.IPty | undefined;
     }
 
     // Watchdog: if the bound PTY dies without the resolver settling (e.g. the
@@ -492,6 +515,46 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     }
   }
 
+  /** Idempotent teardown for a dead PTY — shared by the socket-`error` handler, the
+   *  proc `onExit` handler, and run()'s warm-reuse failure path. A broken PTY can raise
+   *  `error` WITHOUT ever firing `onExit` (and both can fire, in either order), so no
+   *  single trigger is sufficient; `deadHandles` makes the first caller win and the rest
+   *  no-op. Steps: (1) identity-gated lifecycle cleanup (evict the warm corpse + clear
+   *  scrollback) only if this is still the session's current handle; (2) stop the per-PTY
+   *  SSE proxy; (3) interrupt the active turn iff this proc is the bound one, so run()'s
+   *  promise resolves instead of hanging until the turn watchdog (issue #18). */
+  private handlePtyDeath(jinnSessionId: string, proc: pty.IPty, handle: PtyHandle, cause: string): void {
+    if (this.deadHandles.has(handle)) return;
+    this.deadHandles.add(handle);
+    // Identity gate: in a kill->respawn race the lifecycle/stream entries already point
+    // at the NEW PTY by the time THIS (old) PTY dies. Only touch shared state when this
+    // handle is still the session's current warm one — else we'd evict the live PTY.
+    const isCurrent = this.lifecycle.getWarm(jinnSessionId) === handle;
+    if (isCurrent) {
+      // Clear scrollback so a stale farewell (Claude's "Resume this session…" hint on
+      // SIGHUP shutdown) doesn't persist into the next PTY incarnation.
+      const s = this.streams.get(jinnSessionId);
+      if (s) {
+        s.chunks = [];
+        s.totalBytes = 0;
+        // Drop the entry if no WS subscribers — otherwise it leaks one per ran session.
+        if (s.subscribers.size === 0) this.streams.delete(jinnSessionId);
+      }
+      // Evict so a future run() can't pick this dead handle up as "warm" and inject
+      // into a corpse.
+      this.lifecycle.releaseSession(jinnSessionId);
+    }
+    // Tear down THIS PTY's SSE forward proxy (one per PTY) regardless of identity.
+    ((handle as any)._proxy as SsePtyProxy | undefined)?.stop();
+    // Settle the active turn as interrupted so run()'s promise doesn't hang — but only
+    // if this dying proc is the one bound to the active turn. After a kill->respawn race
+    // the active entry holds the NEW turn's resolver+proc; identity mismatch => no-op.
+    const e = this.active.get(jinnSessionId);
+    if (e && e.boundProc === proc) {
+      e.resolver.interrupt(`Interrupted: claude ${cause}`);
+    }
+  }
+
   /** Wrap a freshly-spawned pty.IPty in a PtyHandle and wire its output into
    *  the session's scrollback ring buffer + live subscribers. On PTY exit, if this
    *  proc is the one bound to the active turn, the resolver is interrupted (a crash
@@ -521,8 +584,16 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     // internal handler), so any socket error (EIO on claude exit, EPIPE, etc.) propagates as
     // an uncaught exception and kills the daemon. Adding a handler here bumps the count to 2
     // and prevents the throw; we log it and let the onExit path handle cleanup.
+    // A PTY-master socket `error` (EIO on claude exit, EPIPE, EBADF, …) means the
+    // interactive transport is broken: reads/writes fail and `onExit` is NOT
+    // guaranteed to follow. Treat ANY error as terminal — log the code, then run the
+    // same teardown as onExit. Leaving a broken PTY warm is what zombied a sessionKey:
+    // the next run() reused the corpse, injected into a dead socket, and the turn hung
+    // until the 90-min watchdog (see issue #18). Cleanup is idempotent (deadHandles).
     (proc as any).on?.("error", (err: Error) => {
+      const code = (err as NodeJS.ErrnoException).code ?? err.message;
       logger.warn(`PTY socket error for session ${jinnSessionId}: ${err.message}`);
+      this.handlePtyDeath(jinnSessionId, proc, handle, `PTY socket error (${code})`);
     });
 
     proc.onData((d) => {
@@ -546,45 +617,12 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       }
     });
     proc.onExit(() => {
-      // Session-level cleanup MUST be identity-gated. In a kill->respawn race the
-      // lifecycle/stream entries already point at the NEW PTY by the time THIS
-      // (old, killed) PTY's exit fires. releaseSession is keyed by sessionId, so an
-      // unguarded call here would kill the freshly-adopted PTY — whose own onExit
-      // then fires the spurious second "claude process exited". Only this PTY being
-      // the session's CURRENT warm handle means the cleanup is ours to do.
-      const isCurrent = this.lifecycle.getWarm(jinnSessionId) === handle;
-      if (isCurrent) {
-        // Clear scrollback so a stale farewell (Claude's "Resume this session…" hint
-        // printed on SIGHUP shutdown) doesn't persist into the next PTY incarnation.
-        const s = this.streams.get(jinnSessionId);
-        if (s) {
-          s.chunks = [];
-          s.totalBytes = 0;
-          // If no WS subscribers are attached, the entry is dead weight — drop it so
-          // the map doesn't leak entries for every session that ever ran. Subscribers,
-          // when present, are kept so a future respawn can notify them via Task 4's
-          // reset event; that path also clears the subscribers Set on full teardown.
-          if (s.subscribers.size === 0) {
-            this.streams.delete(jinnSessionId);
-          }
-        }
-        // Release the lifecycle entry so the dead handle isn't picked up by a future
-        // run() as "warm" — that would inject into a corpse.
-        this.lifecycle.releaseSession(jinnSessionId);
-      }
-      // Tear down THIS PTY's SSE forward proxy (one proxy per PTY) regardless.
-      proxy?.stop();
-      // PTY exited without a Stop hook (crash / early exit) — settle the active turn
-      // as interrupted so run()'s promise doesn't hang. BUT only if this dying proc is
-      // the one bound to the active turn: after a kill->respawn race the active entry
-      // holds the NEW turn's resolver+proc, and this (old, released) proc must not
-      // poison it. Identity mismatch => benign cleanup, no interrupt.
-      const e = this.active.get(jinnSessionId);
-      if (e && e.boundProc === proc) {
-        e.resolver.interrupt("Interrupted: claude process exited");
-      }
+      this.handlePtyDeath(jinnSessionId, proc, handle, "process exited");
     });
     (handle as any)._proc = proc;
+    // Keep the per-PTY proxy reachable from the handle so handlePtyDeath can tear it
+    // down even when invoked from run()'s warm-reuse path (which has no proxy closure).
+    (handle as any)._proxy = proxy;
     return handle;
   }
 


### PR DESCRIPTION
Fixes #18

## 原因
`InteractiveClaudeEngine` の PTY-master socket error（EIO/EPIPE 等）は **logger.warn のみ**で、後始末（warm evict＋停止ターンの settle）が `proc.onExit` にしか無かった。EIO は **onExit を必ずしも発火させない**ため、壊れた PTY が warm プールに残留 → 次の `run()` が死体を warm として掴み、死んだ socket に `injectPrompt` → SessionStart/Stop フックが来ず resolver 未解決 → per-sessionKey 直列キューが固着し、当該 Slack スレッドの応答が無言で恒久停止していた（90分 watchdog まで）。

## 修正
- onExit の後始末を冪等な **`handlePtyDeath()`（WeakSet ガード）に共通化**し、**socket-error ハンドラからも呼ぶ**。あらゆる pty `error` を terminal 扱いし、warm evict＋active ターン interrupt。
- `run()` warm 再利用: 再利用前に**死活チェック**、**`entry.boundProc` を `injectPrompt` の前に設定**、inject 失敗時も死亡処理で settle（← Codex レビュー指摘の最重要点。死を inject 前後で取り逃さない）。
- per-PTY SSE proxy を handle に紐付け、warm 再利用パスからも proxy を停止可能に。warm 再利用ログ追加（無言ドロップの可視化）。
- バージョン 2026.6.6 → 2026.6.7

## レビュー / テスト
- Codex レビュー実施（賛成＋`boundProc` 先置きの重大指摘を反映）。
- 回帰テスト3本追加: ①EIO無onExitでも interrupt＋evict ②死んだ warm を再利用せず cold respawn ③EIO＋遅延onExit の冪等性。engine テスト **85 passed**、tsc 通過。

## デプロイ
実機 `ryoko.service` に 2026.6.7 install 済み・0エラー稼働確認済み。