### PR TITLE
feat(delivery): reply-disposition — sanitize engine output before posting (supersedes #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 
 # Jinn runtime dir (safety: never commit tokens)
 .jinn/
+/docs

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.6.9",
+  "version": "2026.6.10",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -39,7 +39,7 @@ export class SlackConnector implements Connector {
   private readonly bootTimeMs = Date.now();
   private started = false;
   private lastError: string | null = null;
-  private channelNameCache = new Map<string, { name: string; cachedAt: number }>();
+  private channelNameCache = new Map<string, { name?: string; isExtShared: boolean; cachedAt: number }>();
   private userInfoCache = new Map<string, { info: SpeakerInfo; cachedAt: number }>();
   private botUserId: string | null = null;
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
@@ -263,22 +263,33 @@ export class SlackConnector implements Connector {
     }
   }
 
-  private async resolveChannelName(channelId: string): Promise<string | undefined> {
+  /**
+   * Resolve channel name and external-shared status in one cached call.
+   * `isExtShared` is true for Slack Connect (externally/org shared) channels —
+   * the delivery layer treats these (and unknowns) as "external" so the model's
+   * operator-facing notes are never posted there. See reply-disposition.ts.
+   */
+  private async resolveChannelInfo(channelId: string): Promise<{ name?: string; isExtShared: boolean }> {
     const cached = this.channelNameCache.get(channelId);
     if (cached && Date.now() - cached.cachedAt < SlackConnector.CHANNEL_CACHE_TTL_MS) {
-      return cached.name;
+      return { name: cached.name, isExtShared: cached.isExtShared };
     }
     try {
       const result = await this.app.client.conversations.info({ channel: channelId });
-      const name = result.channel?.name;
-      if (name) {
-        this.channelNameCache.set(channelId, { name, cachedAt: Date.now() });
-        return name;
-      }
+      const channel = result.channel as { name?: string; is_ext_shared?: boolean; is_org_shared?: boolean; is_shared?: boolean } | undefined;
+      const name = channel?.name;
+      const isExtShared = !!(channel?.is_ext_shared || channel?.is_org_shared || channel?.is_shared);
+      this.channelNameCache.set(channelId, { name, isExtShared, cachedAt: Date.now() });
+      return { name, isExtShared };
     } catch (err) {
-      logger.debug(`Failed to resolve channel name for ${channelId}: ${err}`);
+      logger.debug(`Failed to resolve channel info for ${channelId}: ${err}`);
     }
-    return undefined;
+    // Unknown → treat as external (safe): never assume a channel is private.
+    return { name: undefined, isExtShared: true };
+  }
+
+  private async resolveChannelName(channelId: string): Promise<string | undefined> {
+    return (await this.resolveChannelInfo(channelId)).name;
   }
 
   async start() {
@@ -353,12 +364,15 @@ export class SlackConnector implements Connector {
       }
 
       const slackUserId = (event as any).user as string;
-      const [channelName, speaker] = await Promise.all([
-        this.resolveChannelName((event as any).channel),
+      const [channelInfo, speaker] = await Promise.all([
+        this.resolveChannelInfo((event as any).channel),
         this.resolveSpeakerInfo(slackUserId),
       ]);
+      const channelName = channelInfo.name;
 
       const channelType = ((event as any).channel_type as string) || "channel";
+      // DM is never "external"; otherwise trust the Slack Connect flag.
+      const channelExternal = channelType !== "im" && channelInfo.isExtShared;
       const rawText = ((event as any).text || "") as string;
       const wasMentioned = !!this.botUserId && rawText.includes(`<@${this.botUserId}>`);
 
@@ -403,6 +417,7 @@ export class SlackConnector implements Connector {
         raw: event,
         transportMeta: {
           channelType,
+          channelExternal,
           team: ((event as any).team as string) || null,
           channelName: channelName || null,
           wasMentioned,
@@ -591,11 +606,12 @@ export class SlackConnector implements Connector {
         return;
       }
 
-      // Resolve channel name and reactor (speaker) in parallel
-      const [channelName, speaker] = await Promise.all([
-        this.resolveChannelName(channelId),
+      // Resolve channel name/external status and reactor (speaker) in parallel
+      const [channelInfo, speaker] = await Promise.all([
+        this.resolveChannelInfo(channelId),
         this.resolveSpeakerInfo(event.user),
       ]);
+      const channelName = channelInfo.name;
       const channelDisplay = channelName ? `#${channelName}` : channelId;
 
       // Build the prompt with reaction context
@@ -622,6 +638,7 @@ export class SlackConnector implements Connector {
         raw: event,
         transportMeta: {
           channelType: "channel",
+          channelExternal: channelInfo.isExtShared,
           team: null,
           channelName: channelName || null,
           ...this.speakerTransportFields(speaker, event.user),

--- a/packages/jimmy/src/sessions/__tests__/reply-disposition.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/reply-disposition.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDisposition,
+  normalizeDelivery,
+  normalizeTurns,
+  SAFE_ACK,
+  type DeliveryContext,
+} from "../reply-disposition.js";
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+function sentinel(obj: unknown): string {
+  return `<!--RYOKO-DISPOSITION:v1:${b64url(obj)}-->`;
+}
+
+const EXTERNAL: DeliveryContext = { addressed: true, channelExternal: true, isDM: false, canReact: true };
+const INTERNAL_CH: DeliveryContext = { addressed: true, channelExternal: false, isDM: false, canReact: true };
+const DM: DeliveryContext = { addressed: true, channelExternal: false, isDM: true, canReact: true };
+const NO_REACT: DeliveryContext = { addressed: true, channelExternal: true, isDM: false, canReact: false };
+const UNADDRESSED: DeliveryContext = { addressed: false, channelExternal: true, isDM: false, canReact: true };
+
+describe("parseDisposition", () => {
+  it("no sentinel → whole text is public", () => {
+    const p = parseDisposition("just a normal reply");
+    expect(p.hadSentinel).toBe(false);
+    expect(p.publicText).toBe("just a normal reply");
+    expect(p.payload).toEqual({});
+  });
+
+  it("splits public body from sentinel payload", () => {
+    const text = `荒木さん、確認して折り返します。\n\n${sentinel({ internal: "録画が未アップ", react: ":eyes:" })}`;
+    const p = parseDisposition(text);
+    expect(p.hadSentinel).toBe(true);
+    expect(p.decodeError).toBe(false);
+    expect(p.publicText).toBe("荒木さん、確認して折り返します。");
+    expect(p.payload.internal).toBe("録画が未アップ");
+    expect(p.payload.react).toBe(":eyes:");
+  });
+
+  it("fail-closed: malformed payload is still recognized as sentinel and stripped", () => {
+    const text = `public part\n\n<!--RYOKO-DISPOSITION:v1:@@@notbase64@@@-->`;
+    const p = parseDisposition(text);
+    expect(p.hadSentinel).toBe(true);
+    expect(p.decodeError).toBe(true);
+    expect(p.publicText).toBe("public part");
+    // The marker line must never survive into the public body.
+    expect(p.publicText).not.toContain("RYOKO-DISPOSITION");
+    expect(p.payload.internal).toBeUndefined();
+  });
+
+  it("fail-closed: base64 with padding still strips the sentinel (no whole-text restore)", () => {
+    // Standard base64 padding "=" must not break sentinel recognition.
+    const text = `public part\n\n<!--RYOKO-DISPOSITION:v1:YWJjZA==-->`;
+    const p = parseDisposition(text);
+    expect(p.hadSentinel).toBe(true);
+    expect(p.publicText).toBe("public part");
+    expect(p.publicText).not.toContain("RYOKO-DISPOSITION");
+  });
+
+  it("fail-closed: valid base64url of non-JSON drops sentinel, no internal", () => {
+    const bad = Buffer.from("not json{{{").toString("base64url");
+    const text = `public part\n\n<!--RYOKO-DISPOSITION:v1:${bad}-->`;
+    const p = parseDisposition(text);
+    expect(p.hadSentinel).toBe(true);
+    expect(p.decodeError).toBe(true);
+    expect(p.publicText).toBe("public part");
+    expect(p.payload.internal).toBeUndefined();
+  });
+
+  it("does not match a sentinel that is not on the last non-empty line", () => {
+    const text = `${sentinel({ internal: "x" })}\n\nreal reply below`;
+    const p = parseDisposition(text);
+    expect(p.hadSentinel).toBe(false);
+    expect(p.publicText).toContain("real reply below");
+  });
+});
+
+describe("normalizeDelivery — invariants", () => {
+  it("plain reply on external channel passes through", () => {
+    const d = normalizeDelivery("ご連絡ありがとうございます。", EXTERNAL);
+    expect(d.publicAction).toEqual({ kind: "reply", text: "ご連絡ありがとうございます。" });
+    expect(d.internal).toBeUndefined();
+  });
+
+  it("strips internal note from external channel, keeps public body", () => {
+    const text = `確認して折り返します。\n\n${sentinel({ internal: "file ID: 123 / GO待ち" })}`;
+    const d = normalizeDelivery(text, EXTERNAL);
+    expect(d.publicAction).toEqual({ kind: "reply", text: "確認して折り返します。" });
+    expect(d.internal).toBe("file ID: 123 / GO待ち");
+  });
+
+  it("the actual accident: internal-only report never posts publicly, ack instead", () => {
+    // Model wrote an operator report as the whole body but marked suppressPublic.
+    const text = `亮介にお願いしたいこと…\n\n${sentinel({ internal: "亮介にお願い…", suppressPublic: true })}`;
+    const d = normalizeDelivery(text, EXTERNAL);
+    // suppressPublic + no react + addressed → safe ack, internal saved
+    expect(d.publicAction).toEqual({ kind: "reply", text: SAFE_ACK });
+    expect(d.internal).toBeTruthy();
+  });
+
+  it("addressed + nothing public → safe ack (never silent)", () => {
+    const text = sentinel({ suppressPublic: true });
+    const d = normalizeDelivery(text, EXTERNAL);
+    expect(d.publicAction).toEqual({ kind: "reply", text: SAFE_ACK });
+  });
+
+  it("unaddressed + nothing public → none (silence allowed)", () => {
+    const text = sentinel({ suppressPublic: true });
+    const d = normalizeDelivery(text, UNADDRESSED);
+    expect(d.publicAction).toEqual({ kind: "none" });
+  });
+
+  it("react-only when no body", () => {
+    const text = sentinel({ react: ":+1:" });
+    const d = normalizeDelivery(text, EXTERNAL);
+    expect(d.publicAction).toEqual({ kind: "react", emoji: "+1" });
+  });
+
+  it("react degrades to reply when connector cannot react", () => {
+    const text = sentinel({ react: ":+1:" });
+    const d = normalizeDelivery(text, NO_REACT);
+    expect(d.publicAction).toEqual({ kind: "reply", text: SAFE_ACK });
+  });
+
+  it("DM: audience separation OFF — internal is shown to operator", () => {
+    const text = `状況です。\n\n${sentinel({ internal: "録画未アップ・file ID 123" })}`;
+    const d = normalizeDelivery(text, DM);
+    expect(d.publicAction.kind).toBe("reply");
+    if (d.publicAction.kind === "reply") {
+      expect(d.publicAction.text).toContain("状況です。");
+      expect(d.publicAction.text).toContain("録画未アップ");
+    }
+    expect(d.internal).toBeUndefined();
+  });
+
+  it("internal channel still strips internal (only DM is exempt)", () => {
+    const text = `本文\n\n${sentinel({ internal: "secret" })}`;
+    const d = normalizeDelivery(text, INTERNAL_CH);
+    expect(d.publicAction).toEqual({ kind: "reply", text: "本文" });
+    expect(d.internal).toBe("secret");
+  });
+});
+
+describe("normalizeTurns — batch", () => {
+  it("strips internal from each turn, no per-turn ack", () => {
+    const turns = [
+      `進捗1\n\n${sentinel({ internal: "メモ1" })}`,
+      "進捗2",
+    ];
+    const { actions, internals } = normalizeTurns(turns, EXTERNAL);
+    expect(actions).toEqual([
+      { kind: "reply", text: "進捗1" },
+      { kind: "reply", text: "進捗2" },
+    ]);
+    expect(internals).toEqual(["メモ1"]);
+  });
+
+  it("all-internal turns + addressed → single trailing ack", () => {
+    const turns = [
+      sentinel({ internal: "メモ1", suppressPublic: true }),
+      sentinel({ internal: "メモ2", suppressPublic: true }),
+    ];
+    const { actions, internals } = normalizeTurns(turns, EXTERNAL);
+    expect(actions).toEqual([{ kind: "reply", text: SAFE_ACK }]);
+    expect(internals).toEqual(["メモ1", "メモ2"]);
+  });
+
+  it("all-internal turns + unaddressed → no ack", () => {
+    const turns = [sentinel({ internal: "メモ", suppressPublic: true })];
+    const { actions } = normalizeTurns(turns, UNADDRESSED);
+    expect(actions).toEqual([]);
+  });
+});

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -651,9 +651,14 @@ function buildConnectorContext(connectors: string[], gatewayUrl: string, portalN
 
   lines.push("");
   lines.push("### Replying to the current conversation");
-  lines.push("- The text you return as your final answer is delivered to the current user in the correct conversation/thread.");
+  lines.push("- The text you return as your final answer is delivered to the current conversation/thread. Treat it as PUBLIC to the current speaker and channel.");
   lines.push("- Do not call `/send`, `curl`, or the `send_message` tool for the current conversation. That creates duplicate or meta replies.");
-  lines.push("- Your final answer is shown verbatim to the user, so make it the actual reply rather than work narration.");
+  lines.push("- Your final answer is shown verbatim, so make it the actual reply — NOT work narration, status reports to the operator, or internal deliberation.");
+  lines.push("- Never put operator notes, file IDs, internal drafts, approval waits (\"GO待ち\"), or instructions meant for another audience in the public body — especially in externally-shared channels.");
+  lines.push("- To keep an operator-only note out of the channel, append a trailer whose LAST non-empty line is exactly this (base64url-encoded JSON):");
+  lines.push("  `<!--RYOKO-DISPOSITION:v1:<base64url of {\"internal\":\"...\",\"react\":\":emoji:\",\"suppressPublic\":false}>-->`");
+  lines.push("  The `internal` field is never posted publicly (saved for the operator). `react` makes the public reply a single emoji reaction; `suppressPublic` omits the public body.");
+  lines.push("- When you are directly addressed (mentioned / asked), ALWAYS give a non-empty public reply. Use react-only for pure acknowledgments or social confirmations — never as the answer to a substantive question.");
 
   lines.push(`\n- **List all connectors**: \`curl ${gatewayUrl}/api/connectors\``);
   lines.push(`- Channel IDs and connector config can be found in \`~/.jinn/config.yaml\``);

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -19,6 +19,7 @@ import {
 } from "./registry.js";
 import { notifyParentSession, notifyRateLimited, notifyRateLimitResumed, notifyDiscordChannel } from "./callbacks.js";
 import { buildContext } from "./context.js";
+import { normalizeDelivery, normalizeTurns, deliverPublic, type DeliveryContext } from "./reply-disposition.js";
 import { SessionQueue } from "./queue.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { logger } from "../shared/logger.js";
@@ -233,6 +234,34 @@ export class SessionManager {
     );
 
     return { sessionId };
+  }
+
+  /**
+   * Build the audience/routing context used to sanitize engine output before it
+   * is posted. `addressed` is true for any non-cron (human-originated) session:
+   * "read-the-air" silence is handled upstream in triage, so a session that ran
+   * at all owes a response. `channelExternal` defaults to true for non-DM when
+   * the connector doesn't report it (safe — strips operator notes from any
+   * public channel). See reply-disposition.ts / the 2026-06-18 design doc.
+   */
+  private buildDeliveryContext(
+    session: Session,
+    msg: IncomingMessage,
+    capabilities: { reactions: boolean },
+  ): DeliveryContext {
+    const meta = (msg.transportMeta ?? {}) as Record<string, unknown>;
+    const isDM = meta.channelType === "im";
+    const channelExternal = isDM
+      ? false
+      : meta.channelExternal === undefined
+        ? true
+        : meta.channelExternal === true;
+    return {
+      addressed: session.source !== "cron",
+      channelExternal,
+      isDM,
+      canReact: capabilities.reactions,
+    };
   }
 
   private async runSession(
@@ -594,9 +623,13 @@ export class SessionManager {
             if (decorateMessages && connector.setTypingStatus) {
               await connector.setTypingStatus(target.channel, threadTs, "").catch(() => {});
             }
-            await connector.replyMessage(target, fallbackText).catch(() => {});
+            // Clear "eyes" before delivery so a react-only ":eyes:" reply survives.
             if (decorateMessages && capabilities.reactions) {
               await connector.removeReaction(target, "eyes").catch(() => {});
+            }
+            {
+              const { publicAction } = normalizeDelivery(fallbackText, this.buildDeliveryContext(session, msg, capabilities));
+              await deliverPublic(connector, target, publicAction).catch(() => {});
             }
 
             const updated = updateSession(session.id, {
@@ -762,7 +795,10 @@ export class SessionManager {
               await connector.removeReaction(target, waitEmoji).catch(() => {});
             }
 
-            await connector.replyMessage(target, retryText).catch(() => {});
+            {
+              const { publicAction } = normalizeDelivery(retryText, this.buildDeliveryContext(session, msg, capabilities));
+              await deliverPublic(connector, target, publicAction).catch(() => {});
+            }
             const retryUpdated = updateSession(session.id, {
               ...(retryResult.sessionId?.trim() ? { engineSessionId: retryResult.sessionId } : {}),
               status: retryResult.error ? "error" : "idle",
@@ -817,23 +853,30 @@ export class SessionManager {
       if (decorateMessages && connector.setTypingStatus) {
         await connector.setTypingStatus(target.channel, threadTs, "").catch(() => {});
       }
-      if (!wasInterrupted) {
-        // Multi-turn sessions (driven by /goal) carry every intermediate
-        // turn in `result.turns`. Surface each as its own Slack reply so
-        // the user sees progress chronologically. The last entry contains
-        // the same text as `result.result`, so we send the array directly.
-        const turns = result.turns ?? [];
-        if (turns.length > 1) {
-          for (const turnText of turns) {
-            if (!turnText || !turnText.trim()) continue;
-            await connector.replyMessage(target, turnText);
-          }
-        } else {
-          await connector.replyMessage(target, responseText);
-        }
-      }
+      // Clear the processing "eyes" BEFORE delivering, so a react-only reply of
+      // ":eyes:" isn't removed by this cleanup right after it's added.
       if (decorateMessages && capabilities.reactions) {
         await connector.removeReaction(target, "eyes").catch(() => {});
+      }
+      if (!wasInterrupted) {
+        // Sanitize engine output before posting: strip operator-facing notes
+        // (reply-disposition trailer) so they never reach an external channel,
+        // and enforce "addressed ⇒ never silent". See the 2026-06-18 design doc.
+        const deliveryCtx = this.buildDeliveryContext(session, msg, capabilities);
+        // Multi-turn sessions (driven by /goal) carry every intermediate turn in
+        // `result.turns`. Batch-normalize so internal notes are stripped per turn
+        // without ack multiplication; a single ack is added only if no turn was
+        // public. The last entry equals `result.result`.
+        const turns = result.turns ?? [];
+        if (turns.length > 1) {
+          const { actions } = normalizeTurns(turns, deliveryCtx);
+          for (const action of actions) {
+            await deliverPublic(connector, target, action);
+          }
+        } else {
+          const { publicAction } = normalizeDelivery(responseText, deliveryCtx);
+          await deliverPublic(connector, target, publicAction);
+        }
       }
       const updatedSession = updateSession(session.id, {
         ...(result.sessionId?.trim() ? { engineSessionId: result.sessionId } : {}),

--- a/packages/jimmy/src/sessions/reply-disposition.ts
+++ b/packages/jimmy/src/sessions/reply-disposition.ts
@@ -1,0 +1,229 @@
+/**
+ * Reply disposition — audience separation for engine output.
+ *
+ * Problem: an engine's final answer is delivered verbatim to the originating
+ * conversation. When the model writes an operator-facing status report (drafts,
+ * file IDs, approval waits) as its final answer, that internal content leaks to
+ * an external channel. See docs/plans/2026-06-18-reply-disposition-design.md.
+ *
+ * This module is the single, engine-agnostic chokepoint: every engine converges
+ * on `EngineResult.result` (a plain string), so parsing/sanitizing here covers
+ * claude-interactive, claude-print, codex, gemini and mock uniformly.
+ *
+ * Wire format (opt-in, fail-closed): the model MAY append a trailer whose last
+ * non-empty line is an HTML-comment sentinel carrying base64url-encoded JSON:
+ *
+ *   <public-facing reply>
+ *
+ *   <!--RYOKO-DISPOSITION:v1:eyJpbnRlcm5hbCI6Ii4uLiJ9-->
+ *
+ * - No sentinel → the whole text is the public reply (backward compatible).
+ * - Sentinel present but undecodable → fail CLOSED: post only the text before
+ *   the sentinel; never restore the whole text, never expose internal.
+ */
+
+import type { Target } from "../shared/types.js";
+
+export interface DispositionPayload {
+  /** Operator-facing note. Never posted to the originating channel. */
+  internal?: string;
+  /** Emoji name (with or without surrounding colons) for a react-only reply. */
+  react?: string;
+  /** Suppress the public body, leaving only a react/ack. */
+  suppressPublic?: boolean;
+}
+
+export interface ParsedDisposition {
+  /** Text before the sentinel (or the whole text when no sentinel). */
+  publicText: string;
+  payload: DispositionPayload;
+  hadSentinel: boolean;
+  decodeError: boolean;
+}
+
+export interface DeliveryContext {
+  /** True when @-mentioned or triage decided "reply" — i.e. we owe a response. */
+  addressed: boolean;
+  /** True for externally-shared/org-shared channels, or when unknown (safe). */
+  channelExternal: boolean;
+  /** True for 1:1 DM with the operator — audience separation is OFF here. */
+  isDM: boolean;
+  /** True when the connector supports emoji reactions. */
+  canReact: boolean;
+}
+
+export type PublicAction =
+  | { kind: "reply"; text: string }
+  | { kind: "react"; emoji: string }
+  | { kind: "none" };
+
+export interface Delivery {
+  publicAction: PublicAction;
+  /** Operator-facing note to persist (session log), never posted publicly. */
+  internal?: string;
+}
+
+/** Safe acknowledgment used to honor "addressed ⇒ never silent". */
+export const SAFE_ACK = "確認しました。追って対応します。";
+
+// Match the sentinel by SHAPE (permissive payload capture), so a malformed
+// payload is still recognized as a sentinel and stripped — never posted whole.
+// base64url has no ">", so `[^>]*` cannot over-run the closing "-->".
+const SENTINEL_RE = /^<!--RYOKO-DISPOSITION:v1:([^>]*)-->$/;
+
+function normalizeEmoji(name: string): string {
+  return name.trim().replace(/^:+|:+$/g, "");
+}
+
+/**
+ * Parse the trailer convention. Pure; performs no side effects.
+ */
+export function parseDisposition(text: string): ParsedDisposition {
+  const raw = text ?? "";
+  const lines = raw.split("\n");
+
+  // Find the last non-empty line.
+  let lastIdx = lines.length - 1;
+  while (lastIdx >= 0 && lines[lastIdx].trim() === "") lastIdx--;
+
+  if (lastIdx < 0) {
+    return { publicText: "", payload: {}, hadSentinel: false, decodeError: false };
+  }
+
+  const match = SENTINEL_RE.exec(lines[lastIdx].trim());
+  if (!match) {
+    return { publicText: raw.trimEnd(), payload: {}, hadSentinel: false, decodeError: false };
+  }
+
+  // Everything before the sentinel line is the public body.
+  const publicText = lines.slice(0, lastIdx).join("\n").trimEnd();
+
+  let payload: DispositionPayload = {};
+  let decodeError = false;
+  try {
+    const json = Buffer.from(match[1], "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const p = parsed as Record<string, unknown>;
+      payload = {
+        internal: typeof p.internal === "string" ? p.internal : undefined,
+        react: typeof p.react === "string" ? p.react : undefined,
+        suppressPublic: p.suppressPublic === true,
+      };
+    } else {
+      decodeError = true;
+    }
+  } catch {
+    // fail-closed: drop the sentinel, keep only the pre-sentinel public body,
+    // and do NOT surface any internal content.
+    decodeError = true;
+  }
+
+  return { publicText, payload, hadSentinel: true, decodeError };
+}
+
+/**
+ * Resolve a single engine output string into a public action + internal note,
+ * enforcing the invariants. Pure; the caller performs the actual side effects.
+ */
+export function normalizeDelivery(rawText: string, ctx: DeliveryContext): Delivery {
+  const parsed = parseDisposition(rawText);
+
+  // DM with the operator: audience separation is OFF. Show everything
+  // (public body + internal note), dropping only the sentinel syntax.
+  if (ctx.isDM) {
+    const merged = [parsed.publicText, parsed.payload.internal]
+      .filter((s): s is string => Boolean(s && s.trim()))
+      .join("\n\n");
+    const text = merged.trim() || rawText.trim();
+    if (text) return { publicAction: { kind: "reply", text } };
+    return ctx.addressed
+      ? { publicAction: { kind: "reply", text: SAFE_ACK } }
+      : { publicAction: { kind: "none" } };
+  }
+
+  const internal = parsed.payload.internal?.trim() || undefined;
+  const hasBody = parsed.publicText.trim().length > 0;
+  const wantsReactOnly =
+    parsed.payload.suppressPublic === true || (!hasBody && Boolean(parsed.payload.react));
+
+  let publicAction: PublicAction;
+  if (wantsReactOnly) {
+    publicAction = parsed.payload.react
+      ? { kind: "react", emoji: normalizeEmoji(parsed.payload.react) }
+      : { kind: "none" };
+  } else if (hasBody) {
+    publicAction = { kind: "reply", text: parsed.publicText.trim() };
+  } else if (parsed.payload.react) {
+    publicAction = { kind: "react", emoji: normalizeEmoji(parsed.payload.react) };
+  } else {
+    publicAction = { kind: "none" };
+  }
+
+  // Invariant: a react on a connector that can't react degrades to a reply.
+  if (publicAction.kind === "react" && !ctx.canReact) {
+    publicAction = { kind: "reply", text: SAFE_ACK };
+  }
+
+  // Invariant: addressed ⇒ never silent.
+  if (ctx.addressed && publicAction.kind === "none") {
+    publicAction = { kind: "reply", text: SAFE_ACK };
+  }
+
+  return internal ? { publicAction, internal } : { publicAction };
+}
+
+/** Minimal connector surface needed to perform a public action. */
+export interface PublicDeliverer {
+  replyMessage(target: Target, text: string): Promise<string | void>;
+  addReaction(target: Target, emoji: string): Promise<void>;
+}
+
+/**
+ * Perform a single resolved public action. Reply errors propagate (callers that
+ * want best-effort wrap with `.catch`); reaction errors are swallowed.
+ */
+export async function deliverPublic(
+  connector: PublicDeliverer,
+  target: Target,
+  action: PublicAction,
+): Promise<void> {
+  if (action.kind === "reply") {
+    await connector.replyMessage(target, action.text);
+  } else if (action.kind === "react") {
+    await connector.addReaction(target, action.emoji).catch(() => {});
+  }
+  // kind === "none" → intentionally post nothing
+}
+
+export interface TurnsDelivery {
+  /** Public actions to perform in order (internal stripped from each). */
+  actions: PublicAction[];
+  /** Collected internal notes to persist. */
+  internals: string[];
+}
+
+/**
+ * Batch-normalize multi-turn (`/goal`) output. Internal notes are stripped from
+ * every turn. We do NOT ack per turn; if no turn yields a public reply/react and
+ * we're addressed, a single safe ack is appended (avoids ack multiplication).
+ */
+export function normalizeTurns(turns: string[], ctx: DeliveryContext): TurnsDelivery {
+  const actions: PublicAction[] = [];
+  const internals: string[] = [];
+  // Per-turn we must not auto-ack: pass addressed=false so empties become "none".
+  const perTurnCtx: DeliveryContext = { ...ctx, addressed: false };
+
+  for (const turn of turns) {
+    if (!turn || !turn.trim()) continue;
+    const d = normalizeDelivery(turn, perTurnCtx);
+    if (d.internal) internals.push(d.internal);
+    if (d.publicAction.kind !== "none") actions.push(d.publicAction);
+  }
+
+  if (ctx.addressed && actions.length === 0) {
+    actions.push({ kind: "reply", text: SAFE_ACK });
+  }
+
+  return { actions, internals };
+}


### PR DESCRIPTION
## What & why

エンジン出力を公開チャンネルに投稿する前に**サニタイズ**する配信層 `reply-disposition`。**PR #23（中間ブロックをライブ進捗として配信）を置き換える発展版**。

PR #23 の「全assistantブロックを進捗として配信」方針は、オペレーター向けノート・内部審議・`GO待ち`等が公開チャンネル（特に外部共有チャンネル）に漏れるリスクがあった。本PRは「**最終回答は公開・オペレーター向けは専用トレーラーで分離・addressed なら必ず返信**」へ再設計する。

## Changes
- **`reply-disposition.ts`（新規・229行）**: `<!--RYOKO-DISPOSITION:v1:<base64url of JSON>-->` トレーラーを parse し、`internal` ノートを公開 body から除去（オペレーター用に保持）。`react`(emojiのみ) / `suppressPublic` の public action を決定。**addressed（人間起点セッション）は必ず非空の公開返信**（空なら `SAFE_ACK` フォールバック）
- **`normalizeDelivery` / `normalizeTurns` / `deliverPublic`**: 通常・fallback・retry・multi-turn の**全配信経路を統一サニタイズ**。`:eyes:` react-only 返信が直後の cleanup で消えない順序に修正
- **`context.ts`**: ガイダンスを「最終回答は公開扱い・内部ノートはトレーラーで分離・直接呼ばれたら必ず返信・react-only は純粋な相づちのみ」に更新
- **`slack/index.ts`**: `channelExternal`（`isExtShared`）を検出し `transportMeta` で伝搬 → 外部チャンネルでより厳格にサニタイズ
- **`reply-disposition.test.ts`**: 18テスト

## 検証
- 型チェッククリーン / **全502テスト pass**（reply-disposition 18 + registry 23 含む、回帰ゼロ）
- Codex独立実行で shared+sessions ロジック **119 pass**
- `npm run build` 成功（dist/web 同梱）/ registry(2026.6.9)の上に rebase 済み

## Supersedes
- **#23**（feat/surface-progress-updates）。本PRマージ時に #23 はクローズ。

## 注意
- 設計doc `docs/plans/2026-06-18-reply-disposition-design.md` は `/docs` を gitignore しているためリポジトリ未収録（ローカル保持）
- 実機デプロイは本PRスコープ外
