### PR TITLE
feat(engine): upstream jinn 安定性4点セットの移植（StopFailure grace / lost-Stop recovery / status-reconciler / ネイティブコマンド）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.7.4] - 2026-07-02
+
+### Features（upstream jinn 0.20〜0.23 から安定性4点セットを移植）
+- **StopFailure grace window（20秒）**: `server_error`/`invalid_request`/`unknown` 系の StopFailure を即失敗確定せず猶予保留。CLI が自力リトライして完走すれば後続の Stop が**成功で上書き**、ツールフック/SSE活動で猶予を再アーム、**サブエージェントのAPIリクエストが in-flight の間は失敗確定を延期**（サブエージェントのAPIエラーが親ターンを誤って失敗させる問題の根本修正）。`rate_limit`/`billing_error`/`authentication_failed`/`max_output_tokens` は従来どおり即確定。
+- **Lost-Stop recovery**: Stop フック自体が消失した場合（relay障害・gateway.json 差し替え等）、5分経過+60秒静穏+ツール/API非実行を条件に、**transcript から最終アシスタントメッセージを復元してターンを成功確定**。ターン終了後に結果テキストが空だった場合の transcript バックフィルも追加（「(no output)」返信の解消）。
+- **status-reconciler**: `status:"running"` のままスタックしたセッションを15秒ごとにスイープし、ハートビート45秒超過+実ターンなしを**2回連続**確認したら idle に自動復旧（完了イベント喪失の最終バックストップ）。transient retry の待機中は20秒ごとのハートビートで誤検知を防止。
+- **ネイティブコマンド処理**: `/compact`/`/clear`/`/model` 等（Stopフックを発火しない）は出力静穏ウィンドウで完了確定、`/usage`/`/limits` 等（Stop の last_assistant_message が**前ターンのテキスト**を載せてくる）は空で確定し、重複エコーの再投稿を防止。
+- その他: 思考ブロック（`<thinking>`等）が最終テキストに漏れた場合の除去、bracketed-paste 後の CR を 50ms→150ms（ペースト未消化で送信が落ちるレースの解消、upstream知見）。
+
+### Tests
+- jimmy: 562 tests pass（grace window の保留/上書き/再アーム/延期、transcript 復元ヘルパー、status-reconciler の2スイープ確定、ネイティブコマンド判定・空確定の回帰テストを追加）。
+
 ## [2026.7.3] - 2026-07-02
 
 ### Fixes（空気読みトリアージ — 「スタンプだけ返す」が機能しない問題）

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.7.3",
+  "version": "2026.7.4",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/engines/__tests__/claude-interactive-transcript-recovery.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude-interactive-transcript-recovery.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("node-pty", () => ({ spawn: vi.fn() }));
+
+import { findTranscriptForSession, lastAssistantTextFromTranscript, stripReasoningBlocks } from "../claude-interactive.js";
+
+// Lost-Stop recovery reads the turn's final assistant message straight from
+// Claude Code's on-disk transcript (~/.claude/projects/<cwd-slug>/<sid>.jsonl).
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-recovery-"));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeTranscript(projectsDir: string, slugDir: string, sid: string, lines: unknown[]): string {
+  const dir = path.join(projectsDir, slugDir);
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, `${sid}.jsonl`);
+  fs.writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return p;
+}
+
+const assistantLine = (text: string, ts?: string) => ({
+  type: "assistant",
+  ...(ts ? { timestamp: ts } : {}),
+  message: { content: [{ type: "text", text }] },
+});
+
+describe("findTranscriptForSession", () => {
+  it("resolves the direct cwd-slug path", () => {
+    const projects = path.join(tmp, "projects");
+    const home = "/home/user/.ryoko";
+    const expected = writeTranscript(projects, "-home-user--ryoko", "sid-1", [assistantLine("hi")]);
+    expect(findTranscriptForSession("sid-1", home, projects)).toBe(expected);
+  });
+
+  it("falls back to scanning project dirs when the slug misses", () => {
+    const projects = path.join(tmp, "projects");
+    const expected = writeTranscript(projects, "-some-other-dir", "sid-2", [assistantLine("hi")]);
+    expect(findTranscriptForSession("sid-2", "/home/user/.ryoko", projects)).toBe(expected);
+  });
+
+  it("returns undefined for a missing session or projects dir", () => {
+    expect(findTranscriptForSession("nope", "/home/user/.ryoko", path.join(tmp, "absent"))).toBeUndefined();
+    expect(findTranscriptForSession("", "/home/user/.ryoko", tmp)).toBeUndefined();
+  });
+});
+
+describe("lastAssistantTextFromTranscript", () => {
+  it("returns the LAST assistant text block", () => {
+    const p = writeTranscript(path.join(tmp, "projects"), "-x", "sid-3", [
+      { type: "user", message: { content: "question" } },
+      assistantLine("first"),
+      { type: "system", subtype: "turn_duration" },
+      assistantLine("final answer"),
+    ]);
+    expect(lastAssistantTextFromTranscript(p)).toBe("final answer");
+  });
+
+  it("honors the afterMs filter — pre-turn history is not 'recovered'", () => {
+    const p = writeTranscript(path.join(tmp, "projects"), "-x", "sid-4", [
+      assistantLine("stale previous turn", "2026-07-01T00:00:00Z"),
+      assistantLine("this turn's answer", "2026-07-02T12:00:00Z"),
+    ]);
+    const afterMs = Date.parse("2026-07-02T00:00:00Z");
+    expect(lastAssistantTextFromTranscript(p, afterMs)).toBe("this turn's answer");
+    const tooLate = Date.parse("2026-07-03T00:00:00Z");
+    expect(lastAssistantTextFromTranscript(p, tooLate)).toBeUndefined();
+  });
+
+  it("skips unparseable lines and non-text content", () => {
+    const dir = path.join(tmp, "projects", "-x");
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, "sid-5.jsonl");
+    fs.writeFileSync(p, [
+      "not json at all",
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash" }] } }),
+      JSON.stringify(assistantLine("real text")),
+    ].join("\n"));
+    expect(lastAssistantTextFromTranscript(p)).toBe("real text");
+  });
+});
+
+describe("stripReasoningBlocks", () => {
+  it("removes thinking/reasoning tags and fenced thinking blocks", () => {
+    expect(stripReasoningBlocks("<thinking>secret</thinking>\n\nanswer")).toBe("answer");
+    expect(stripReasoningBlocks("```thinking\nsecret\n```\nanswer")).toBe("answer");
+    expect(stripReasoningBlocks("plain answer")).toBe("plain answer");
+  });
+});

--- a/packages/jimmy/src/engines/__tests__/claude-interactive.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude-interactive.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi } from "vitest";
 // focused and CI-portable.
 vi.mock("node-pty", () => ({ spawn: vi.fn() }));
 
-import { TurnResolver } from "../claude-interactive.js";
+import { TurnResolver, isNativeClaudeCommand } from "../claude-interactive.js";
 
 describe("TurnResolver", () => {
   it("resolves only after BOTH SessionStart and Stop", async () => {
@@ -56,5 +56,123 @@ describe("TurnResolver", () => {
     expect(v.error).toMatch(/rate_limit/);
     expect(v.numTurns).toBe(1);
     expect(r.stopFailure?.error).toBe("rate_limit");
+  });
+});
+
+describe("TurnResolver — StopFailure grace window (upstream port)", () => {
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  it("holds a server_error StopFailure in grace and settles with the error after expiry", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "s", stopFailureGraceMs: 20 });
+    let resolved: any;
+    r.promise.then((v) => { resolved = v; });
+    r.onHook({ hook_event_name: "StopFailure", error: "server_error" });
+    await sleep(5);
+    expect(resolved).toBeUndefined(); // held in grace, not settled yet
+    await sleep(40);
+    expect(resolved?.error).toMatch(/server_error/);
+    expect(resolved?.numTurns).toBe(1);
+  });
+
+  it("a later Stop supersedes the graced failure — the CLI retried and finished", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "s", assumeStarted: true, stopFailureGraceMs: 50 });
+    r.onHook({ hook_event_name: "StopFailure", error: "server_error" });
+    await sleep(5);
+    r.onHook({ hook_event_name: "Stop", last_assistant_message: "recovered answer" });
+    const v = await r.promise;
+    expect(v.error).toBeUndefined();
+    expect(v.result).toBe("recovered answer");
+    expect(r.stopFailure).toBeUndefined(); // superseded, not exposed
+  });
+
+  it("tool-hook activity re-arms the grace window", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "s", stopFailureGraceMs: 30 });
+    let resolved: any;
+    r.promise.then((v) => { resolved = v; });
+    r.onHook({ hook_event_name: "StopFailure", error: "server_error" });
+    // Keep feeding activity past the original 30ms window.
+    for (let i = 0; i < 4; i++) {
+      await sleep(15);
+      r.onHook({ hook_event_name: "PostToolUse", tool_name: "Bash" });
+    }
+    expect(resolved).toBeUndefined(); // still alive well past 30ms
+    await sleep(60); // quiet — grace finally expires
+    expect(resolved?.error).toMatch(/server_error/);
+  });
+
+  it("defers settling while shouldDeferStopFailure reports in-flight work", async () => {
+    let busy = true;
+    const r = new TurnResolver({ fallbackSessionId: "s", stopFailureGraceMs: 10, shouldDeferStopFailure: () => busy });
+    let resolved: any;
+    r.promise.then((v) => { resolved = v; });
+    r.onHook({ hook_event_name: "StopFailure", error: "server_error" });
+    await sleep(40);
+    expect(resolved).toBeUndefined(); // deferred — sub-agent still streaming
+    busy = false;
+    await sleep(30);
+    expect(resolved?.error).toMatch(/server_error/);
+  });
+
+  it("rate_limit / authentication_failed still settle immediately", async () => {
+    for (const error of ["rate_limit", "authentication_failed", "billing_error", "max_output_tokens"]) {
+      const r = new TurnResolver({ fallbackSessionId: "s", stopFailureGraceMs: 10_000 });
+      r.onHook({ hook_event_name: "StopFailure", error });
+      const v = await r.promise; // resolves without waiting for any grace
+      expect(v.error).toContain(error);
+    }
+  });
+
+  it("PTY death with a pending graced failure reports the API error, not 'process exited'", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "s", stopFailureGraceMs: 10_000 });
+    r.onHook({ hook_event_name: "StopFailure", error: "server_error" });
+    r.interrupt("Interrupted: claude process exited");
+    const v = await r.promise;
+    expect(v.error).toMatch(/server_error/);
+  });
+
+  it("strips leaked thinking blocks from Stop hook assistant text", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "warm-sid", assumeStarted: true });
+    r.onHook({
+      hook_event_name: "Stop",
+      last_assistant_message: "<thinking>private reasoning</thinking>\n\nVisible answer.",
+    });
+    const v = await r.promise;
+    expect(v.result).toBe("Visible answer.");
+  });
+
+  it("can recover-complete a turn when the Stop hook is missing", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "old" });
+    r.onHook({ hook_event_name: "SessionStart", session_id: "c1" });
+    r.completeRecovered("transcript final", "c1");
+    const v = await r.promise;
+    expect(v.result).toBe("transcript final");
+    expect(v.sessionId).toBe("c1");
+  });
+});
+
+describe("native Claude command handling (upstream port)", () => {
+  it("classifies native local commands", () => {
+    expect(isNativeClaudeCommand("/compact")).toBe(true);
+    expect(isNativeClaudeCommand("/usage")).toBe(true);
+    expect(isNativeClaudeCommand("  /model opus")).toBe(true);
+    expect(isNativeClaudeCommand("/init")).toBe(false); // real-turn command
+    expect(isNativeClaudeCommand("hello /compact")).toBe(false);
+    expect(isNativeClaudeCommand("")).toBe(false);
+  });
+
+  it("a native turn's Stop settles EMPTY — stale last_assistant_message is not persisted", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "warm-sid", assumeStarted: true, native: true });
+    r.onHook({ hook_event_name: "Stop", last_assistant_message: "PREVIOUS turn's text" });
+    const v = await r.promise;
+    expect(v.result).toBe("");
+    expect(v.error).toBeUndefined();
+  });
+
+  it("completeNativeCommand settles empty (context mutators fire no Stop at all)", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "warm-sid", assumeStarted: true, native: true });
+    r.completeNativeCommand();
+    const v = await r.promise;
+    expect(v.result).toBe("");
+    expect(v.numTurns).toBe(1);
   });
 });

--- a/packages/jimmy/src/engines/claude-interactive.ts
+++ b/packages/jimmy/src/engines/claude-interactive.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import * as pty from "node-pty";
 import type { InterruptibleEngine, EngineRunOpts, EngineResult, EngineRateLimitInfo, StreamDelta } from "../shared/types.js";
 import { logger } from "../shared/logger.js";
@@ -115,6 +117,73 @@ function computeInteractiveCost(transcriptPath: string, model?: string): { cost:
   return { cost, turns: u.assistantTurns };
 }
 
+/** Claude Code stores per-project transcripts at
+ *  ~/.claude/projects/<cwd-slug>/<claudeSessionId>.jsonl, where the slug is the
+ *  cwd with every "/" and "." replaced by "-". Derive that path; fall back to a
+ *  scan across project dirs if the slug heuristic misses (defensive). Exported
+ *  for the transcript-recovery unit test. (Ported from upstream jinn.) */
+export function findTranscriptForSession(
+  claudeSessionId: string,
+  homeDir: string = JINN_HOME,
+  projectsDir: string = path.join(os.homedir(), ".claude", "projects"),
+): string | undefined {
+  if (!claudeSessionId) return undefined;
+  const slug = homeDir.replace(/[/.]/g, "-");
+  const direct = path.join(projectsDir, slug, `${claudeSessionId}.jsonl`);
+  if (fs.existsSync(direct)) return direct;
+  try {
+    for (const d of fs.readdirSync(projectsDir)) {
+      const p = path.join(projectsDir, d, `${claudeSessionId}.jsonl`);
+      if (fs.existsSync(p)) return p;
+    }
+  } catch { /* projects dir missing — nothing to recover */ }
+  return undefined;
+}
+
+function transcriptLineTimestampMs(msg: any): number | undefined {
+  const raw = msg?.timestamp ?? msg?.created_at ?? msg?.createdAt;
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw !== "string" || !raw.trim()) return undefined;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Last assistant text block from a Claude transcript — the turn's final
+ *  message. Used to recover result text when the Stop hook (which normally
+ *  carries last_assistant_message) was lost (gateway restart deleting
+ *  gateway.json mid-turn, PTY crash, or relay drop), so the reply shows real
+ *  output instead of "(no output)". Exported for tests. */
+export function lastAssistantTextFromTranscript(transcriptPath: string, afterMs?: number): string | undefined {
+  let raw: string;
+  try { raw = fs.readFileSync(transcriptPath, "utf-8"); } catch { return undefined; }
+  let last: string | undefined;
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let msg: any;
+    try { msg = JSON.parse(t); } catch { continue; }
+    if (msg.type !== "assistant") continue;
+    if (afterMs !== undefined) {
+      const ts = transcriptLineTimestampMs(msg);
+      if (ts === undefined || ts < afterMs) continue;
+    }
+    const content = msg?.message?.content;
+    if (!Array.isArray(content)) continue;
+    const text = content.filter((b: any) => b?.type === "text").map((b: any) => String(b.text ?? "")).join("");
+    if (text.trim()) last = text;
+  }
+  return last;
+}
+
+/** Strip model reasoning blocks that occasionally leak into
+ *  last_assistant_message / transcript text — they are never user-facing. */
+export function stripReasoningBlocks(text: string): string {
+  return text
+    .replace(/<\s*(thinking|reasoning|thought)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, "")
+    .replace(/```(?:thinking|reasoning|thought)\b[\s\S]*?```/gi, "")
+    .trim();
+}
+
 /**
  * Map a StopFailure hook payload to an EngineRateLimitInfo.
  * Returns null unless the turn failed specifically with error === "rate_limit".
@@ -189,12 +258,29 @@ export function sseEventToDeltas(e: SseDataEvent): StreamDelta[] {
   }
 }
 
+const STOP_FAILURE_GRACE_MS = 20_000;
+/** StopFailure errors that must settle immediately. Rate-limit/billing/auth
+ *  need the manager fallback machinery right away; everything else gets a grace
+ *  window because Claude Code can keep working after a sub-agent/API failure.
+ *  (Ported from upstream jinn — this is the fix for "a sub-agent's API error
+ *  fails the whole turn even though the main agent keeps going".) */
+const IMMEDIATE_STOP_FAILURE_ERRORS = new Set(["rate_limit", "billing_error", "authentication_failed", "max_output_tokens"]);
+
 export interface TurnResolverOpts {
   fallbackSessionId: string | undefined;
   /** When true (warm-PTY reuse / post-idle-spawn), the resolver skips waiting for
    *  SessionStart (it already fired once at process start) and pre-fills the
    *  Claude session id from fallbackSessionId. */
   assumeStarted?: boolean;
+  /** Test override for the StopFailure grace window (default 20s). */
+  stopFailureGraceMs?: number;
+  /** While true, a graced StopFailure keeps waiting instead of settling. */
+  shouldDeferStopFailure?: () => boolean;
+  /** This turn is a Claude-native local command (see isNativeClaudeCommand). Such
+   *  commands produce no new assistant message, so a Stop hook's
+   *  last_assistant_message is the PREVIOUS turn's stale text — maybeComplete must
+   *  settle empty rather than re-persist it as a duplicate. */
+  native?: boolean;
 }
 
 /** State machine for one interactive turn: resolves after BOTH SessionStart + Stop, or on StopFailure/interrupt. */
@@ -206,6 +292,7 @@ export class TurnResolver {
   private gotSessionStart = false;
   private stopPayload: HookPayload | undefined;
   private stopFailurePayload: HookPayload | undefined;
+  private graceTimer: NodeJS.Timeout | undefined;
 
   constructor(private opts: TurnResolverOpts) {
     this.promise = new Promise((res) => { this.resolve = res; });
@@ -222,26 +309,35 @@ export class TurnResolver {
       if (typeof h.session_id === "string") this.claudeSessionId = h.session_id;
       this.maybeComplete();
     } else if (h.hook_event_name === "Stop") {
+      // A Stop supersedes any pending StopFailure — the CLI retried and finished.
+      this.clearGrace();
+      this.stopFailurePayload = undefined;
       this.stopPayload = h;
       if (typeof h.session_id === "string" && !this.claudeSessionId) this.claudeSessionId = h.session_id;
       this.maybeComplete();
     } else if (h.hook_event_name === "StopFailure") {
-      // API error ended the turn (rate_limit, billing_error, …). Settle immediately
-      // with an error — do NOT wait for SessionStart (an early failure may never
-      // produce one). numTurns:1 keeps isDeadSessionError from false-positiving.
+      // API error ended the turn. In interactive mode the CLI survives
+      // invalid_request/server_error/unknown and usually retries — hold the
+      // failure in a grace window instead of settling: a later Stop supersedes
+      // it, activity re-arms it, the PTY-death watchdog still fails fast.
+      // Other error types (rate_limit, billing, auth) settle immediately.
+      // numTurns:1 keeps isDeadSessionError from false-positiving.
       this.stopFailurePayload = h;
       if (typeof h.session_id === "string" && !this.claudeSessionId) this.claudeSessionId = h.session_id;
-      this.settle({
-        sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "",
-        result: "",
-        error: `Interactive turn failed: ${h.error ?? "unknown"}`,
-        numTurns: 1,
-      });
+      if (!IMMEDIATE_STOP_FAILURE_ERRORS.has(String(h.error ?? "unknown"))) {
+        this.armGrace();
+      } else {
+        this.settleWithFailure();
+      }
+    } else {
+      // PreToolUse/PostToolUse/etc — proof of life while a failure is pending.
+      this.noteActivity();
     }
   }
 
   /** Claude session id learned so far (for engineSessionId persistence on warm-PTY turns). */
   get sessionId(): string | undefined { return this.claudeSessionId; }
+  get isSettled(): boolean { return this.settled; }
   /** The StopFailure payload, if the turn ended in an API error (Task 5.3 maps it to rateLimit). */
   get stopFailure(): HookPayload | undefined { return this.stopFailurePayload; }
   /** transcript_path from whichever hook carried it. */
@@ -257,19 +353,107 @@ export class TurnResolver {
       this.settle({ sessionId: "", result: "", error: "Interactive turn produced no Claude session id" });
       return;
     }
-    const text = String(this.stopPayload.last_assistant_message ?? "");
+    // Native local commands (/usage, /limits, …) produce no new assistant
+    // message; the Stop hook's last_assistant_message is the prior turn's stale
+    // text. Settling with it would persist a duplicate chat echo — settle empty.
+    const text = this.opts.native ? "" : stripReasoningBlocks(String(this.stopPayload.last_assistant_message ?? ""));
     this.settle({ sessionId: sid, result: text, error: undefined, numTurns: 1 });
   }
 
   interrupt(reason: string): void {
+    // PTY died while a StopFailure was held in grace — the API error is the
+    // real cause; report it instead of the generic "process exited". Other
+    // interrupt reasons (user abort, engine switch, shutdown) keep their
+    // "Interrupted: …" text so the quiet-interrupt handling downstream engages.
+    if (this.stopFailurePayload && !this.settled && reason === "Interrupted: claude process exited") {
+      this.settleWithFailure();
+      return;
+    }
     this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: "", error: reason });
+  }
+
+  /** Settle a native local command (no Stop hook fires for context mutators). */
+  completeNativeCommand(): void {
+    this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: "", numTurns: 1 });
+  }
+
+  /** Settle with text recovered from the transcript (the Stop hook was lost). */
+  completeRecovered(text: string, sessionId?: string): void {
+    if (sessionId && !this.claudeSessionId) this.claudeSessionId = sessionId;
+    this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: stripReasoningBlocks(text), numTurns: 1 });
+  }
+
+  /** Proof of life (SSE delta / tool hook) while a StopFailure is pending —
+   *  re-arms the grace window. No-op when no failure is pending. */
+  noteActivity(): void {
+    if (this.graceTimer) this.armGrace();
+  }
+
+  private armGrace(): void {
+    this.clearGrace();
+    const ms = this.opts.stopFailureGraceMs ?? STOP_FAILURE_GRACE_MS;
+    this.graceTimer = setTimeout(() => {
+      if (this.opts.shouldDeferStopFailure?.()) {
+        this.armGrace();
+        return;
+      }
+      this.settleWithFailure();
+    }, ms);
+    this.graceTimer.unref?.();
+  }
+
+  private clearGrace(): void {
+    if (this.graceTimer) {
+      clearTimeout(this.graceTimer);
+      this.graceTimer = undefined;
+    }
+  }
+
+  private settleWithFailure(): void {
+    this.settle({
+      sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "",
+      result: "",
+      error: `Interactive turn failed: ${this.stopFailurePayload?.error ?? "unknown"}`,
+      numTurns: 1,
+    });
   }
 
   private settle(r: EngineResult): void {
     if (this.settled) return;
     this.settled = true;
+    this.clearGrace();
     this.resolve(r);
   }
+}
+
+const NATIVE_COMMAND_QUIET_MS = 1800;
+const NATIVE_COMMAND_MIN_MS = 3000;
+const NATIVE_COMMAND_MAX_MS = 90_000;
+const LOST_STOP_RECOVERY_QUIET_MS = 60_000;
+const LOST_STOP_RECOVERY_MIN_MS = 5 * 60_000;
+
+/** Claude Code built-in slash commands that run locally and never produce a new
+ *  assistant API turn. Two behaviours, both handled by the native-command path:
+ *   - Context mutators (/compact, /clear, /model) end without firing a Stop hook;
+ *     the native-command quiet-window timer settles them with an empty result.
+ *   - Info/overlay commands (/usage, /limits, /cost, …) DO fire a Stop hook on
+ *     dismiss, but its `last_assistant_message` still carries the PREVIOUS turn's
+ *     text. Without native classification that stale text was persisted as a new
+ *     assistant message — the duplicate-chat-echo bug. native-aware maybeComplete
+ *     settles these empty instead.
+ *  Only commands that genuinely yield no persistable assistant output belong here:
+ *  misclassifying a real-turn command (/init, /review, skill commands) would drop
+ *  its answer. */
+const NATIVE_CLAUDE_COMMANDS = new Set([
+  "/compact", "/clear", "/model",
+  "/usage", "/limits", "/cost", "/status", "/config", "/help", "/doctor",
+  "/release-notes", "/vim", "/terminal-setup", "/mcp", "/agents", "/permissions",
+  "/hooks", "/memory", "/export", "/login", "/logout", "/bug", "/resume",
+]);
+
+export function isNativeClaudeCommand(prompt: string): boolean {
+  const first = prompt.trim().split(/\s+/, 1)[0]?.toLowerCase();
+  return first !== undefined && NATIVE_CLAUDE_COMMANDS.has(first);
 }
 
 /** Cap for the per-session PTY scrollback ring buffer (xterm.js reconnect replay). */
@@ -285,7 +469,9 @@ const SCROLLBACK_CAP_BYTES = 262144;
 function pasteAndSubmit(proc: pty.IPty, text: string): void {
   const payload = neutralizeForPaste(text);
   proc.write(`\x1b[200~${payload}\x1b[201~`);
-  setTimeout(() => proc.write("\r"), 50);
+  // 150ms beat (upstream finding): 50ms occasionally raced the TUI's paste
+  // handling and the CR landed before the paste was consumed.
+  setTimeout(() => proc.write("\r"), 150);
 }
 
 export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngine {
@@ -296,7 +482,10 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
    *  released by a kill->respawn race can't poison the freshly-started turn.
    *  `onStream` is the current turn's delta callback; the per-PTY SSE proxy routes
    *  parsed events here (a PTY outlives its turn, so the proxy looks this up live). */
-  private active = new Map<string, { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty }>();
+  private active = new Map<string, { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty; activeTools: number }>();
+  /** Epoch ms of the most recent PTY output per session — the quiet-window
+   *  signal for native-command settle and lost-Stop recovery. */
+  private lastOutputAt = new Map<string, number>();
   /** Sessions with an in-flight async idle-spawn (proxy.start awaited) — prevents
    *  a second ensureIdleSpawn from racing in a duplicate PTY during that gap. */
   private idleSpawning = new Set<string>();
@@ -378,16 +567,30 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
         warm = undefined;
       }
     }
+    const turnStartedAtMs = Date.now();
+    // Claude-native local command (/compact, /usage, …): no new assistant turn is
+    // produced; completion is detected by output quiet-window, and a Stop hook's
+    // stale last_assistant_message must not be persisted as a duplicate reply.
+    const nativeCommand = isNativeClaudeCommand(opts.prompt);
     const resolver = new TurnResolver({
       fallbackSessionId: opts.resumeSessionId,
       assumeStarted: !!warm, // warm PTY = SessionStart already fired (turn 1 or idle spawn)
+      // Defer a graced StopFailure while upstream API requests are in flight —
+      // a sub-agent's failure must not fail the turn the main agent is still
+      // working on.
+      shouldDeferStopFailure: () => this.hasInflightUpstream(jinnSessionId),
+      native: nativeCommand,
     });
-    const entry: { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty } = { resolver, onStream: opts.onStream };
+    const entry: { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty; activeTools: number } = { resolver, onStream: opts.onStream, activeTools: 0 };
     this.active.set(jinnSessionId, entry);
 
     // Register BEFORE spawning so a fast SessionStart is buffered+drained, not lost.
     this.hookRegistry.register(jinnSessionId, (h) => {
       resolver.onHook(h);
+      // Track local tool executions: lost-Stop recovery must never fire while a
+      // tool is mid-run (transcript text exists but the turn isn't done).
+      if (h.hook_event_name === "PreToolUse") entry.activeTools += 1;
+      if (h.hook_event_name === "PostToolUse") entry.activeTools = Math.max(0, entry.activeTools - 1);
       // tool_use markers + intermediate text now stream from the per-PTY SSE proxy
       // (content_block_start / content_block_delta) in true order. The hook only
       // supplies tool_result — the assistant SSE stream has no tool_result event
@@ -440,7 +643,6 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     // would never fire. Both the stuck "in progress" badge and lost child-session
     // callbacks trace to this. Force-settle once the proc is provably dead so
     // run() always resolves and the normal completion path runs.
-    const turnStartedAt = Date.now();
     const watchdog = setInterval(() => {
       const p = entry.boundProc as { _exitCode?: number | null } | undefined;
       if (p && p._exitCode != null) {
@@ -453,7 +655,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       // demonstrably still working (API requests streaming through the SSE proxy) —
       // the deadline exists to catch WEDGED turns, not to cap long legitimate
       // autonomous runs; a truly hung pty goes quiet and gets reaped on a later tick.
-      if (Date.now() - turnStartedAt > this.turnTimeoutMs && !this.isEngineBusy(jinnSessionId)) {
+      if (Date.now() - turnStartedAtMs > this.turnTimeoutMs && !this.isEngineBusy(jinnSessionId)) {
         logger.warn(`InteractiveClaudeEngine: turn for ${jinnSessionId} exceeded ${Math.round(this.turnTimeoutMs / 1000)}s with no engine activity — force-settling as timed out`);
         resolver.interrupt("Interrupted: interactive turn timed out");
         this.lifecycle.releaseSession(jinnSessionId);
@@ -461,14 +663,83 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     }, 5000);
     watchdog.unref?.();
 
+    // Native local command: no Stop hook fires for context mutators (/compact,
+    // /clear, /model) — settle on an output quiet-window instead of hanging
+    // until the turn watchdog.
+    let nativeCommandTimer: NodeJS.Timeout | undefined;
+    if (nativeCommand) {
+      nativeCommandTimer = setInterval(() => {
+        const now = Date.now();
+        const quietFor = now - (this.lastOutputAt.get(jinnSessionId) ?? turnStartedAtMs);
+        const elapsed = now - turnStartedAtMs;
+        if ((elapsed >= NATIVE_COMMAND_MIN_MS && quietFor >= NATIVE_COMMAND_QUIET_MS) || elapsed >= NATIVE_COMMAND_MAX_MS) {
+          resolver.completeNativeCommand();
+        }
+      }, 500);
+      nativeCommandTimer.unref?.();
+    }
+
+    // Lost-Stop recovery: the Stop hook can be lost outright (relay failure,
+    // gateway.json replaced mid-turn, hook process killed). If the turn has run
+    // ≥5 min, the PTY has been quiet ≥60s, no tool is executing and no API
+    // request is in flight, and the transcript has a fresh assistant message —
+    // the turn actually finished; recover its text instead of hanging until the
+    // watchdog fails it. (Ported from upstream jinn.)
+    let lostStopRecoveryTimer: NodeJS.Timeout | undefined;
+    if (!nativeCommand) {
+      lostStopRecoveryTimer = setInterval(() => {
+        if (resolver.isSettled) return;
+        // A StopFailure is held in the grace window — the turn's fate is the
+        // grace timer's call (Stop supersedes / expiry fails). Recovering
+        // intermediate transcript text here would fabricate a wrong success.
+        if (resolver.stopFailure) return;
+        if (entry.activeTools > 0 || this.hasInflightUpstream(jinnSessionId)) return;
+        const now = Date.now();
+        const elapsed = now - turnStartedAtMs;
+        const quietFor = now - (this.lastOutputAt.get(jinnSessionId) ?? turnStartedAtMs);
+        if (elapsed < LOST_STOP_RECOVERY_MIN_MS || quietFor < LOST_STOP_RECOVERY_QUIET_MS) return;
+        const sid = resolver.sessionId ?? opts.resumeSessionId;
+        const transcript = sid ? findTranscriptForSession(sid) : undefined;
+        if (!transcript) return;
+        try {
+          if (fs.statSync(transcript).mtimeMs < turnStartedAtMs - 1000) return;
+        } catch {
+          return;
+        }
+        const recovered = lastAssistantTextFromTranscript(transcript, turnStartedAtMs);
+        if (recovered?.trim()) {
+          logger.warn(`InteractiveClaudeEngine: recovered completed turn for ${jinnSessionId} after missing Stop hook`);
+          resolver.completeRecovered(recovered, sid);
+        }
+      }, 2000);
+      lostStopRecoveryTimer.unref?.();
+    }
+
     let result: EngineResult;
     try {
       result = await resolver.promise;
     } finally {
       clearInterval(watchdog);
+      if (nativeCommandTimer) clearInterval(nativeCommandTimer);
+      if (lostStopRecoveryTimer) clearInterval(lostStopRecoveryTimer);
       this.hookRegistry.unregister(jinnSessionId);
       this.active.delete(jinnSessionId);
       this.lifecycle.turnEnded(jinnSessionId); // manager decides kill vs keep-warm
+    }
+
+    // Recover lost result text: if the turn settled with no text and no API-level
+    // failure, the Stop hook (which carries last_assistant_message) was dropped or
+    // arrived empty. The real final message is still on disk in the transcript;
+    // backfill it so the reply shows real output instead of "(no output)".
+    // stopFailure turns are a genuine no-output API error — leave those alone.
+    if (!nativeCommand && !result.error && !result.result?.trim() && !resolver.stopFailure) {
+      const sid = resolver.sessionId ?? opts.resumeSessionId ?? result.sessionId;
+      const recoveryPath = sid ? findTranscriptForSession(sid) : undefined;
+      const recovered = recoveryPath ? lastAssistantTextFromTranscript(recoveryPath, turnStartedAtMs) : undefined;
+      if (recovered) {
+        logger.info(`Recovered ${recovered.length} chars of lost turn text for session ${jinnSessionId} from transcript (Stop hook missing)`);
+        result.result = stripReasoningBlocks(recovered);
+      }
     }
 
     // Reconstruct cost from the transcript (the Stop hook carries no cost).
@@ -518,7 +789,10 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
    *  them to the active turn's onStream. A PTY outlives its turn, so we look up
    *  the live active entry here rather than capturing onStream at spawn. */
   private handleSseEvent(jinnSessionId: string, e: SseDataEvent, ctx: StreamCtx): void {
-    const onStream = this.active.get(jinnSessionId)?.onStream;
+    const activeEntry = this.active.get(jinnSessionId);
+    // SSE deltas are proof of life — re-arm a pending StopFailure grace window.
+    activeEntry?.resolver.noteActivity();
+    const onStream = activeEntry?.onStream;
     if (!onStream) return; // idle PTY / no turn in flight — nothing to stream
     // Tag sub-agent deltas so the chat pane routes them into a collapsible card
     // instead of the main transcript; main-agent deltas pass through untagged.
@@ -569,6 +843,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       // Evict so a future run() can't pick this dead handle up as "warm" and inject
       // into a corpse.
       this.lifecycle.releaseSession(jinnSessionId);
+      this.lastOutputAt.delete(jinnSessionId);
     }
     // Tear down THIS PTY's SSE forward proxy (one per PTY) regardless of identity.
     ((handle as any)._proxy as SsePtyProxy | undefined)?.stop();
@@ -623,6 +898,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     });
 
     proc.onData((d) => {
+      this.lastOutputAt.set(jinnSessionId, Date.now());
       // Convert string to Buffer once; push to ring; evict head until under cap.
       const chunk = Buffer.from(d, "utf-8");
       stream.chunks.push(chunk);
@@ -854,6 +1130,17 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     if (!handle) return false;
     const proxy = (handle as any)._proxy as SsePtyProxy | undefined;
     return proxy?.isBusy(InteractiveClaudeEngine.BUSY_ACTIVITY_WINDOW_MS) ?? false;
+  }
+
+  /** True while an upstream API request is streaming through the session's SSE
+   *  proxy RIGHT NOW (no recency window — strictly in-flight). Used to defer a
+   *  graced StopFailure (a sub-agent error while the main agent still works)
+   *  and to hold lost-Stop recovery while the model is mid-request. */
+  private hasInflightUpstream(sessionId: string): boolean {
+    const handle = this.lifecycle.getWarm(sessionId);
+    if (!handle) return false;
+    const proxy = (handle as any)._proxy as SsePtyProxy | undefined;
+    return proxy?.hasInflight() ?? false;
   }
 
   /** Out-of-turn engine activity observed via an orphan hook (a background

--- a/packages/jimmy/src/engines/sse-pty-proxy.ts
+++ b/packages/jimmy/src/engines/sse-pty-proxy.ts
@@ -190,6 +190,12 @@ export class SsePtyProxy {
     return this.lastUpstreamActivityAt > 0 && Date.now() - this.lastUpstreamActivityAt < recentMs;
   }
 
+  /** Strictly in-flight (no recency window): an upstream request is streaming
+   *  through this proxy right now. */
+  hasInflight(): boolean {
+    return this.inflightCount > 0;
+  }
+
   private handle(req: http.IncomingMessage, res: http.ServerResponse): void {
     const chunks: Buffer[] = [];
     // Holder (not a plain `let`) so the req-close handler always destroys the

--- a/packages/jimmy/src/gateway/__tests__/status-reconciler.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/status-reconciler.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const listSessions = vi.fn();
+const updateSession = vi.fn();
+vi.mock("../../sessions/registry.js", () => ({
+  listSessions: (...a: unknown[]) => listSessions(...a),
+  updateSession: (...a: unknown[]) => updateSession(...a),
+}));
+
+import { sweepOnce, type StatusReconcilerDeps } from "../status-reconciler.js";
+
+const NOW = Date.parse("2026-07-02T12:00:00Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "s1",
+    engine: "claude",
+    status: "running",
+    lastActivity: iso(120_000), // stale by default
+    employee: null,
+    title: "t",
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<StatusReconcilerDeps> = {}): StatusReconcilerDeps & { emitted: unknown[] } {
+  const emitted: unknown[] = [];
+  return {
+    engines: new Map(),
+    emit: (event, payload) => emitted.push({ event, payload }),
+    now: () => NOW,
+    pendingStuck: new Set<string>(),
+    emitted,
+    ...overrides,
+  } as StatusReconcilerDeps & { emitted: unknown[] };
+}
+
+beforeEach(() => {
+  listSessions.mockReset();
+  updateSession.mockReset();
+});
+
+describe("status-reconciler sweepOnce", () => {
+  it("skips sessions with a fresh heartbeat", () => {
+    listSessions.mockReturnValue([makeSession({ lastActivity: iso(10_000) })]);
+    const deps = makeDeps();
+    expect(sweepOnce(deps)).toBe(0);
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it("skips stale sessions whose engine reports a live turn", () => {
+    listSessions.mockReturnValue([makeSession()]);
+    const engines = new Map<string, unknown>([
+      ["claude", { isTurnRunning: (id: string) => id === "s1" }],
+    ]);
+    const deps = makeDeps({ engines: engines as StatusReconcilerDeps["engines"] });
+    expect(sweepOnce(deps)).toBe(0);
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it("resets a stuck session only on the SECOND consecutive sweep", () => {
+    listSessions.mockReturnValue([makeSession()]);
+    const engines = new Map<string, unknown>([
+      ["claude", { isTurnRunning: () => false }],
+    ]);
+    const deps = makeDeps({ engines: engines as StatusReconcilerDeps["engines"] });
+
+    expect(sweepOnce(deps)).toBe(0); // first observation — marked, not reset
+    expect(updateSession).not.toHaveBeenCalled();
+    expect(deps.pendingStuck!.has("s1")).toBe(true);
+
+    expect(sweepOnce(deps)).toBe(1); // second consecutive — reset
+    expect(updateSession).toHaveBeenCalledWith("s1", expect.objectContaining({ status: "idle", lastError: null }));
+    expect(deps.emitted).toEqual([
+      expect.objectContaining({ event: "session:completed" }),
+    ]);
+    expect(deps.pendingStuck!.has("s1")).toBe(false);
+  });
+
+  it("a live turn between sweeps clears the stuck mark (turn-boundary race)", () => {
+    listSessions.mockReturnValue([makeSession()]);
+    let running = false;
+    const engines = new Map<string, unknown>([
+      ["claude", { isTurnRunning: () => running }],
+    ]);
+    const deps = makeDeps({ engines: engines as StatusReconcilerDeps["engines"] });
+
+    expect(sweepOnce(deps)).toBe(0); // marked
+    running = true;
+    expect(sweepOnce(deps)).toBe(0); // live turn — mark cleared
+    expect(deps.pendingStuck!.has("s1")).toBe(false);
+    running = false;
+    expect(sweepOnce(deps)).toBe(0); // needs two consecutive observations again
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it("falls back to isAlive for headless engines and treats unknown engines as no-turn", () => {
+    listSessions.mockReturnValue([
+      makeSession({ id: "codex-1", engine: "codex" }),
+      makeSession({ id: "ghost-1", engine: "ghost" }),
+    ]);
+    const engines = new Map<string, unknown>([
+      ["codex", { isAlive: () => true }], // live headless process — skip
+    ]);
+    const deps = makeDeps({ engines: engines as StatusReconcilerDeps["engines"] });
+    expect(sweepOnce(deps)).toBe(0); // codex skipped; ghost marked (first sweep)
+    expect(deps.pendingStuck!.has("ghost-1")).toBe(true);
+    expect(sweepOnce(deps)).toBe(1); // ghost reset on second sweep
+    expect(updateSession).toHaveBeenCalledTimes(1);
+    expect(updateSession).toHaveBeenCalledWith("ghost-1", expect.anything());
+  });
+});

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -20,6 +20,7 @@ import { PtyLifecycleManager } from "../engines/pty-lifecycle.js";
 import type { PtyViewEngine } from "../engines/pty-view-engine.js";
 import { attachPtyWebSocket } from "./pty-ws.js";
 import { HookRegistry } from "./hook-registry.js";
+import { startStatusReconciler } from "./status-reconciler.js";
 import { writeGatewayInfo } from "./gateway-info.js";
 import { cleanupSessionSettings, seedTrust } from "../shared/claude-settings.js";
 import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, CLAUDE_SETTINGS_DIR, JINN_HOME } from "../shared/paths.js";
@@ -852,6 +853,10 @@ export async function startGateway(
     }
   };
 
+  // Backstop for lost completion events: unstick sessions stuck at
+  // status:"running" with no live turn (see status-reconciler.ts).
+  const stopStatusReconciler = startStatusReconciler({ engines, emit });
+
   // API context
   const apiContext: ApiContext = {
     config: currentConfig,
@@ -1229,6 +1234,7 @@ export async function startGateway(
     if (interactiveClaudeEngine) {
       interactiveClaudeEngine.killAll();
       claudeLifecycle?.dispose();
+      try { stopStatusReconciler(); } catch { /* best effort */ }
       try { hookRegistry?.dispose(); } catch { /* best effort */ }
       try { fs.rmSync(GATEWAY_INFO_FILE, { force: true }); } catch { /* best effort */ }
     } else {

--- a/packages/jimmy/src/gateway/status-reconciler.ts
+++ b/packages/jimmy/src/gateway/status-reconciler.ts
@@ -1,0 +1,106 @@
+/**
+ * Status reconciler — unsticks sessions stuck at status:"running" with no live
+ * turn. (Ported from upstream jinn 0.20.0.)
+ *
+ * A completion event can be lost (process crash between engine settle and
+ * status persistence, a thrown error in the delivery path, a lost hook) and
+ * the session then shows "running" forever: the dashboard spinner never
+ * clears and new messages queue behind a phantom turn. This sweep is the
+ * backstop: a "running" session whose lastActivity is stale AND whose engine
+ * reports no live turn is reset to idle — but only on the SECOND consecutive
+ * sweep that finds it stuck, so a benign turn-boundary race (process exited,
+ * final status not yet persisted) never triggers a reset.
+ */
+import type { Engine } from "../shared/types.js";
+import { listSessions, updateSession } from "../sessions/registry.js";
+import { logger } from "../shared/logger.js";
+
+const DEFAULT_INTERVAL_MS = 15_000;
+/** A "running" session whose lastActivity is older than this has no live turn
+ *  heartbeat driving it. Correctness does NOT hinge on this value — a stale
+ *  session is still probed against the engine's live-turn state below; this
+ *  only gates how soon a lost completion is noticed. */
+const DEFAULT_STALE_MS = 45_000;
+
+export interface StatusReconcilerDeps {
+  engines: Map<string, Engine>;
+  emit: (event: string, payload: unknown) => void;
+  intervalMs?: number;
+  staleMs?: number;
+  /** Test override. */
+  now?: () => number;
+  /** Carry-over between sweeps: sessions seen stuck once. A session is only
+   *  reset on the SECOND consecutive sweep that finds it stuck. Created by
+   *  startStatusReconciler; tests may pass their own. */
+  pendingStuck?: Set<string>;
+}
+
+/** One sweep: unstick sessions stuck at status:"running" with no live turn.
+ *  Returns the number of sessions fixed. Exported for tests. */
+export function sweepOnce(deps: StatusReconcilerDeps): number {
+  const now = deps.now?.() ?? Date.now();
+  const staleMs = deps.staleMs ?? DEFAULT_STALE_MS;
+  let fixed = 0;
+  for (const session of listSessions({ status: "running" })) {
+    const last = session.lastActivity ? new Date(session.lastActivity).getTime() : 0;
+    const staleFor = now - last;
+    if (staleFor < staleMs) {
+      deps.pendingStuck?.delete(session.id); // fresh heartbeat — recovered, clear any mark
+      continue;
+    }
+    const engine = deps.engines.get(session.engine);
+    // Same live-turn probe as the API status path: interactive engines expose
+    // isTurnRunning (warm-but-idle PTYs must not count); headless engines
+    // approximate with isAlive; an unknown engine cannot have a live turn.
+    const turnRunning = !!engine && (
+      "isTurnRunning" in engine
+        ? (engine as unknown as { isTurnRunning(id: string): boolean }).isTurnRunning(session.id)
+        : (typeof (engine as { isAlive?: (id: string) => boolean }).isAlive === "function"
+          ? (engine as unknown as { isAlive(id: string): boolean }).isAlive(session.id)
+          : false)
+    );
+    if (turnRunning) {
+      deps.pendingStuck?.delete(session.id); // live turn — clear any mark
+      continue;
+    }
+    // Session qualifies as stuck: stale heartbeat + no live turn.
+    const pending = deps.pendingStuck;
+    if (pending && !pending.has(session.id)) {
+      pending.add(session.id);
+      continue; // confirm on the next sweep — could be a turn-boundary race
+    }
+    pending?.delete(session.id);
+    updateSession(session.id, {
+      status: "idle",
+      lastActivity: new Date(now).toISOString(),
+      lastError: null,
+    });
+    deps.emit("session:completed", {
+      sessionId: session.id,
+      employee: session.employee ?? undefined,
+      title: session.title,
+      result: null,
+      error: null,
+    });
+    logger.warn(
+      `[reconciler] session ${session.id} (${session.engine}) was stuck status=running with no live turn ` +
+      `(heartbeat stale ${Math.round(staleFor / 1000)}s) — reset to idle`,
+    );
+    fixed++;
+  }
+  return fixed;
+}
+
+/** Start the periodic sweep. Returns a stop function. */
+export function startStatusReconciler(deps: StatusReconcilerDeps): () => void {
+  const pendingStuck = deps.pendingStuck ?? new Set<string>();
+  const timer = setInterval(() => {
+    try {
+      sweepOnce({ ...deps, pendingStuck });
+    } catch (err) {
+      logger.warn(`[reconciler] sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, deps.intervalMs ?? DEFAULT_INTERVAL_MS);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -614,8 +614,14 @@ export class SessionManager {
           logger.warn(
             `Session ${session.id} hit a transient server error — retry ${i + 1}/${delays.length} in ${Math.round(delayMs / 1000)}s`,
           );
-          updateSession(session.id, { status: "running", lastActivity: new Date().toISOString() });
-          await new Promise((r) => setTimeout(r, delayMs));
+          // Chunked wait with a heartbeat: the status reconciler treats a
+          // "running" session with a stale lastActivity and no live engine turn
+          // as stuck — which is exactly what this backoff window looks like.
+          // Refreshing lastActivity every 20s keeps it out of the sweep.
+          for (let waited = 0; waited < delayMs; waited += 20_000) {
+            updateSession(session.id, { status: "running", lastActivity: new Date().toISOString() });
+            await new Promise((r) => setTimeout(r, Math.min(20_000, delayMs - waited)));
+          }
           const resumeId = result.sessionId?.trim() || session.engineSessionId || undefined;
           result = await engine.run({
             prompt:


### PR DESCRIPTION
## 背景

元リポジトリ hristo2612/jinn の進化を調査（6月だけで405コミット、v0.18→v0.23.3）。インタラクティブエンジンの安定性について upstream が実戦投入済みの4機構を、本フォークの構成（ryoko命名・トリアージ・reply-disposition・2026.7.2の耐障害性修正）に適合させて移植した。

## 移植内容

1. **StopFailure grace window（20秒）** — `server_error`/`unknown` 系は即失敗確定せず保留。CLIが自力リトライして完走すれば後続Stopが成功で上書き / フック・SSE活動で再アーム / **サブエージェントのリクエストがin-flightの間は確定延期**（= upstream 0.23.0「subagent StopFailureが親ターンを誤失敗させる」修正）。`rate_limit`/`billing`/`auth`/`max_output_tokens` は即確定のまま。2026.7.2 の transient retry は「真の失敗」の回復として併存
2. **Lost-Stop recovery** — Stopフック消失時（relay障害等）、5分経過+60秒静穏+ツール/API非実行を条件にtranscriptから最終メッセージを復元してターン成功確定。空結果ターンのtranscriptバックフィルも追加
3. **status-reconciler** — running のままスタックしたセッションを15秒スイープ・2回連続確認でidleに自動復旧。transient retry のバックオフ待機に20秒ハートビートを追加して誤検知を防止
4. **ネイティブコマンド処理** — `/compact` 等（Stop非発火→静穏ウィンドウで確定）、`/usage` 等（Stopが前ターンテキストを搬送→空で確定、重複エコー防止）

付随: 思考ブロック漏れの除去（stripReasoningBlocks）、bracketed-paste CR 50→150ms。

## テスト

- `packages/jimmy`: **562 tests pass**（新規23件: grace保留/Stop上書き/再アーム/in-flight延期/即確定系、transcript復元ヘルパー、reconciler 2スイープ確定・ターン境界レース、ネイティブコマンド判定）
- 実機 (ryoko-wsl) に 2026.7.4 としてデプロイ済み・正常稼働確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)