### PR TITLE
feat: Claude Sonnet 5 対応 + effort xhigh デフォルト + 決定論的 config-patch マイグレーション

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.7.1] - 2026-07-01
+
+### Features
+- **Claude Sonnet 5 対応**: `sonnet` エイリアスが解決する新モデル `claude-sonnet-5` をコスト推定表（headless / interactive 両方）と設定画面のモデル表記に追加。コンテキスト窓は既存の `sonnet` パターン一致で 1M に解決。
+- **Claude の effort デフォルトを `xhigh` に**: Sonnet 5 / Opus 4.7・4.8 が対応した `xhigh` を標準化。設定画面の Effort Level に「Extra High」を追加。合成レジストリはモデル能力に応じて `xhigh` の可否を判定し（Opus 4.7+ / Sonnet 5 のみ）、Haiku や旧 Opus/Sonnet では `resolveEffort` が安全に `medium` へクランプ。
+- **決定論的 config パッチ機構**: マイグレーションに `config-patch.json` を同梱すると、`ryoko update`（`ryoko migrate --auto`）が config.yaml のデフォルト値を**ユーザーのカスタマイズを壊さずに**追従更新（未設定→挿入 / 旧デフォルト一致→更新 / カスタム済み→スキップ、冪等）。2026.7.1 では `engines.claude.effortLevel: medium → xhigh` を適用。
+
+### Fixes
+- **interactive Claude のコスト計上**: エイリアス（`sonnet` 等）ではなくトランスクリプトの実モデルID（`claude-sonnet-5` 等）で料金を解決するようにし、Sonnet/Haiku が Opus 価格で過大計上される問題を修正。
+
+### Tests
+- jimmy: 521 tests pass（config パッチのセマンティクス・冪等・カスタム保護、出荷 patch の妥当性検証、モデル別 effort 能力判定の回帰テストを追加）。
+
 ## [2026.6.5] - 2026-06-03
 
 ### Features

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.6.10",
+  "version": "2026.7.1",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/cli/migrate.ts
+++ b/packages/jimmy/src/cli/migrate.ts
@@ -24,6 +24,7 @@ import {
   readPortalName,
   buildTemplateReplacements,
 } from "../shared/templateReplacements.js";
+import { parseConfigPatch, applyPatchOps, type PatchOutcome } from "../shared/configPatch.js";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -77,6 +78,60 @@ function stampVersion(version: string): void {
   config.jinn.version = version;
 
   fs.writeFileSync(CONFIG_PATH, yaml.dump(config, { lineWidth: -1 }), "utf-8");
+}
+
+/**
+ * Apply any `config-patch.json` shipped with the pending migrations to the
+ * instance config.yaml. Deterministic and idempotent — evolves shipped default
+ * values without clobbering values the user has customized (see configPatch.ts).
+ * Returns the number of keys actually changed. Logs each outcome.
+ */
+function applyConfigPatches(pending: string[]): number {
+  const patchFiles = pending
+    .map((version) => ({ version, file: path.join(MIGRATIONS_DIR, version, "config-patch.json") }))
+    .filter(({ file }) => fs.existsSync(file));
+
+  if (patchFiles.length === 0 || !fs.existsSync(CONFIG_PATH)) return 0;
+
+  let working: unknown;
+  try {
+    working = yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8"));
+  } catch (err: any) {
+    console.log(`  ${RED}[config-patch: could not read config.yaml: ${err?.message ?? err}]${RESET}`);
+    return 0;
+  }
+
+  const allOutcomes: PatchOutcome[] = [];
+  for (const { version, file } of patchFiles) {
+    let ops;
+    try {
+      ops = parseConfigPatch(fs.readFileSync(file, "utf-8"));
+    } catch (err: any) {
+      console.log(`  ${RED}[config-patch ${version}: ${err?.message ?? err}]${RESET}`);
+      continue;
+    }
+    const { config: nextConfig, outcomes } = applyPatchOps(working, ops);
+    working = nextConfig;
+    allOutcomes.push(...outcomes);
+  }
+
+  const changed = allOutcomes.filter((o) => o.action === "set" || o.action === "insert").length;
+  if (changed > 0) {
+    fs.writeFileSync(CONFIG_PATH, yaml.dump(working, { lineWidth: -1 }), "utf-8");
+  }
+
+  for (const o of allOutcomes) {
+    if (o.action === "set") {
+      console.log(`  ${GREEN}[config]${RESET} ${o.path}: ${JSON.stringify(o.from)} → ${JSON.stringify(o.to)}`);
+    } else if (o.action === "insert") {
+      console.log(`  ${GREEN}[config]${RESET} ${o.path}: (added) ${JSON.stringify(o.to)}`);
+    } else if (o.action === "skip" && o.reason === "customized") {
+      console.log(`  ${YELLOW}[config skip]${RESET} ${o.path} (customized: ${JSON.stringify(o.current)})`);
+    }
+    // reason "already" → silent no-op
+  }
+
+  return changed;
 }
 
 /**
@@ -272,8 +327,12 @@ async function applyAutoMigrations(
     }
   }
 
+  // Deterministic config.yaml value updates (respects user customizations).
+  // Idempotent, so it is safe to run even when files are skipped below.
+  const configChanges = applyConfigPatches(pending);
+
   if (skippedExisting > 0) {
-    console.log(`\n${YELLOW}Auto-migration partially applied.${RESET} ${applied} file(s) added, ${skippedExisting} existing file(s) need AI merge.`);
+    console.log(`\n${YELLOW}Auto-migration partially applied.${RESET} ${applied} file(s) added, ${configChanges} config value(s) updated, ${skippedExisting} existing file(s) need AI merge.`);
     console.log(`${YELLOW}Version was not updated.${RESET} Run ${RESET}ryoko migrate${YELLOW} (without --auto) to merge the skipped files and complete the migration.${RESET}`);
     console.log(`${DIM}Staged migration files remain in ${MIGRATIONS_DIR}.${RESET}\n`);
     return;
@@ -281,7 +340,7 @@ async function applyAutoMigrations(
 
   stampVersion(packageVersion);
   console.log(`\n  ${GREEN}[version]${RESET} ${instanceVersion} → ${packageVersion}`);
-  console.log(`\n${GREEN}Auto-migration complete.${RESET} ${applied} file(s) added.`);
+  console.log(`\n${GREEN}Auto-migration complete.${RESET} ${applied} file(s) added, ${configChanges} config value(s) updated.`);
 
   fs.rmSync(MIGRATIONS_DIR, { recursive: true, force: true });
 }

--- a/packages/jimmy/src/cli/setup.ts
+++ b/packages/jimmy/src/cli/setup.ts
@@ -240,7 +240,7 @@ engines:
   claude:
     bin: claude
     model: opus
-    effortLevel: medium
+    effortLevel: xhigh
   codex:
     bin: codex
     model: gpt-5.5

--- a/packages/jimmy/src/engines/claude-interactive.ts
+++ b/packages/jimmy/src/engines/claude-interactive.ts
@@ -24,13 +24,28 @@ interface InteractiveArgsOpts {
   attachments?: string[];
 }
 
-interface TranscriptUsage { inputTokens: number; outputTokens: number; cacheTokens: number; assistantTurns: number; }
+interface TranscriptUsage { inputTokens: number; outputTokens: number; cacheTokens: number; assistantTurns: number; model?: string; }
+
+// Config stores short aliases (opus/sonnet/haiku); the CLI resolves them to
+// concrete ids. When the transcript doesn't carry a model id we fall back to
+// this map so pricing keys line up with MODEL_PRICES instead of DEFAULT_PRICE.
+const CLAUDE_ALIAS_TO_ID: Record<string, string> = {
+  opus: "claude-opus-4-8",
+  sonnet: "claude-sonnet-5",
+  haiku: "claude-haiku-4-5",
+};
+
+function resolveClaudeModelId(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  return CLAUDE_ALIAS_TO_ID[model] ?? model;
+}
 
 // $/million tokens. Conservative defaults. Older model ids kept so cost can still
 // be reconstructed when resuming historical transcripts.
 const MODEL_PRICES: Record<string, { in: number; out: number }> = {
   "claude-opus-4-8": { in: 15, out: 75 },
   "claude-opus-4-7": { in: 15, out: 75 },
+  "claude-sonnet-5": { in: 3, out: 15 },
   "claude-sonnet-4-6": { in: 3, out: 15 },
   "claude-haiku-4-5": { in: 1, out: 5 },
 };
@@ -60,6 +75,10 @@ function sumTranscriptUsage(content: string): TranscriptUsage {
     u.inputTokens += Number(usage.input_tokens ?? 0);
     u.outputTokens += Number(usage.output_tokens ?? 0);
     u.cacheTokens += Number(usage.cache_read_input_tokens ?? 0) + Number(usage.cache_creation_input_tokens ?? 0);
+    // Concrete model id (e.g. "claude-sonnet-5") emitted by the CLI — the most
+    // reliable pricing key. Last one wins if it ever changes mid-session.
+    const m = msg?.message?.model;
+    if (typeof m === "string" && m) u.model = m;
   }
   return u;
 }
@@ -88,7 +107,10 @@ function computeInteractiveCost(transcriptPath: string, model?: string): { cost:
   try { content = fs.readFileSync(transcriptPath, "utf-8"); } catch { return null; }
   const u = sumTranscriptUsage(content);
   if (u.assistantTurns === 0) return null;
-  const price = (model && MODEL_PRICES[model]) || DEFAULT_PRICE;
+  // Prefer the concrete id from the transcript; fall back to resolving the
+  // config alias (opus/sonnet/haiku) so Sonnet/Haiku aren't priced as Opus.
+  const modelId = u.model ?? resolveClaudeModelId(model);
+  const price = (modelId && MODEL_PRICES[modelId]) || DEFAULT_PRICE;
   const cost = (u.inputTokens / 1_000_000) * price.in + (u.outputTokens / 1_000_000) * price.out;
   return { cost, turns: u.assistantTurns };
 }

--- a/packages/jimmy/src/shared/__tests__/configPatch.test.ts
+++ b/packages/jimmy/src/shared/__tests__/configPatch.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { applyPatchOps, parseConfigPatch } from "../configPatch.js";
+
+describe("applyPatchOps", () => {
+  it("updates a key that still holds the old default (from matches)", () => {
+    const cfg = { engines: { claude: { effortLevel: "medium" } } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", from: "medium", to: "xhigh" },
+    ]);
+    expect(config.engines.claude.effortLevel).toBe("xhigh");
+    expect(outcomes).toEqual([
+      { path: "engines.claude.effortLevel", action: "set", from: "medium", to: "xhigh" },
+    ]);
+  });
+
+  it("skips a customized value (current differs from `from`)", () => {
+    const cfg = { engines: { claude: { effortLevel: "high" } } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", from: "medium", to: "xhigh" },
+    ]);
+    expect(config.engines.claude.effortLevel).toBe("high"); // untouched
+    expect(outcomes[0]).toMatchObject({ action: "skip", reason: "customized", current: "high" });
+  });
+
+  it("inserts when the key is missing", () => {
+    const cfg = { engines: { claude: { bin: "claude" } } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", from: "medium", to: "xhigh" },
+    ]);
+    expect(config.engines.claude.effortLevel).toBe("xhigh");
+    expect(outcomes[0]).toMatchObject({ action: "insert", to: "xhigh" });
+  });
+
+  it("creates intermediate objects for a deep missing path", () => {
+    const { config, outcomes } = applyPatchOps({}, [
+      { path: "engines.claude.effortLevel", to: "xhigh" },
+    ]);
+    expect(config.engines.claude.effortLevel).toBe("xhigh");
+    expect(outcomes[0].action).toBe("insert");
+  });
+
+  it("is a no-op when the value already equals `to`", () => {
+    const cfg = { engines: { claude: { effortLevel: "xhigh" } } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", from: "medium", to: "xhigh" },
+    ]);
+    expect(config.engines.claude.effortLevel).toBe("xhigh");
+    expect(outcomes[0]).toMatchObject({ action: "skip", reason: "already" });
+  });
+
+  it("without `from`, never overwrites an existing value (insert-only)", () => {
+    const cfg = { engines: { claude: { effortLevel: "low" } } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", to: "xhigh" },
+    ]);
+    expect(config.engines.claude.effortLevel).toBe("low");
+    expect(outcomes[0]).toMatchObject({ action: "skip", reason: "customized" });
+  });
+
+  it("does not mutate the input config object", () => {
+    const cfg = { engines: { claude: { effortLevel: "medium" } } };
+    const { config } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", from: "medium", to: "xhigh" },
+    ]);
+    expect(cfg.engines.claude.effortLevel).toBe("medium"); // original untouched
+    expect(config).not.toBe(cfg);
+  });
+
+  it("is idempotent — re-applying after a set makes no further change", () => {
+    const ops = [{ path: "engines.claude.effortLevel", from: "medium", to: "xhigh" }];
+    const first = applyPatchOps({ engines: { claude: { effortLevel: "medium" } } }, ops);
+    const second = applyPatchOps(first.config, ops);
+    expect(second.config.engines.claude.effortLevel).toBe("xhigh");
+    expect(second.outcomes[0]).toMatchObject({ action: "skip", reason: "already" });
+  });
+
+  it("skips (does not clobber) when a defined non-object parent blocks the path", () => {
+    const cfg = { engines: { claude: "custom-string" } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.effortLevel", from: "medium", to: "xhigh" },
+    ]);
+    expect(config.engines.claude).toBe("custom-string"); // untouched, not turned into an object
+    expect(outcomes[0]).toMatchObject({ action: "skip", reason: "customized", current: "custom-string" });
+  });
+
+  it("supports non-string values via structural equality", () => {
+    const cfg = { engines: { claude: { maxLivePtys: 8 } } };
+    const { config, outcomes } = applyPatchOps(cfg, [
+      { path: "engines.claude.maxLivePtys", from: 8, to: 12 },
+    ]);
+    expect(config.engines.claude.maxLivePtys).toBe(12);
+    expect(outcomes[0].action).toBe("set");
+  });
+});
+
+describe("parseConfigPatch", () => {
+  it("parses a valid array of ops, preserving optional `from`", () => {
+    const ops = parseConfigPatch(
+      JSON.stringify([
+        { path: "a.b", from: "x", to: "y" },
+        { path: "c", to: 1 },
+      ]),
+    );
+    expect(ops).toEqual([
+      { path: "a.b", from: "x", to: "y" },
+      { path: "c", to: 1 },
+    ]);
+  });
+
+  it("rejects a non-array payload", () => {
+    expect(() => parseConfigPatch(JSON.stringify({ path: "a", to: 1 }))).toThrow(/must be a JSON array/);
+  });
+
+  it("rejects an op without a path", () => {
+    expect(() => parseConfigPatch(JSON.stringify([{ to: 1 }]))).toThrow(/non-empty string "path"/);
+  });
+
+  it("rejects an op without `to`", () => {
+    expect(() => parseConfigPatch(JSON.stringify([{ path: "a" }]))).toThrow(/needs a "to" value/);
+  });
+
+  it('preserves an explicit `to: null` (distinct from missing)', () => {
+    const ops = parseConfigPatch(JSON.stringify([{ path: "a", to: null }]));
+    expect(ops).toEqual([{ path: "a", to: null }]);
+  });
+});

--- a/packages/jimmy/src/shared/__tests__/effort.test.ts
+++ b/packages/jimmy/src/shared/__tests__/effort.test.ts
@@ -3,7 +3,7 @@ import { resolveEffort } from "../effort.js";
 import { effortLevelsForModel, invalidateModelRegistry } from "../models.js";
 import type { JinnConfig } from "../types.js";
 
-const CLAUDE = ["low", "medium", "high"];
+const CLAUDE = ["low", "medium", "high", "xhigh"];
 const CODEX = ["low", "medium", "high", "xhigh"];
 
 describe("resolveEffort (registry-driven validation)", () => {
@@ -11,8 +11,12 @@ describe("resolveEffort (registry-driven validation)", () => {
     expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "xhigh" }, null, CODEX)).toBe("xhigh");
   });
 
-  it("rejects xhigh for claude (not in its levels) and falls back to medium", () => {
-    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "xhigh" }, null, CLAUDE)).toBe("medium");
+  it("passes through claude xhigh (now supported on Opus 4.7+/Sonnet 5)", () => {
+    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "xhigh" }, null, CLAUDE)).toBe("xhigh");
+  });
+
+  it("rejects a level outside the valid set and falls back to medium", () => {
+    expect(resolveEffort({}, { parentSessionId: "p", effortLevel: "max" }, null, CLAUDE)).toBe("medium");
   });
 
   it("claude still accepts low/medium/high", () => {

--- a/packages/jimmy/src/shared/__tests__/models.test.ts
+++ b/packages/jimmy/src/shared/__tests__/models.test.ts
@@ -27,15 +27,34 @@ describe("synthesizeFromEngineConfig (backward-compat fallback)", () => {
     expect(reg.gemini.models[0].id).toBe("gemini-2.5-pro");
   });
 
-  it("uses per-engine effort semantics: claude flag (low/med/high), codex config (incl xhigh), gemini none", () => {
+  it("uses per-engine effort semantics: claude flag (low/med/high/xhigh), codex config (incl xhigh), gemini none", () => {
     const reg = synthesizeFromEngineConfig(cfg({}));
     expect(reg.claude.effortMechanism).toBe("claude-flag");
-    expect(reg.claude.models[0].effortLevels).toEqual(["low", "medium", "high"]);
+    expect(reg.claude.models[0].effortLevels).toEqual(["low", "medium", "high", "xhigh"]);
     expect(reg.codex.effortMechanism).toBe("codex-config");
     expect(reg.codex.models[0].effortLevels).toContain("xhigh");
     expect(reg.gemini.effortMechanism).toBe("none");
     expect(reg.gemini.models[0].supportsEffort).toBe(false);
     expect(reg.gemini.models[0].effortLevels).toEqual([]);
+  });
+
+  it("grants xhigh only to xhigh-capable claude models", () => {
+    const levelsFor = (model: string) =>
+      synthesizeFromEngineConfig(cfg({ claude: { bin: "claude", model } })).claude.models[0].effortLevels;
+
+    // aliases resolve to latest → xhigh
+    expect(levelsFor("opus")).toContain("xhigh");
+    expect(levelsFor("sonnet")).toContain("xhigh");
+    // explicit capable ids
+    expect(levelsFor("claude-opus-4-8")).toContain("xhigh");
+    expect(levelsFor("claude-opus-4-7")).toContain("xhigh");
+    expect(levelsFor("claude-sonnet-5")).toContain("xhigh");
+
+    // haiku and older pinned ids → no xhigh (clamped by resolveEffort)
+    expect(levelsFor("haiku")).toEqual(["low", "medium", "high"]);
+    expect(levelsFor("claude-haiku-4-5")).toEqual(["low", "medium", "high"]);
+    expect(levelsFor("claude-opus-4-6")).toEqual(["low", "medium", "high"]);
+    expect(levelsFor("claude-sonnet-4-6")).toEqual(["low", "medium", "high"]);
   });
 });
 

--- a/packages/jimmy/src/shared/__tests__/shippedConfigPatches.test.ts
+++ b/packages/jimmy/src/shared/__tests__/shippedConfigPatches.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseConfigPatch } from "../configPatch.js";
+
+/**
+ * Guardrail: every `config-patch.json` we ship must parse and validate. A
+ * malformed shipped patch would be silently skipped at `ryoko migrate --auto`
+ * time (the version still stamps), so the config evolution would be lost with
+ * no retry. Catch it here at build/test time instead.
+ */
+const here = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.resolve(here, "../../../template/migrations");
+
+function shippedPatchFiles(): string[] {
+  if (!fs.existsSync(MIGRATIONS_DIR)) return [];
+  return fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(MIGRATIONS_DIR, e.name, "config-patch.json"))
+    .filter((f) => fs.existsSync(f));
+}
+
+describe("shipped config-patch.json files", () => {
+  const files = shippedPatchFiles();
+
+  it("has a discoverable migrations directory", () => {
+    expect(fs.existsSync(MIGRATIONS_DIR)).toBe(true);
+  });
+
+  it.each(files)("parses and validates: %s", (file) => {
+    const ops = parseConfigPatch(fs.readFileSync(file, "utf-8"));
+    expect(Array.isArray(ops)).toBe(true);
+    for (const op of ops) {
+      expect(typeof op.path).toBe("string");
+      expect(op.path.length).toBeGreaterThan(0);
+      expect(Object.prototype.hasOwnProperty.call(op, "to")).toBe(true);
+    }
+  });
+});

--- a/packages/jimmy/src/shared/configPatch.ts
+++ b/packages/jimmy/src/shared/configPatch.ts
@@ -1,0 +1,150 @@
+/**
+ * Deterministic config.yaml patching for migrations.
+ *
+ * A migration version directory may ship a `config-patch.json` describing
+ * key-level changes to the instance config. Patches are applied during
+ * `ryoko migrate --auto` (i.e. on `ryoko update`) so that shipped default
+ * values can evolve WITHOUT clobbering values the user has customized.
+ *
+ * Per-op semantics (see {@link ConfigPatchOp}):
+ *   - key missing              → set to `to`   (adopt the new default)
+ *   - key === `from`           → set to `to`   (user still on the old default)
+ *   - key defined, `from` set, current !== from → skip (user customized)
+ *   - `from` omitted, key present → skip (never overwrite an existing value)
+ *   - key already === `to`     → skip (no-op)
+ *
+ * The whole operation is idempotent: re-running it after a successful apply
+ * leaves the config unchanged, because the value is now `to`, not `from`.
+ */
+
+export interface ConfigPatchOp {
+  /** Dotted path into the config object, e.g. "engines.claude.effortLevel". */
+  path: string;
+  /** New value to write. */
+  to: unknown;
+  /**
+   * Old shipped default. When provided, the key is only rewritten if its
+   * current value still equals it. Omit to make the op insert-only (it will
+   * fill in a missing key but never overwrite one the user already set).
+   */
+  from?: unknown;
+}
+
+export type PatchOutcome =
+  | { path: string; action: "set"; from: unknown; to: unknown }
+  | { path: string; action: "insert"; to: unknown }
+  | { path: string; action: "skip"; reason: "customized" | "already"; current: unknown };
+
+/** Structural equality for the primitive/plain-data values found in config.yaml. */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function getDeep(obj: unknown, segments: string[]): { found: boolean; value: unknown } {
+  let cur: any = obj;
+  for (const seg of segments) {
+    if (cur == null || typeof cur !== "object" || !(seg in cur)) {
+      return { found: false, value: undefined };
+    }
+    cur = cur[seg];
+  }
+  return { found: true, value: cur };
+}
+
+/**
+ * Walk toward a dotted path; report whether a *defined, non-object* intermediate
+ * blocks descent (e.g. `engines.claude` holds a string while the op targets
+ * `engines.claude.effortLevel`). Such a value is a user customization we must
+ * not clobber by materializing an object over it.
+ */
+function blockingParent(obj: unknown, segments: string[]): { blocked: boolean; value: unknown } {
+  let cur: any = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (cur == null || typeof cur !== "object") return { blocked: false, value: undefined };
+    const seg = segments[i];
+    if (!(seg in cur)) return { blocked: false, value: undefined }; // missing → creatable
+    cur = cur[seg];
+    if (cur != null && typeof cur !== "object") return { blocked: true, value: cur };
+  }
+  return { blocked: false, value: undefined };
+}
+
+/** Set a dotted path on `obj`, creating intermediate objects as needed. Mutates `obj`. */
+function setDeep(obj: any, segments: string[], value: unknown): void {
+  let cur = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    if (cur[seg] == null || typeof cur[seg] !== "object") {
+      cur[seg] = {};
+    }
+    cur = cur[seg];
+  }
+  cur[segments[segments.length - 1]] = value;
+}
+
+/**
+ * Apply patch ops to a config object. Returns a NEW config object (the input
+ * is never mutated) plus a per-op outcome log.
+ */
+export function applyPatchOps(
+  config: unknown,
+  ops: ConfigPatchOp[],
+): { config: any; outcomes: PatchOutcome[] } {
+  const next = structuredClone(config ?? {}) as any;
+  const outcomes: PatchOutcome[] = [];
+
+  for (const op of ops) {
+    const segments = op.path.split(".");
+    const { found, value: current } = getDeep(next, segments);
+    const hasFrom = Object.prototype.hasOwnProperty.call(op, "from");
+
+    if (!found || current === undefined) {
+      const parent = blockingParent(next, segments);
+      if (parent.blocked) {
+        outcomes.push({ path: op.path, action: "skip", reason: "customized", current: parent.value });
+        continue;
+      }
+      setDeep(next, segments, op.to);
+      outcomes.push({ path: op.path, action: "insert", to: op.to });
+      continue;
+    }
+
+    if (valuesEqual(current, op.to)) {
+      outcomes.push({ path: op.path, action: "skip", reason: "already", current });
+      continue;
+    }
+
+    if (hasFrom && valuesEqual(current, op.from)) {
+      setDeep(next, segments, op.to);
+      outcomes.push({ path: op.path, action: "set", from: current, to: op.to });
+      continue;
+    }
+
+    // Defined, not equal to `to`, and either no `from` was given or the user
+    // has diverged from the old default — never overwrite.
+    outcomes.push({ path: op.path, action: "skip", reason: "customized", current });
+  }
+
+  return { config: next, outcomes };
+}
+
+/** Parse and validate a raw config-patch.json payload into typed ops. */
+export function parseConfigPatch(raw: string): ConfigPatchOp[] {
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data)) {
+    throw new Error("config-patch.json must be a JSON array of patch ops");
+  }
+  return data.map((op, i) => {
+    if (typeof op !== "object" || op === null || typeof op.path !== "string" || !op.path) {
+      throw new Error(`config-patch.json[${i}]: each op needs a non-empty string "path"`);
+    }
+    if (!Object.prototype.hasOwnProperty.call(op, "to")) {
+      throw new Error(`config-patch.json[${i}]: each op needs a "to" value`);
+    }
+    const parsed: ConfigPatchOp = { path: op.path, to: op.to };
+    if (Object.prototype.hasOwnProperty.call(op, "from")) parsed.from = op.from;
+    return parsed;
+  });
+}

--- a/packages/jimmy/src/shared/models.ts
+++ b/packages/jimmy/src/shared/models.ts
@@ -27,10 +27,49 @@ const EFFORT_MECHANISM: Record<EngineName, EffortMechanism> = {
 
 /** Conservative per-engine defaults used when synthesizing (no `models:` block). */
 const SYNTH_DEFAULTS: Record<EngineName, { supportsEffort: boolean; effortLevels: string[]; fallbackModel: string }> = {
-  claude: { supportsEffort: true, effortLevels: ["low", "medium", "high"], fallbackModel: "opus" },
+  claude: { supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"], fallbackModel: "opus" },
   codex: { supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"], fallbackModel: "gpt-5.3-codex" },
   gemini: { supportsEffort: false, effortLevels: [], fallbackModel: "gemini-2.5-pro" },
 };
+
+/**
+ * Whether a Claude model supports the `xhigh` effort level. `xhigh` landed on
+ * Opus 4.7 and Sonnet 5; Haiku-tier and *older* Opus/Sonnet (Opus ≤4.6,
+ * Sonnet ≤4.6) reject it. The bare aliases `opus`/`sonnet` resolve to the
+ * latest model, which supports it. Anything unrecognized is treated as
+ * unsupported (conservative), so `resolveEffort` clamps it instead of passing
+ * a broken `--effort xhigh` to the CLI.
+ */
+function claudeSupportsXhigh(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  if (id.includes("haiku")) return false;
+  if (id === "opus" || id === "sonnet") return true; // aliases → latest model
+  if (/opus-4-(?:[7-9]|\d\d)/.test(id)) return true; // Opus 4.7+ (incl. 4.10+)
+  if (/opus-(?:[5-9]|\d\d)/.test(id)) return true; //  Opus 5+
+  if (/sonnet-(?:[5-9]|\d\d)/.test(id)) return true; // Sonnet 5+
+  return false;
+}
+
+/**
+ * Effort levels for a synthesized Claude model. Offering `xhigh` on a model
+ * that rejects it would let a config default flow through as `--effort xhigh`
+ * and break the run, so narrow by capability.
+ */
+function claudeEffortLevels(modelId: string): string[] {
+  const base = ["low", "medium", "high"];
+  return claudeSupportsXhigh(modelId) ? [...base, "xhigh"] : base;
+}
+
+/** Effort levels a synthesized (no `models:` block) entry gives a specific model. */
+function synthEffortLevels(engine: EngineName, modelId: string): string[] {
+  const d = SYNTH_DEFAULTS[engine];
+  if (!d.supportsEffort) return [];
+  return engine === "claude" ? claudeEffortLevels(modelId) : [...d.effortLevels];
+}
+
+function isEngineName(engine: string): engine is EngineName {
+  return (ENGINE_NAMES as readonly string[]).includes(engine);
+}
 
 let cached: ModelRegistry | null = null;
 
@@ -54,11 +93,22 @@ export function getModelRegistry(config: JinnConfig): ModelRegistry {
 export function effortLevelsForModel(config: JinnConfig, engine: string, modelId?: string): string[] {
   const entry = getModelRegistry(config)[engine];
   if (!entry) return [];
-  const model =
-    (modelId ? entry.models.find((m) => m.id === modelId) : undefined) ??
-    entry.models.find((m) => m.id === entry.defaultModel) ??
-    entry.models[0];
-  return model?.supportsEffort ? [...model.effortLevels] : [];
+
+  const exact = modelId ? entry.models.find((m) => m.id === modelId) : undefined;
+  if (exact) return exact.supportsEffort ? [...exact.effortLevels] : [];
+
+  // modelId not in the registry (e.g. a session overrides the engine model to
+  // one that isn't the config default). For a SYNTHESIZED engine (no explicit
+  // `models:` block) compute levels for THIS model rather than borrowing the
+  // default model's — otherwise a haiku session inherits opus's `xhigh` and
+  // passes an unsupported `--effort xhigh` through. When a `models:` block
+  // exists the user declared exact levels, so keep the default-model fallback.
+  if (modelId && isEngineName(engine) && !config.models?.[engine]) {
+    return synthEffortLevels(engine, modelId);
+  }
+
+  const fallback = entry.models.find((m) => m.id === entry.defaultModel) ?? entry.models[0];
+  return fallback?.supportsEffort ? [...fallback.effortLevels] : [];
 }
 
 /** Context window (tokens) for a session's engine+model, or undefined if unknown. */
@@ -99,7 +149,7 @@ export function synthesizeFromEngineConfig(config: JinnConfig): ModelRegistry {
       id: modelId,
       label: modelId,
       supportsEffort: defaults.supportsEffort,
-      effortLevels: defaults.supportsEffort ? [...defaults.effortLevels] : [],
+      effortLevels: synthEffortLevels(name, modelId),
     };
     registry[name] = {
       name,

--- a/packages/jimmy/template/config.default.yaml
+++ b/packages/jimmy/template/config.default.yaml
@@ -10,7 +10,7 @@ engines:
   claude:
     bin: claude
     model: opus
-    effortLevel: medium
+    effortLevel: xhigh
     # Interactive PTY mode (opt-in). When true, Claude work turns run as an
     # interactive PTY (cc_entrypoint=cli) which bills against the Max subscription
     # instead of metered API usage. Turns resolve via Claude Code Stop hooks.

--- a/packages/jimmy/template/migrations/2026.7.1/MIGRATION.md
+++ b/packages/jimmy/template/migrations/2026.7.1/MIGRATION.md
@@ -1,0 +1,73 @@
+# Migration: 2026.7.1 (Claude Sonnet 5 対応 / effort デフォルト xhigh / 決定論的 config パッチ)
+
+## Summary
+
+3 点の変更を含む:
+
+1. **Claude Sonnet 5 対応** — `sonnet` エイリアスが指す新モデル `claude-sonnet-5` の料金・表示ラベルを登録
+2. **Claude の effort デフォルトを `medium` → `xhigh` に変更** — Sonnet 5 / Opus 4.7・4.8 が対応した `xhigh` を標準化
+3. **決定論的 config パッチ機構の導入** — アップデート時に config.yaml のデフォルト値を、ユーザーのカスタマイズを壊さずに追従させる仕組み（本マイグレーション自身がその最初の利用例）
+
+> **互換性メモ**: config.yaml の version key は **`jinn.version` のまま**。
+
+## 決定論的 config パッチ（新機構）
+
+これまで `ryoko update`（= `ryoko migrate --auto`）は**新規ファイルの追加のみ**で、既存 config.yaml の値は一切書き換えなかった（カスタマイズ保護のため）。本バージョンから、マイグレーションディレクトリに `config-patch.json` を同梱すると、`--auto` が config.yaml のキー単位で決定論的にパッチを当てる。
+
+### `config-patch.json` の形式
+
+```jsonc
+[
+  {
+    "path": "engines.claude.effortLevel", // ドット区切りのキーパス
+    "from": "medium",                     // 旧デフォルト（省略可）
+    "to": "xhigh"                         // 新しい値
+  }
+]
+```
+
+### 適用セマンティクス（カスタマイズ保護）
+
+| 現在の状態 | 挙動 |
+|---|---|
+| キーが未設定 | `to` を挿入 |
+| 現在値 === `from` | `to` に更新（ユーザーが旧デフォルトのままだった） |
+| 現在値が `from` 以外に設定済み | **スキップ**（ユーザーがカスタムした値を守る） |
+| `from` 省略 & キー存在 | スキップ（既存値を上書きしない） |
+| 現在値 === `to` | no-op |
+
+冪等（何度実行しても結果は同じ）。実装は [configPatch.ts](../../src/shared/configPatch.ts)、適用は [migrate.ts の applyConfigPatches](../../src/cli/migrate.ts)。
+
+## このマイグレーションが行う config 変更
+
+`config-patch.json`:
+
+```json
+[{ "path": "engines.claude.effortLevel", "from": "medium", "to": "xhigh" }]
+```
+
+- `effortLevel` が **`medium`（旧デフォルト）または未設定**のユーザー → `xhigh` に自動更新
+- `low` / `high` などに**カスタム済み**のユーザー → そのまま（変更されない）
+
+## Template files changed（新規セットアップ向け、既存ユーザーには影響なし）
+
+| ファイル | 変更 |
+|---|---|
+| `template/config.default.yaml` | `engines.claude.effortLevel: medium → xhigh` |
+| `packages/web`（コンパイル済み UI） | 設定画面のモデルラベル `Sonnet (claude-sonnet-5)`、Claude effort に `Extra High` 追加 |
+
+これらは**新規 `ryoko setup` にのみ**適用。既存ユーザーの config 値は上記 config-patch が担当する。
+
+## Merge instructions
+
+### 1. Config（自動）
+
+`ryoko update` / `ryoko migrate --auto` が config-patch を自動適用し、`jinn.version` を `"2026.7.1"` に更新する。手動操作は不要。
+
+### 2. Gateway 再起動
+
+料金テーブルと effort フラグの反映のため gateway を再起動（`ryoko update --restart` なら自動）。
+
+## Breaking changes
+
+なし。config-patch はカスタム値を保護する。effort が `xhigh` になるのは旧デフォルト（medium）のままだったユーザーのみ。

--- a/packages/jimmy/template/migrations/2026.7.1/config-patch.json
+++ b/packages/jimmy/template/migrations/2026.7.1/config-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "path": "engines.claude.effortLevel",
+    "from": "medium",
+    "to": "xhigh"
+  }
+]

--- a/packages/web/src/app/settings/page.tsx
+++ b/packages/web/src/app/settings/page.tsx
@@ -1198,7 +1198,7 @@ export default function SettingsPage() {
                     }
                     options={[
                       { value: "opus", label: "Opus (claude-opus-4-8)" },
-                      { value: "sonnet", label: "Sonnet (claude-sonnet-4-6)" },
+                      { value: "sonnet", label: "Sonnet (claude-sonnet-5)" },
                       { value: "haiku", label: "Haiku (claude-haiku-4-5)" },
                     ]}
                   />
@@ -1214,6 +1214,7 @@ export default function SettingsPage() {
                       { value: "low", label: "Low" },
                       { value: "medium", label: "Medium" },
                       { value: "high", label: "High" },
+                      { value: "xhigh", label: "Extra High" },
                     ]}
                   />
                 </FieldRow>

--- a/packages/web/src/lib/costs.ts
+++ b/packages/web/src/lib/costs.ts
@@ -88,6 +88,7 @@ const PRICING: Record<string, ModelPricing> = {
   'claude-opus-4-8':     { inputPer1M: 15, outputPer1M: 75 },
   'claude-opus-4-7':     { inputPer1M: 15, outputPer1M: 75 },
   'claude-opus-4-6':     { inputPer1M: 15, outputPer1M: 75 },
+  'claude-sonnet-5':     { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-6':   { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-5':   { inputPer1M: 3, outputPer1M: 15 },
   'claude-haiku-4-5':    { inputPer1M: 0.80, outputPer1M: 4 },


### PR DESCRIPTION
## Summary
Claude Sonnet 5 対応と effort デフォルトの `xhigh` 化、そして「アップデート時に config.yaml のデフォルト値をユーザーのカスタマイズを壊さず追従させる」決定論的 config パッチ機構を追加します。

## Changes
### Features
- **Claude Sonnet 5**: `claude-sonnet-5` をコスト表（headless / interactive）と設定画面モデル表記に追加。コンテキスト窓は既存 `sonnet` パターンで 1M。
- **effort デフォルト `xhigh`**: 設定 UI に「Extra High」追加。合成レジストリはモデル能力で `xhigh` 可否を判定（**Opus 4.7+ / Sonnet 5 のみ**）。Haiku / 旧 Opus・Sonnet は `resolveEffort` が安全に `medium` へクランプ（config 既定・セッション上書き両経路）。
- **決定論的 config パッチ**: マイグレーションに `config-patch.json` を同梱すると `ryoko migrate --auto`（= `ryoko update`）が config.yaml をキー単位で更新。未設定→挿入 / 旧デフォルト一致→更新 / カスタム済み→スキップ、冪等。2026.7.1 で `engines.claude.effortLevel: medium → xhigh` を適用。

### Fixes
- **interactive コスト**: エイリアスではなくトランスクリプトの実モデルID で料金解決。Sonnet/Haiku が Opus 価格で過大計上される問題を修正。

## Verification
- 型チェック: クリーン / jimmy: **521 tests pass**
- Codex レビュー 2 ラウンド（HIGH×2 / MEDIUM×2 / LOW×1 を検出→全修正・再検証）
- E2E: `ryoko migrate --auto` で medium→xhigh 更新 / カスタム値保護 / 挿入・冪等 を実機同等で確認
- 実機モデル別 effort クランプ確認: opus・sonnet・opus-4-8・sonnet-5 → `xhigh` / haiku・opus-4-6・sonnet-4-6 → `medium`

## Breaking changes
なし。config パッチはカスタム値を保護し、`xhigh` は能力対応モデルのみに付与。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
