### PR TITLE
fix(engine): serialize claude spawns across OAuth token refresh window

### DIFF
--- a/packages/jimmy/src/cron/scheduler.ts
+++ b/packages/jimmy/src/cron/scheduler.ts
@@ -9,6 +9,10 @@ import { logger } from "../shared/logger.js";
 import type { SessionManager } from "../sessions/manager.js";
 import { loadJobs, saveJobs } from "./jobs.js";
 
+/** Max random delay applied to each scheduled cron fire to de-synchronize the
+ *  herd of jobs that share a schedule (e.g. every-15-min jobs all firing at :00). */
+const CRON_JITTER_MS = 20 * 1000;
+
 let tasks: cron.ScheduledTask[] = [];
 let currentSessionManager: SessionManager;
 let currentConfig: JinnConfig;
@@ -50,7 +54,15 @@ function scheduleJobs(jobs: CronJob[]): void {
     const task = cron.schedule(
       job.schedule,
       () => {
-        runCronJob(job, currentSessionManager, currentConfig, currentConnectors);
+        // Jitter the fire by 0–CRON_JITTER_MS to spread the :00/:15/:30/:45
+        // thundering herd (multiple jobs spawning `claude` in the same instant).
+        // Reduces load spikes and lock contention on shared resources; the OAuth
+        // refresh race is fixed separately by the spawn gate, this is defence in
+        // depth. Manual triggers (triggerCronJob) bypass the jitter intentionally.
+        const jitter = Math.floor(Math.random() * CRON_JITTER_MS);
+        setTimeout(() => {
+          runCronJob(job, currentSessionManager, currentConfig, currentConnectors);
+        }, jitter);
       },
       { timezone: job.timezone },
     );

--- a/packages/jimmy/src/cron/scheduler.ts
+++ b/packages/jimmy/src/cron/scheduler.ts
@@ -14,6 +14,11 @@ import { loadJobs, saveJobs } from "./jobs.js";
 const CRON_JITTER_MS = 20 * 1000;
 
 let tasks: cron.ScheduledTask[] = [];
+/** Pending jitter timers (the 0–CRON_JITTER_MS delay between a cron fire and the
+ *  actual run). Tracked so stopScheduler()/reload can cancel them — otherwise a
+ *  delayed fire would run AFTER its job was disabled/deleted, against a stale
+ *  job/config/connector snapshot, and could double-fire on reload. */
+let jitterTimers = new Set<NodeJS.Timeout>();
 let currentSessionManager: SessionManager;
 let currentConfig: JinnConfig;
 let currentConnectors: Map<string, Connector>;
@@ -40,6 +45,9 @@ export function stopScheduler(): void {
     task.stop();
   }
   tasks = [];
+  // Cancel any in-flight jitter delays so a stale fire can't land after stop/reload.
+  for (const timer of jitterTimers) clearTimeout(timer);
+  jitterTimers.clear();
 }
 
 function scheduleJobs(jobs: CronJob[]): void {
@@ -60,9 +68,11 @@ function scheduleJobs(jobs: CronJob[]): void {
         // refresh race is fixed separately by the spawn gate, this is defence in
         // depth. Manual triggers (triggerCronJob) bypass the jitter intentionally.
         const jitter = Math.floor(Math.random() * CRON_JITTER_MS);
-        setTimeout(() => {
+        const timer = setTimeout(() => {
+          jitterTimers.delete(timer);
           runCronJob(job, currentSessionManager, currentConfig, currentConnectors);
         }, jitter);
+        jitterTimers.add(timer);
       },
       { timezone: job.timezone },
     );

--- a/packages/jimmy/src/engines/claude-interactive.ts
+++ b/packages/jimmy/src/engines/claude-interactive.ts
@@ -4,6 +4,7 @@ import type { InterruptibleEngine, EngineRunOpts, EngineResult, EngineRateLimitI
 import { logger } from "../shared/logger.js";
 import { JINN_HOME, CLAUDE_SETTINGS_DIR, HOOK_RELAY_SCRIPT } from "../shared/paths.js";
 import { writeSessionSettings } from "../shared/claude-settings.js";
+import { awaitFreshClaudeCredentials } from "../shared/claude-oauth-gate.js";
 import { PtyLifecycleManager, type PtyHandle } from "./pty-lifecycle.js";
 import type { PtyControlEvent, PtyViewEngine, PtyIdleSpawnOpts } from "./pty-view-engine.js";
 import type { HookRegistry, HookPayload } from "../gateway/hook-registry.js";
@@ -639,6 +640,9 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       cliFlags: opts.cliFlags,
       attachments: opts.attachments,
     });
+    // Serialize the spawn herd across the shared-OAuth near-expiry window so only
+    // one child triggers the (single-use) token refresh — others wait for it.
+    await awaitFreshClaudeCredentials();
     const { proxy, port } = await this.startProxy(jinnSessionId);
     const env = this.buildPtyEnv(port || undefined);
     const bin = opts.bin || "claude";
@@ -688,6 +692,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
 
     void (async () => {
       try {
+        await awaitFreshClaudeCredentials();
         const { proxy, port } = await this.startProxy(jinnSessionId);
         // Re-check after the async gap: a real turn (run) or another idle spawn may
         // have claimed the session while we awaited the proxy bind. If so, don't

--- a/packages/jimmy/src/shared/__tests__/claude-oauth-gate.test.ts
+++ b/packages/jimmy/src/shared/__tests__/claude-oauth-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { awaitFreshClaudeCredentials } from "../claude-oauth-gate.js";
+
+// The gate reads $CLAUDE_CONFIG_DIR/.credentials.json. Point it at a temp dir so
+// tests drive expiresAt deterministically without touching the real ~/.claude.
+let dir: string;
+const credsPath = () => path.join(dir, ".credentials.json");
+function writeExpiresAt(expiresAt: number | null): void {
+  const body = expiresAt === null ? {} : { claudeAiOauth: { expiresAt } };
+  fs.writeFileSync(credsPath(), JSON.stringify(body));
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "oauth-gate-"));
+  process.env.CLAUDE_CONFIG_DIR = dir;
+});
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("awaitFreshClaudeCredentials", () => {
+  it("returns immediately when the token is comfortably valid", async () => {
+    writeExpiresAt(Date.now() + 60 * 60 * 1000); // +1h
+    const t0 = Date.now();
+    await awaitFreshClaudeCredentials();
+    expect(Date.now() - t0).toBeLessThan(50);
+  });
+
+  it("returns immediately when no OAuth credentials exist (e.g. API-key mode)", async () => {
+    writeExpiresAt(null);
+    const t0 = Date.now();
+    await awaitFreshClaudeCredentials();
+    expect(Date.now() - t0).toBeLessThan(50);
+  });
+
+  it("returns immediately when the credential file is absent", async () => {
+    // no file written
+    const t0 = Date.now();
+    await awaitFreshClaudeCredentials();
+    expect(Date.now() - t0).toBeLessThan(50);
+  });
+
+  it("leader proceeds at once near expiry; a follower waits until the token is refreshed", async () => {
+    const staleExp = Date.now() + 1000; // within the 90s near-expiry window
+    writeExpiresAt(staleExp);
+
+    // Leader: elected, returns immediately to spawn (and to perform the refresh).
+    const tLeader = Date.now();
+    await awaitFreshClaudeCredentials();
+    expect(Date.now() - tLeader).toBeLessThan(50);
+
+    // Follower arrives during the same window — must block.
+    let followerDone = false;
+    const follower = awaitFreshClaudeCredentials().then(() => { followerDone = true; });
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(followerDone).toBe(false); // still waiting for the refresh
+
+    // Simulate the leader's claude refreshing the shared token.
+    writeExpiresAt(Date.now() + 8 * 60 * 60 * 1000);
+
+    await follower;
+    expect(followerDone).toBe(true);
+  });
+});

--- a/packages/jimmy/src/shared/claude-oauth-gate.ts
+++ b/packages/jimmy/src/shared/claude-oauth-gate.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logger } from "./logger.js";
+
+/**
+ * OAuth refresh gate for PTY-spawned `claude` children.
+ *
+ * Problem: every interactive turn spawns the genuine `claude` CLI, and they ALL
+ * share one subscription-OAuth credential file (~/.claude/.credentials.json).
+ * Its access token rotates ~every 8h. When several `claude` processes start
+ * within the same instant (cron fires up to ~6 turns at :00/:15/:30/:45) right
+ * as the token expires, each tries to refresh using the SAME single-use refresh
+ * token. The first wins and rotates it; the rest present a now-invalidated
+ * refresh token → 401 invalid_grant, surfaced by the Stop hook as
+ * `authentication_failed` → "Interactive turn failed: authentication_failed".
+ * A lone interactive turn never races, which is why it "fails sometimes".
+ *
+ * Fix WITHOUT touching the OAuth protocol (re-implementing refresh against a
+ * shared production credential file risks logging out every consumer — this
+ * gateway, host OpenClaw, Cursor — by burning the refresh token): serialize the
+ * spawn herd only across the narrow near-expiry window. Elect ONE leader to
+ * spawn first; its `claude` performs the single refresh as a startup side
+ * effect. Followers wait until the credential file's `expiresAt` advances (i.e.
+ * the leader refreshed) or a bounded timeout, then proceed reading the fresh
+ * token. When the token is comfortably valid — the overwhelming common case —
+ * this is a single file read with zero waiting and zero contention.
+ */
+
+/** Start serializing once the token is within this window of expiry (or past it).
+ *  Kept small so we only gate when `claude` will actually refresh on startup. */
+const NEAR_EXPIRY_MS = 90 * 1000;
+/** Max a follower waits for the leader's refresh before proceeding anyway. A
+ *  refresh is a single fast HTTPS call; this is a safety valve, not the norm. */
+const MAX_WAIT_MS = 25 * 1000;
+/** How often a follower re-reads the credential file while waiting. */
+const POLL_MS = 400;
+
+/** In-flight leader election. Non-null while a near-expiry refresh window is
+ *  being drained. Process-local — the gateway is a single process, so this
+ *  alone serializes all of its interactive spawns. */
+let refreshWindow: Promise<void> | null = null;
+
+function credentialsPath(): string {
+  const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  return path.join(dir, ".credentials.json");
+}
+
+/** Read `claudeAiOauth.expiresAt` (epoch ms) from the credential file, or
+ *  undefined when the file is absent/unreadable/not OAuth (e.g. API-key mode) —
+ *  in which case there is nothing to gate and callers proceed immediately. */
+function readExpiresAt(): number | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(credentialsPath(), "utf-8");
+  } catch {
+    return undefined;
+  }
+  try {
+    const exp = JSON.parse(raw)?.claudeAiOauth?.expiresAt;
+    return typeof exp === "number" && exp > 0 ? exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Poll the credential file until `expiresAt` advances past the stale value the
+ *  leader observed (the refresh landed) or the safety timeout elapses. */
+async function waitForRefresh(staleExpiresAt: number): Promise<void> {
+  const deadline = Date.now() + MAX_WAIT_MS;
+  while (Date.now() < deadline) {
+    await sleep(POLL_MS);
+    const exp = readExpiresAt();
+    // Refreshed (advanced) or creds vanished/changed shape — stop blocking.
+    if (exp === undefined || exp > staleExpiresAt) return;
+  }
+  logger.warn(
+    `claude-oauth-gate: refresh not observed within ${MAX_WAIT_MS}ms — proceeding (token may still be refreshing)`,
+  );
+}
+
+/**
+ * Call immediately before spawning a `claude` PTY child. Resolves at once when
+ * the shared OAuth token is comfortably valid; otherwise serializes the spawn
+ * herd so exactly one child triggers the token refresh and the rest wait for it.
+ */
+export async function awaitFreshClaudeCredentials(): Promise<void> {
+  const exp = readExpiresAt();
+  // No OAuth creds, or comfortably valid → nothing to gate.
+  if (exp === undefined || Date.now() < exp - NEAR_EXPIRY_MS) return;
+
+  // Near-expiry window. The first arrival becomes the leader: it returns
+  // immediately to spawn (so its claude performs the refresh) and opens the
+  // window others wait on. Election is race-free — no await between the
+  // null-check and the assignment on this single thread.
+  if (!refreshWindow) {
+    const staleExpiresAt = exp;
+    logger.info(
+      `claude-oauth-gate: token within ${NEAR_EXPIRY_MS}ms of expiry — leader spawning to refresh, followers will wait`,
+    );
+    refreshWindow = waitForRefresh(staleExpiresAt).finally(() => {
+      refreshWindow = null;
+    });
+    return; // leader proceeds to spawn
+  }
+
+  // Follower: wait for the leader's refresh to land before spawning.
+  await refreshWindow;
+}


### PR DESCRIPTION
## 問題

interactive PTY engine は毎ターン本物の `claude` CLI を別プロセス起動し、全ターンが**同一の共有OAuthクレデンシャル** `~/.claude/.credentials.json`（Maxサブスク、access tokenは約8hで失効）を読む。`buildPtyEnv` が `ANTHROPIC_API_KEY/AUTH_TOKEN` を意図的に strip するためOAuth一本でフォールバック無し。

token失効の瞬間に cron が `:00/:15/:30/:45` で `claude` を最大6個同時spawnすると、各自が**使い捨て(rotate)の同一refresh token**でリフレッシュを試みる → 最初の1個だけ成功してトークンをローテート、残りは無効化済トークンを提示し `401 invalid_grant` → Stop hook が `authentication_failed` を返す → **`Interactive turn failed: authentication_failed`**。単発の対話は競合しないので「出たり出なかったり」になる。

実ログでも 401 `authentication_failed` の発生が `:00/:15/:30/:45` ちょうど（cron一斉発火）に集中しており、共有クレデンシャルの同時リフレッシュ競合であることが裏付けられた。

## 修正

OAuthプロトコルには触れない（共有クレデンシャルに対してリフレッシュを再実装すると、refresh tokenを焼いて全コンシューマ＝gateway・他のClaude Codeセッション・Cursorを巻き込みログアウトさせる事故リスク）。代わりに **spawnを失効間近の窓だけ直列化** する軽量ゲートを追加：

- 新規 `shared/claude-oauth-gate.ts` の `awaitFreshClaudeCredentials()` を spawn直前に挿入。
- token が十分有効な通常時はファイル1回読むだけの no-op（待ち・ロックゼロ）。
- 失効間近(90s)のときだけ：最初の1プロセス(リーダー)が先行spawn=リフレッシュ実行、残り(フォロワー)は credential の `expiresAt` 更新を観測するまで最大25s待ってから fresh token で進む。
- 加えて cron発火に 0–20s のジッターを入れ `:00` 等の thundering herd を散らす（防御の二重化）。

## テスト

- 新規 `claude-oauth-gate` 単体テスト（fast-path / クレデンシャル無し / リーダー先行・フォロワー待機）。
- 全 **459 green**。

## 補足

- `claude-interactive.ts` への差し込みは import 1行 + spawn直前 `await` 2箇所のみ（cold spawn / idle spawn 両経路）。warm-PTY再利用パスは新規claudeを起動しないのでゲート不要。
- ロジックは upstream の interactive engine 設計と独立・後方互換。`interactive: false`（headless）構成には影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)