### PR TITLE
fix(gateway): don't surface message-interrupted turns as errors

### DIFF
--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -2658,6 +2658,18 @@ async function runWebSession(
       }
     }
 
+    // A turn interrupted by a newer user message is not an error — the newer
+    // message is already being dispatched as its own turn. Surface a calm
+    // notice instead of a red error, and let the new turn drive the UI/status.
+    if (wasInterrupted) {
+      const noticeText = "🔄 新しいメッセージを踏まえて再検討";
+      insertMessage(currentSession.id, "notification", noticeText);
+      context.emit("session:notification", { sessionId: currentSession.id, message: noticeText });
+      updateSession(currentSession.id, { lastActivity: new Date().toISOString(), lastError: null });
+      logger.info(`Web session ${currentSession.id} interrupted by new message — reconsidering`);
+      return;
+    }
+
     // Persist the assistant response
     if (result.result) {
       insertMessage(currentSession.id, "assistant", result.result);


### PR DESCRIPTION
## What

When a new user message arrives mid-turn, the running turn is killed with `engine.kill(session.id, "Interrupted: new message received")`. That reason propagates into `result.error`, so the turn's completion handler in `packages/jimmy/src/gateway/api.ts` set the session to `status: "error"` and stored the reason as `lastError` — which the UI renders as a red `Error:` banner.

But this is not an error: the newer message is **already being dispatched as its own turn**. Showing a red error for normal "I sent a follow-up while it was thinking" behavior is misleading.

## Change

Right before the completion handler persists the assistant response, detect the interrupt (the existing `wasInterrupted` flag) and instead of falling through to the error path:

- emit a calm notification (`🔄 新しいメッセージを踏まえて再検討`)
- clear `lastError`
- return early, leaving status/UI to the newly dispatched turn

```ts
// A turn interrupted by a newer user message is not an error — the newer
// message is already being dispatched as its own turn. Surface a calm
// notice instead of a red error, and let the new turn drive the UI/status.
if (wasInterrupted) {
  const noticeText = "🔄 新しいメッセージを踏まえて再検討";
  insertMessage(currentSession.id, "notification", noticeText);
  context.emit("session:notification", { sessionId: currentSession.id, message: noticeText });
  updateSession(currentSession.id, { lastActivity: new Date().toISOString(), lastError: null });
  logger.info(`Web session ${currentSession.id} interrupted by new message — reconsidering`);
  return;
}
```

`wasInterrupted` relies on `result.error?.startsWith("Interrupted")`, so the kill reason string is left unchanged — gateway-restart / shutdown interrupts keep their existing detection.

## Before / After

- **Before:** sending a follow-up mid-turn → session flips to `status: "error"` with a red `Error: Interrupted: new message received` banner.
- **After:** a calm `🔄 新しいメッセージを踏まえて再検討` notification; the new message's turn proceeds normally.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` (jimmy) — **502 tests passed, 0 failures**
- Verified live on a running instance: mid-turn follow-ups now show the notice instead of a red error.