### PR TITLE
feat(progress): surface intermediate assistant turns as live progress + flip guidance

### DIFF
--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -651,9 +651,10 @@ function buildConnectorContext(connectors: string[], gatewayUrl: string, portalN
 
   lines.push("");
   lines.push("### Replying to the current conversation");
-  lines.push("- The text you return as your final answer is delivered to the current user in the correct conversation/thread.");
-  lines.push("- Do not call `/send`, `curl`, or the `send_message` tool for the current conversation. That creates duplicate or meta replies.");
-  lines.push("- Your final answer is shown verbatim to the user, so make it the actual reply rather than work narration.");
+  lines.push("- Every assistant text block you emit during a turn is delivered to the current conversation as its own message, in order. Intermediate blocks show up as live progress; your final block is the conclusion.");
+  lines.push("- For long tasks that run many tools, narrate deliberately: a kickoff line (what you're starting + rough ETA) when you begin, brief milestone updates at meaningful checkpoints, and a completion line with the result. Keep each one short.");
+  lines.push("- Do not stream half-finished drafts, raw tool output, or internal deliberation. Progress updates are polished status lines, not work-in-progress mutterings.");
+  lines.push("- Do not call `/send`, `curl`, or the `send_message` tool for the current conversation — those create duplicate or meta replies. Emitting plain text is the correct way to post progress here.");
 
   lines.push(`\n- **List all connectors**: \`curl ${gatewayUrl}/api/connectors\``);
   lines.push(`- Channel IDs and connector config can be found in \`~/.jinn/config.yaml\``);

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -807,12 +807,16 @@ export class SessionManager {
         await connector.setTypingStatus(target.channel, threadTs, "").catch(() => {});
       }
       if (!wasInterrupted) {
-        // Multi-turn sessions (driven by /goal) carry every intermediate
-        // turn in `result.turns`. Surface each as its own Slack reply so
-        // the user sees progress chronologically. The last entry contains
-        // the same text as `result.result`, so we send the array directly.
+        // The engine captures every intermediate assistant text block it emitted
+        // during the turn in `result.turns` (chronological). Surface each as its
+        // own reply so the user sees progress as it happened — a kickoff line,
+        // milestone updates, then the conclusion. The last entry duplicates
+        // `result.result`, so iterating the array also delivers the final reply.
+        // This applies to any session that narrates progress, not just /goal.
+        // Disable via `sessions.progressUpdates: false` for final-only delivery.
+        const progressUpdates = this.config.sessions?.progressUpdates !== false;
         const turns = result.turns ?? [];
-        if (turns.length > 1) {
+        if (progressUpdates && turns.length > 1) {
           for (const turnText of turns) {
             if (!turnText || !turnText.trim()) continue;
             await connector.replyMessage(target, turnText);

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -505,6 +505,12 @@ export interface JinnConfig {
     rateLimitStrategy?: "wait" | "fallback";
     /** Engine to use when rateLimitStrategy="fallback". Default: "codex" */
     fallbackEngine?: "codex";
+    /**
+     * Surface each intermediate assistant text block produced during a turn as
+     * its own message to the triggering conversation (live progress), instead of
+     * only the final answer. Default: true. Set false to restore final-only delivery.
+     */
+    progressUpdates?: boolean;
   };
   cron?: {
     defaultDelivery?: CronDelivery;


### PR DESCRIPTION
## What & why

亮介 wanted Ryoko (OpenRyoko) to show intermediate progress during long tasks, the way the OpenClaw agent does (kickoff → milestones → completion), instead of going silent until the final answer.

Investigation finding (the surprise): **the delivery layer already exists.** The engine captures every intermediate assistant text block during a turn (`captureTurnText` → `result.turns`), and `SessionManager` already surfaces each as its own message when `turns.length > 1`. So this was *not* a missing "relay layer" (the assumed Option A).

The real blocker was **guidance, not infrastructure**: the injected system prompt told the agent _"make it the actual reply rather than work narration"_ and _"only your final answer is delivered"_ — so the agent emitted a single final block → only the final was delivered → it looked silent.

## Changes

- **`context.ts`** — flip the *"Replying to the current conversation"* guidance: intermediate text blocks **are** delivered as live progress; narrate deliberately on long tool-running tasks (kickoff + milestones + completion); don't stream half-finished drafts or raw tool output. The ban on `/send`/`curl`/`send_message` for the current conversation is kept (those still cause duplicate/meta replies) — plain text is the channel.
- **`manager.ts`** — gate per-turn delivery behind `sessions.progressUpdates` (default **on**) and generalise the comment beyond `/goal`.
- **`types.ts`** — add `sessions.progressUpdates?: boolean` kill-switch.

## Safety / blast radius

- Delivery code path is unchanged except for the opt-out gate, so other employees/cron keep working.
- `sessions.progressUpdates: false` restores final-only delivery.
- Affects all sessions: agents that narrate will post more (intended). Quiet single-block replies are unchanged (`turns.length === 1` → final only).

## Verification

- `tsc --noEmit` clean
- `vitest run` on sessions + config-merge suites green (4 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)