### PR TITLE
feat(models): port model/capability registry + registry-driven effort from jinn

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.6.8",
+  "version": "2026.6.9",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -2287,7 +2287,7 @@ async function runWebSession(
       engineConfig,
       currentSession,
       employee,
-      effortLevelsForModel(config, currentSession.engine, currentSession.model ?? undefined),
+      effortLevelsForModel(config, currentSession.engine, currentSession.model ?? engineConfig.model),
     );
 
     let lastHeartbeatAt = 0;

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -43,6 +43,7 @@ import { getSttStatus, downloadModel, transcribe as sttTranscribe, resolveLangua
 import { JINN_HOME } from "../shared/paths.js";
 import { handleHookPost, LOOPBACK as HOOK_LOOPBACK } from "./hook-endpoint.js";
 import { resolveEffort } from "../shared/effort.js";
+import { effortLevelsForModel, invalidateModelRegistry } from "../shared/models.js";
 import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, recordClaudeRateLimit } from "../shared/usageAwareness.js";
 import { loadJobs, saveJobs } from "../cron/jobs.js";
@@ -1388,6 +1389,7 @@ Handle this as a priority request from a colleague.`;
         "jinn",
         "gateway",
         "engines",
+        "models",
         "connectors",
         "logging",
         "mcp",
@@ -1454,6 +1456,7 @@ Handle this as a priority request from a colleague.`;
       }
 
       fs.writeFileSync(CONFIG_PATH, yamlStr);
+      invalidateModelRegistry(); // models/engines may have changed — rebuild on next read
       logger.info("Config updated via API");
 
       if (connectorsChanged && context.reloadAllConnectors) {
@@ -2280,7 +2283,12 @@ async function runWebSession(
       : currentSession.engine === "gemini"
         ? config.engines.gemini ?? config.engines.claude
         : config.engines.claude;
-    const effortLevel = resolveEffort(engineConfig, currentSession, employee);
+    const effortLevel = resolveEffort(
+      engineConfig,
+      currentSession,
+      employee,
+      effortLevelsForModel(config, currentSession.engine, currentSession.model ?? undefined),
+    );
 
     let lastHeartbeatAt = 0;
     const runHeartbeat = setInterval(() => {
@@ -2398,7 +2406,12 @@ async function runWebSession(
           );
 
           const fallbackConfig = config.engines.codex;
-          const fallbackEffort = resolveEffort(fallbackConfig, currentSession, employee);
+          const fallbackEffort = resolveEffort(
+            fallbackConfig,
+            currentSession,
+            employee,
+            effortLevelsForModel(config, "codex", currentSession.model ?? fallbackConfig.model),
+          );
           const codexResume = typeof engineSessions.codex === "string" ? (engineSessions.codex as string) : undefined;
           const history = getMessages(currentSession.id)
             .filter((m) => m.role === "user" || m.role === "assistant")

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -1041,6 +1041,7 @@ export async function startGateway(
       try {
         const previous = currentConfig;
         currentConfig = loadConfig();
+        invalidateModelRegistry(); // rebuild the model/capability registry from the reloaded config
         apiContext.config = currentConfig;
         // Propagate the fresh config into SessionManager so new sessions
         // pick up edits to engines.default / portal.* / engine bin paths

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -8,6 +8,7 @@ import { randomUUID, randomBytes } from "node:crypto";
 import { WebSocketServer, type WebSocket } from "ws";
 import type { JinnConfig, Connector, Employee } from "../shared/types.js";
 import { loadConfig } from "../shared/config.js";
+import { invalidateModelRegistry } from "../shared/models.js";
 import { configureLogger, logger } from "../shared/logger.js";
 import { initDb, recoverStaleSessions, recoverStaleQueueItems, getInterruptedSessions, listSessions, updateSession, getSession } from "../sessions/registry.js";
 import { SessionManager, type RouteOptions } from "../sessions/manager.js";
@@ -713,6 +714,7 @@ export async function startGateway(
     // engines.default / portal.* / bin paths. Callers (watcher / API) are
     // responsible for updating apiContext.config too.
     currentConfig = fresh;
+    invalidateModelRegistry(); // rebuild the model/capability registry from the new config
     sessionManager.setConfig(fresh);
 
     // Order:

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -23,6 +23,7 @@ import { SessionQueue } from "./queue.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { logger } from "../shared/logger.js";
 import { resolveEffort } from "../shared/effort.js";
+import { effortLevelsForModel } from "../shared/models.js";
 import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit, isDeadSessionError, isPoisonedTranscriptError } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, isLikelyNearClaudeUsageLimit, recordClaudeRateLimit } from "../shared/usageAwareness.js";
 import { loadJobs } from "../cron/jobs.js";
@@ -327,7 +328,12 @@ export class SessionManager {
         }
       }
 
-      const effortLevel = resolveEffort(engineConfig, session, employee);
+      const effortLevel = resolveEffort(
+        engineConfig,
+        session,
+        employee,
+        effortLevelsForModel(this.config, session.engine, session.model ?? undefined),
+      );
 
       // If we previously switched to GPT while Claude was rate-limited, inject a sync transcript
       // so Claude can resume with full context when it comes back online.
@@ -538,7 +544,12 @@ export class SessionManager {
             });
 
             const fallbackConfig = this.config.engines.codex;
-            const fallbackEffort = resolveEffort(fallbackConfig, session, employee);
+            const fallbackEffort = resolveEffort(
+              fallbackConfig,
+              session,
+              employee,
+              effortLevelsForModel(this.config, "codex", session.model ?? fallbackConfig.model),
+            );
             const codexResume = typeof engineSessions.codex === "string" ? (engineSessions.codex as string) : undefined;
             const history = getMessages(session.id)
               .filter((m) => m.role === "user" || m.role === "assistant")

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -332,7 +332,7 @@ export class SessionManager {
         engineConfig,
         session,
         employee,
-        effortLevelsForModel(this.config, session.engine, session.model ?? undefined),
+        effortLevelsForModel(this.config, session.engine, session.model ?? engineConfig.model),
       );
 
       // If we previously switched to GPT while Claude was rate-limited, inject a sync transcript

--- a/packages/jimmy/src/shared/__tests__/effort.test.ts
+++ b/packages/jimmy/src/shared/__tests__/effort.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveEffort } from "../effort.js";
+import { effortLevelsForModel, invalidateModelRegistry } from "../models.js";
+import type { JinnConfig } from "../types.js";
+
+const CLAUDE = ["low", "medium", "high"];
+const CODEX = ["low", "medium", "high", "xhigh"];
+
+describe("resolveEffort (registry-driven validation)", () => {
+  it("passes through codex xhigh (the previously silently-dropped level)", () => {
+    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "xhigh" }, null, CODEX)).toBe("xhigh");
+  });
+
+  it("rejects xhigh for claude (not in its levels) and falls back to medium", () => {
+    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "xhigh" }, null, CLAUDE)).toBe("medium");
+  });
+
+  it("claude still accepts low/medium/high", () => {
+    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "low" }, null, CLAUDE)).toBe("low");
+    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "high" }, null, CLAUDE)).toBe("high");
+  });
+
+  it("drops an unknown level and defaults (graceful degradation, no throw)", () => {
+    expect(resolveEffort({ effortLevel: "ultra" }, { parentSessionId: null, effortLevel: null }, null, CLAUDE)).toBe("medium");
+  });
+
+  it("returns medium without warning when the engine has no effort concept (empty levels)", () => {
+    expect(resolveEffort({ effortLevel: "high" }, { parentSessionId: "p", effortLevel: "high" }, null, [])).toBe("medium");
+  });
+
+  describe("child-effort resolution chain", () => {
+    it("childEffortOverride wins over everything", () => {
+      expect(resolveEffort(
+        { childEffortOverride: "low" },
+        { parentSessionId: "p", effortLevel: "high" },
+        { effortLevel: "medium" },
+        CLAUDE,
+      )).toBe("low");
+    });
+    it("session beats employee", () => {
+      expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "high" }, { effortLevel: "low" }, CLAUDE)).toBe("high");
+    });
+    it("employee default when no session level", () => {
+      expect(resolveEffort({}, { parentSessionId: "p", effortLevel: null }, { effortLevel: "low" }, CLAUDE)).toBe("low");
+    });
+    it("skips an invalid override and continues down the chain", () => {
+      expect(resolveEffort(
+        { childEffortOverride: "ultra" },
+        { parentSessionId: "p", effortLevel: "high" },
+        null,
+        CLAUDE,
+      )).toBe("high");
+    });
+  });
+
+  it("non-child sessions use the engine default directly", () => {
+    expect(resolveEffort({ effortLevel: "high" }, { parentSessionId: null, effortLevel: "low" }, { effortLevel: "low" }, CLAUDE)).toBe("high");
+  });
+});
+
+describe("effortLevelsForModel (registry lookup)", () => {
+  function cfg(): JinnConfig {
+    return {
+      gateway: { port: 7777, host: "127.0.0.1" },
+      engines: {
+        default: "claude",
+        claude: { bin: "claude", model: "opus" },
+        codex: { bin: "codex", model: "gpt-5.4" },
+        gemini: { bin: "gemini", model: "gemini-2.5-pro" },
+      },
+      models: {
+        claude: { default: "opus", models: [{ id: "opus", supportsEffort: true, effortLevels: CLAUDE }] },
+        codex: { default: "gpt-5.4", models: [{ id: "gpt-5.4", supportsEffort: true, effortLevels: CODEX }] },
+        gemini: { models: [{ id: "gemini-2.5-pro", supportsEffort: false, effortLevels: [] }] },
+      },
+      connectors: {},
+    } as unknown as JinnConfig;
+  }
+  beforeEach(() => invalidateModelRegistry());
+
+  it("returns codex levels including xhigh", () => {
+    expect(effortLevelsForModel(cfg(), "codex")).toContain("xhigh");
+  });
+  it("returns [] for gemini (no effort support)", () => {
+    expect(effortLevelsForModel(cfg(), "gemini")).toEqual([]);
+  });
+  it("returns [] for an unknown engine", () => {
+    expect(effortLevelsForModel(cfg(), "nope")).toEqual([]);
+  });
+  it("returns claude levels for its default model", () => {
+    expect(effortLevelsForModel(cfg(), "claude")).toEqual(CLAUDE);
+  });
+});

--- a/packages/jimmy/src/shared/__tests__/models.test.ts
+++ b/packages/jimmy/src/shared/__tests__/models.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { JinnConfig } from "../types.js";
+import { getModelRegistry, invalidateModelRegistry, synthesizeFromEngineConfig, effortLevelsForModel, contextWindowForModel } from "../models.js";
+
+function cfg(partial: Partial<JinnConfig["engines"]>, models?: JinnConfig["models"]): JinnConfig {
+  return {
+    gateway: { port: 7777, host: "127.0.0.1" },
+    engines: {
+      default: "claude",
+      claude: { bin: "claude", model: "opus" },
+      codex: { bin: "codex", model: "gpt-5.3-codex" },
+      ...partial,
+    },
+    models,
+    connectors: {},
+  } as JinnConfig;
+}
+
+beforeEach(() => invalidateModelRegistry());
+
+describe("synthesizeFromEngineConfig (backward-compat fallback)", () => {
+  it("builds an entry per engine from engines.<name>.model", () => {
+    const reg = synthesizeFromEngineConfig(cfg({}));
+    expect(reg.claude.models[0].id).toBe("opus");
+    expect(reg.claude.defaultModel).toBe("opus");
+    expect(reg.codex.models[0].id).toBe("gpt-5.3-codex");
+    expect(reg.gemini.models[0].id).toBe("gemini-2.5-pro");
+  });
+
+  it("uses per-engine effort semantics: claude flag (low/med/high), codex config (incl xhigh), gemini none", () => {
+    const reg = synthesizeFromEngineConfig(cfg({}));
+    expect(reg.claude.effortMechanism).toBe("claude-flag");
+    expect(reg.claude.models[0].effortLevels).toEqual(["low", "medium", "high"]);
+    expect(reg.codex.effortMechanism).toBe("codex-config");
+    expect(reg.codex.models[0].effortLevels).toContain("xhigh");
+    expect(reg.gemini.effortMechanism).toBe("none");
+    expect(reg.gemini.models[0].supportsEffort).toBe(false);
+    expect(reg.gemini.models[0].effortLevels).toEqual([]);
+  });
+});
+
+describe("getModelRegistry with a models: block", () => {
+  const models: JinnConfig["models"] = {
+    claude: {
+      default: "claude-opus-4-8",
+      effortMechanism: "claude-flag",
+      models: [
+        { id: "claude-opus-4-8", label: "Opus 4.8", supportsEffort: true, effortLevels: ["low", "medium", "high"] },
+        { id: "claude-sonnet-4-6", label: "Sonnet 4.6", supportsEffort: true, effortLevels: ["low", "medium", "high"] },
+      ],
+    },
+    codex: {
+      default: "gpt-5.3-codex",
+      models: [{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex", supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"] }],
+    },
+    gemini: {
+      models: [{ id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", supportsEffort: false, effortLevels: [] }],
+    },
+  };
+
+  it("honors the configured models, labels, and effort levels", () => {
+    const reg = getModelRegistry(cfg({}, models));
+    expect(reg.claude.models.map((m) => m.id)).toEqual(["claude-opus-4-8", "claude-sonnet-4-6"]);
+    expect(reg.claude.models[0].label).toBe("Opus 4.8");
+    expect(reg.codex.models[0].effortLevels).toContain("xhigh");
+    expect(reg.gemini.models[0].supportsEffort).toBe(false);
+  });
+
+  it("resolves defaultModel from block.default, else the first model", () => {
+    const reg = getModelRegistry(cfg({}, models));
+    expect(reg.claude.defaultModel).toBe("claude-opus-4-8");
+    expect(reg.gemini.defaultModel).toBe("gemini-2.5-pro"); // no default → first
+  });
+});
+
+describe("effortLevelsForModel / contextWindowForModel (explicit modelId)", () => {
+  const models: JinnConfig["models"] = {
+    claude: {
+      default: "opus",
+      models: [
+        { id: "opus", supportsEffort: true, effortLevels: ["low", "medium", "high"], contextWindow: 200000 },
+        { id: "sonnet", supportsEffort: true, effortLevels: ["low", "medium"], contextWindow: 1000000 },
+      ],
+    },
+  };
+
+  it("selects the named model's levels, not the default", () => {
+    expect(effortLevelsForModel(cfg({}, models), "claude", "sonnet")).toEqual(["low", "medium"]);
+  });
+
+  it("returns a fresh copy (caller cannot mutate the cached array)", () => {
+    const a = effortLevelsForModel(cfg({}, models), "claude", "opus");
+    a.push("ultra");
+    expect(effortLevelsForModel(cfg({}, models), "claude", "opus")).toEqual(["low", "medium", "high"]);
+  });
+
+  it("reads the context window for a named model", () => {
+    expect(contextWindowForModel(cfg({}, models), "claude", "sonnet")).toBe(1000000);
+  });
+
+  it("contextWindow is undefined when unknown (synthesized entry)", () => {
+    expect(contextWindowForModel(cfg({}), "claude")).toBeUndefined();
+  });
+});
+
+describe("cache + invalidate", () => {
+  it("caches across calls and refreshes only after invalidate", () => {
+    const a = getModelRegistry(cfg({}));
+    const b = getModelRegistry(cfg({ claude: { bin: "claude", model: "CHANGED" } }));
+    expect(b).toBe(a); // cached — ignores the new config until invalidated
+    invalidateModelRegistry();
+    const c = getModelRegistry(cfg({ claude: { bin: "claude", model: "CHANGED" } }));
+    expect(c.claude.models[0].id).toBe("CHANGED");
+  });
+});

--- a/packages/jimmy/src/shared/effort.ts
+++ b/packages/jimmy/src/shared/effort.ts
@@ -1,10 +1,16 @@
 import { logger } from "./logger.js";
 import type { Employee, Session } from "./types.js";
 
-const VALID_EFFORTS = new Set(["low", "medium", "high"]);
+const DEFAULT_EFFORT = "medium";
 
 /**
  * Resolve the effort level for a session.
+ *
+ * Valid effort levels come from the model registry (`validLevels`) for the
+ * session's engine+model — NOT a hardcoded set — so e.g. codex's `xhigh`
+ * validates and passes through instead of being silently dropped. Unknown or
+ * unsupported levels are dropped with a logged warning (graceful degradation),
+ * never a silent pass or a hard throw.
  *
  * For child sessions (has parentSessionId), resolution chain:
  *   1. config.engines.<engine>.childEffortOverride — global cost-control knob
@@ -13,37 +19,44 @@ const VALID_EFFORTS = new Set(["low", "medium", "high"]);
  *   4. config.engines.<engine>.effortLevel — engine fallback
  *
  * For non-child sessions (COO's own), use engine effortLevel directly.
+ *
+ * When the engine/model has no effort concept (validLevels empty, e.g.
+ * Gemini), returns the default without warnings — effort is just ignored.
  */
 export function resolveEffort(
   engineConfig: { effortLevel?: string; childEffortOverride?: string },
   session: Pick<Session, "parentSessionId" | "effortLevel">,
-  employee?: Pick<Employee, "effortLevel"> | null,
+  employee: Pick<Employee, "effortLevel"> | null | undefined,
+  validLevels: string[],
 ): string {
+  if (validLevels.length === 0) return DEFAULT_EFFORT;
+  const isValid = (level: string) => validLevels.includes(level);
+
   if (session.parentSessionId) {
     const override = engineConfig.childEffortOverride;
     if (override) {
-      if (VALID_EFFORTS.has(override)) return override;
-      logger.warn(`Invalid childEffortOverride "${override}" in engine config, skipping`);
+      if (isValid(override)) return override;
+      logger.warn(`Invalid childEffortOverride "${override}" (valid: ${validLevels.join(", ")}), skipping`);
     }
 
     const requested = session.effortLevel;
     if (requested) {
-      if (VALID_EFFORTS.has(requested)) return requested;
-      logger.warn(`Invalid effortLevel "${requested}" on session, skipping`);
+      if (isValid(requested)) return requested;
+      logger.warn(`Invalid effortLevel "${requested}" on session (valid: ${validLevels.join(", ")}), skipping`);
     }
 
     const empDefault = employee?.effortLevel;
     if (empDefault) {
-      if (VALID_EFFORTS.has(empDefault)) return empDefault;
-      logger.warn(`Invalid effortLevel "${empDefault}" on employee, skipping`);
+      if (isValid(empDefault)) return empDefault;
+      logger.warn(`Invalid effortLevel "${empDefault}" on employee (valid: ${validLevels.join(", ")}), skipping`);
     }
   }
 
   // Non-child sessions (COO) or fallback
   const engineDefault = engineConfig.effortLevel;
-  if (engineDefault && VALID_EFFORTS.has(engineDefault)) return engineDefault;
+  if (engineDefault && isValid(engineDefault)) return engineDefault;
   if (engineDefault) {
-    logger.warn(`Invalid effortLevel "${engineDefault}" in engine config, defaulting to "medium"`);
+    logger.warn(`Invalid effortLevel "${engineDefault}" in engine config (valid: ${validLevels.join(", ")}), defaulting to "${DEFAULT_EFFORT}"`);
   }
-  return "medium";
+  return DEFAULT_EFFORT;
 }

--- a/packages/jimmy/src/shared/models.ts
+++ b/packages/jimmy/src/shared/models.ts
@@ -1,0 +1,134 @@
+import type {
+  JinnConfig,
+  ModelInfo,
+  ModelRegistry,
+  EngineRegistryEntry,
+  EffortMechanism,
+  EngineModelsConfig,
+} from "./types.js";
+
+/**
+ * Model + capability registry — the single source of truth for which engines and
+ * models exist and what they support (effort levels). Built from the
+ * optional `models:` block in config.yaml; when that block is absent (or an engine
+ * is missing from it) the entry is synthesized from `engines.<name>.model` so
+ * existing configs keep working. Adding a NEW model is a config edit, no code change.
+ */
+
+/** Engines registered in this build (mirrors server.ts engine map). */
+const ENGINE_NAMES = ["claude", "codex", "gemini"] as const;
+type EngineName = (typeof ENGINE_NAMES)[number];
+
+const EFFORT_MECHANISM: Record<EngineName, EffortMechanism> = {
+  claude: "claude-flag",
+  codex: "codex-config",
+  gemini: "none",
+};
+
+/** Conservative per-engine defaults used when synthesizing (no `models:` block). */
+const SYNTH_DEFAULTS: Record<EngineName, { supportsEffort: boolean; effortLevels: string[]; fallbackModel: string }> = {
+  claude: { supportsEffort: true, effortLevels: ["low", "medium", "high"], fallbackModel: "opus" },
+  codex: { supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"], fallbackModel: "gpt-5.3-codex" },
+  gemini: { supportsEffort: false, effortLevels: [], fallbackModel: "gemini-2.5-pro" },
+};
+
+let cached: ModelRegistry | null = null;
+
+/** Clear the cached registry. Call on config reload / PUT /api/config. */
+export function invalidateModelRegistry(): void {
+  cached = null;
+}
+
+/** Resolve the registry (cached). Pass the current config; cache is keyed by
+ *  invalidation, not by config identity — call invalidateModelRegistry() to refresh. */
+export function getModelRegistry(config: JinnConfig): ModelRegistry {
+  if (!cached) cached = buildRegistry(config);
+  return cached;
+}
+
+/**
+ * Valid effort levels for a session's engine+model, from the registry.
+ * Returns [] when the engine/model doesn't support effort (e.g. gemini) or
+ * the engine is unknown. `modelId` defaults to the engine's default model.
+ */
+export function effortLevelsForModel(config: JinnConfig, engine: string, modelId?: string): string[] {
+  const entry = getModelRegistry(config)[engine];
+  if (!entry) return [];
+  const model =
+    (modelId ? entry.models.find((m) => m.id === modelId) : undefined) ??
+    entry.models.find((m) => m.id === entry.defaultModel) ??
+    entry.models[0];
+  return model?.supportsEffort ? [...model.effortLevels] : [];
+}
+
+/** Context window (tokens) for a session's engine+model, or undefined if unknown. */
+export function contextWindowForModel(config: JinnConfig, engine: string, modelId?: string): number | undefined {
+  const entry = getModelRegistry(config)[engine];
+  if (!entry) return undefined;
+  const model =
+    (modelId ? entry.models.find((m) => m.id === modelId) : undefined) ??
+    entry.models.find((m) => m.id === entry.defaultModel) ??
+    entry.models[0];
+  return model?.contextWindow;
+}
+
+/** Build the registry without touching the cache (used by getModelRegistry + tests). */
+export function buildRegistry(config: JinnConfig): ModelRegistry {
+  const synthesized = synthesizeFromEngineConfig(config);
+  const block = config.models;
+  if (!block) return synthesized;
+
+  const registry: ModelRegistry = {};
+  for (const name of ENGINE_NAMES) {
+    const engineBlock = block[name];
+    registry[name] = engineBlock
+      ? fromEngineModelsConfig(name, engineBlock)
+      : synthesized[name]; // engine omitted from the block → keep the synthesized entry
+  }
+  return registry;
+}
+
+/** Backward-compat: synthesize a minimal registry from engines.<name>.model. */
+export function synthesizeFromEngineConfig(config: JinnConfig): ModelRegistry {
+  const registry: ModelRegistry = {};
+  for (const name of ENGINE_NAMES) {
+    const defaults = SYNTH_DEFAULTS[name];
+    const engineCfg = (config.engines as unknown as Record<string, { model?: string } | undefined>)[name];
+    const modelId = engineCfg?.model || defaults.fallbackModel;
+    const model: ModelInfo = {
+      id: modelId,
+      label: modelId,
+      supportsEffort: defaults.supportsEffort,
+      effortLevels: defaults.supportsEffort ? [...defaults.effortLevels] : [],
+    };
+    registry[name] = {
+      name,
+      available: true,
+      defaultModel: modelId,
+      effortMechanism: EFFORT_MECHANISM[name],
+      models: [model],
+    };
+  }
+  return registry;
+}
+
+function fromEngineModelsConfig(name: EngineName, block: EngineModelsConfig): EngineRegistryEntry {
+  const models: ModelInfo[] = (block.models ?? []).map((m) => {
+    const supportsEffort = m.supportsEffort ?? false;
+    return {
+      id: m.id,
+      label: m.label || m.id,
+      supportsEffort,
+      effortLevels: supportsEffort ? (m.effortLevels ?? []) : [],
+      ...(typeof m.contextWindow === "number" ? { contextWindow: m.contextWindow } : {}),
+    };
+  });
+  const defaultModel = block.default || models[0]?.id || SYNTH_DEFAULTS[name].fallbackModel;
+  return {
+    name,
+    available: true,
+    defaultModel,
+    effortMechanism: block.effortMechanism ?? EFFORT_MECHANISM[name],
+    models,
+  };
+}

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -461,6 +461,60 @@ export interface PortalConfig {
   onboarded?: boolean;
 }
 
+// --- Model + capability registry ---
+// Single source of truth for which engines/models exist and what they support.
+// Shipping a NEW model is a config edit (`models:` block in config.yaml), zero
+// code change. When the block is absent, the registry is synthesized from
+// `engines.<name>.model` so existing configs keep working.
+
+/** How an engine conveys reasoning-effort to its CLI. */
+export type EffortMechanism = "claude-flag" | "codex-config" | "none";
+
+/** A single model and its capabilities, as exposed to the UI / validation. */
+export interface ModelInfo {
+  id: string;
+  label: string;
+  supportsEffort: boolean;
+  /** Valid effort levels for THIS model (empty when supportsEffort is false). */
+  effortLevels: string[];
+  /** Context window size in tokens (for the UI context meter). Omit if unknown. */
+  contextWindow?: number;
+}
+
+/** Resolved per-engine registry entry. */
+export interface EngineRegistryEntry {
+  name: string;
+  /** Engine is registered/usable in this build. */
+  available: boolean;
+  /** Default model id for new sessions on this engine. */
+  defaultModel: string;
+  effortMechanism: EffortMechanism;
+  models: ModelInfo[];
+}
+
+/** Resolved registry, keyed by engine name. */
+export type ModelRegistry = Record<string, EngineRegistryEntry>;
+
+// --- config.yaml `models:` block shapes (all fields optional/forgiving) ---
+
+export interface ModelConfigEntry {
+  id: string;
+  label?: string;
+  supportsEffort?: boolean;
+  effortLevels?: string[];
+  contextWindow?: number;
+}
+
+export interface EngineModelsConfig {
+  /** Default model id; falls back to the first listed model. */
+  default?: string;
+  effortMechanism?: EffortMechanism;
+  models: ModelConfigEntry[];
+}
+
+/** `models:` block keyed by engine name (claude | codex | gemini). */
+export type ModelsConfig = Record<string, EngineModelsConfig>;
+
 export interface JinnConfig {
   jinn?: { version?: string };
   gateway: { port: number; host: string; streaming?: boolean };
@@ -486,6 +540,9 @@ export interface JinnConfig {
     codex: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string };
     gemini?: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string };
   };
+  /** Optional model/capability registry override. Absent → synthesized from
+   *  `engines.<name>.model`. See shared/models.ts. */
+  models?: ModelsConfig;
   connectors: Record<string, any> & {
     web?: WebConnectorConfig;
     slack?: SlackConnectorConfig;


### PR DESCRIPTION
## What & why

upstream `jinn` の **モデル/能力レジストリ (`shared/models.ts`)** と **`effort.ts` のレジストリ駆動化** を OpenRyoko (`packages/jimmy`) に移植。エンジン構成は我々の **claude/codex/gemini** に適応（upstream の `antigravity` → `gemini`）。

### 解決する問題
従来 `effort.ts` は `{low, medium, high}` をハードコードで検証しており、**codex の `xhigh` 等が黙って握り潰されていた**。レジストリ駆動にすることで「エンジン×モデルが実際にサポートする effort levels」で検証され、正しく通る。

## Changes
- **`shared/types.ts`**: `ModelInfo` / `EngineRegistryEntry` / `ModelRegistry` / `EngineModelsConfig` / `EffortMechanism` など型を追加。`JinnConfig.models?` を追加
- **`shared/models.ts`** (新規): モデル/能力レジストリの単一真実源。`getModelRegistry` / `effortLevelsForModel` / `contextWindowForModel` / `synthesizeFromEngineConfig`。`models:` block 不在時は `engines.<name>.model` から合成（**後方互換**・新モデル追加はconfig編集のみ）
- **`shared/effort.ts`**: `validLevels` 引数化。graceful degradation 維持
- **`gateway/api.ts` / `sessions/manager.ts`**: `resolveEffort` 呼び出し4箇所を validLevels 付きに更新。effort検証 model を実行 model (`session.model ?? engineConfig.model` / fallback時は実モデル) と一致
- **キャッシュ無効化**: config 保存 (PUT /api/config)・watcher reload・connector reload の3経路で `invalidateModelRegistry`。`KNOWN_KEYS` に `models` 追加
- **テスト**: `effort.test.ts`(14) + `models.test.ts`(9) 計23テスト追加

## レビュー / 検証
- **Codex レビュー2周**で指摘（KNOWN_KEYS漏れ、cache無効化漏れ、fallback/通常実行の model 不一致、配列mutation）を全て反映
- 型チェッククリーン、**全484テスト pass**、Codex独立テスト実行で shared/sessions ロジック **101 pass**（models/effort含む）
- `npm run build` 成功（dist/web 同梱確認）

## 注意
- 実機デプロイは本PRスコープ外（必要なら xserver-ops で別途実施）
