### PR TITLE
feat(models): Claude Opus 5 対応 — 既定モデルを claude-opus-5 に更新（2026.7.25）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.7.25] - 2026-07-25
+
+### Features
+- **Claude Opus 5 対応（`claude-opus-5`）**: Claude 既定モデルを `opus`（裸エイリアス）→ `claude-opus-5`（明示 ID）に更新（config-patch 同梱、カスタム値は保護・冪等）。裸の `opus` エイリアスはインストール済み Claude CLI が知る最新 Opus 止まりで、CLI が古いと Opus 4.8 に留まるため、明示 ID に統一（Codex の `gpt-5.6-sol` 統一と同じ方針）。Opus 5 は Opus 4.8 と同額（$5/$25 per MTok）・1M コンテキスト・128K 出力・effort 全レベル（low〜max）対応。設定画面の Claude モデル選択肢に Opus 5（既定）/ Opus 4.8（ピン留め用）/ opus（CLI 自動追従）を追加。`claudeSupportsXhigh` は既存の `opus-5` パターンで対応済みのためコード変更なし。
+- **コスト価格表の修正**: Opus 5 の価格（$5/$25）を追加し、Opus 4.8/4.7/4.6 の誤った旧値（$15/$75 = Opus 4.1 世代の価格）を公式価格 $5/$25 に修正。
+
 ## [2026.7.10] - 2026-07-10
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ engines:
   default: claude
   claude:
     bin: claude
-    model: opus            # opus エイリアスは最新 Opus（claude-opus-4-8）に解決
+    model: claude-opus-5   # Opus 5 明示 ID（裸の opus エイリアスは CLI が知る最新 Opus 止まり）
     effortLevel: medium
     interactive: false     # true で対話モード(PTY)起動 → 6/15改定後も通常サブスク枠で動く
   codex:

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.7.10",
+  "version": "2026.7.25",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/cli/setup.ts
+++ b/packages/jimmy/src/cli/setup.ts
@@ -239,7 +239,7 @@ engines:
   default: claude
   claude:
     bin: claude
-    model: opus
+    model: claude-opus-5
     effortLevel: xhigh
   codex:
     bin: codex

--- a/packages/jimmy/src/shared/__tests__/models.test.ts
+++ b/packages/jimmy/src/shared/__tests__/models.test.ts
@@ -46,6 +46,7 @@ describe("synthesizeFromEngineConfig (backward-compat fallback)", () => {
     expect(levelsFor("opus")).toContain("xhigh");
     expect(levelsFor("sonnet")).toContain("xhigh");
     // explicit capable ids
+    expect(levelsFor("claude-opus-5")).toContain("xhigh");
     expect(levelsFor("claude-opus-4-8")).toContain("xhigh");
     expect(levelsFor("claude-opus-4-7")).toContain("xhigh");
     expect(levelsFor("claude-sonnet-5")).toContain("xhigh");

--- a/packages/jimmy/src/shared/models.ts
+++ b/packages/jimmy/src/shared/models.ts
@@ -27,7 +27,7 @@ const EFFORT_MECHANISM: Record<EngineName, EffortMechanism> = {
 
 /** Conservative per-engine defaults used when synthesizing (no `models:` block). */
 const SYNTH_DEFAULTS: Record<EngineName, { supportsEffort: boolean; effortLevels: string[]; fallbackModel: string }> = {
-  claude: { supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"], fallbackModel: "opus" },
+  claude: { supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"], fallbackModel: "claude-opus-5" },
   codex: { supportsEffort: true, effortLevels: ["low", "medium", "high", "xhigh"], fallbackModel: "gpt-5.6-sol" },
   gemini: { supportsEffort: false, effortLevels: [], fallbackModel: "gemini-2.5-pro" },
 };

--- a/packages/jimmy/template/CLAUDE.md
+++ b/packages/jimmy/template/CLAUDE.md
@@ -270,7 +270,7 @@ provides:                    # オプション — この従業員が組織に�
   "schedule": "0 9 * * 1-5",
   "timezone": "Asia/Tokyo",
   "engine": "claude",
-  "model": "opus",
+  "model": "claude-opus-5",
   "employee": "従業員名 or null",
   "prompt": "実行する指示",
   "delivery": {

--- a/packages/jimmy/template/config.default.yaml
+++ b/packages/jimmy/template/config.default.yaml
@@ -9,7 +9,10 @@ engines:
   default: claude
   claude:
     bin: claude
-    model: opus
+    # Opus 5 の明示 ID。裸の "opus" エイリアスはインストール済み Claude CLI が
+    # 知っている最新 Opus に解決されるため、CLI が古いと旧世代（4.8 等）に留まる。
+    # 明示 ID は API パススルーなので CLI バージョンに関係なく Opus 5 が使われる。
+    model: claude-opus-5
     effortLevel: xhigh
     # Interactive PTY mode (opt-in). When true, Claude work turns run as an
     # interactive PTY (cc_entrypoint=cli) which bills against the Max subscription

--- a/packages/jimmy/template/migrations/2026.7.25/MIGRATION.md
+++ b/packages/jimmy/template/migrations/2026.7.25/MIGRATION.md
@@ -1,0 +1,69 @@
+# Migration: 2026.7.25 (Claude Opus 5 対応 / Claude 既定モデル claude-opus-5)
+
+## Summary
+
+Anthropic **Claude Opus 5**（2026-07-24 発表、モデル ID `claude-opus-5`）に対応する。
+
+1. **Claude 既定モデルを `opus`（裸エイリアス）→ `claude-opus-5`（明示 ID）に変更** — 新規セットアップと、旧デフォルトのままの既存インスタンス（config-patch）に反映
+2. **設定画面の Claude モデル選択肢を刷新** — `claude-opus-5`（既定）/ `claude-opus-4-8`（ピン留め用）/ `opus`（CLI 自動追従）/ `sonnet` / `haiku`
+3. **コストダッシュボードの価格表に Opus 5（$5/$25 per MTok）を追加** — あわせて Opus 4.8/4.7/4.6 の誤った旧値（$15/$75 = Opus 4.1 世代の価格）を公式価格 $5/$25 に修正
+
+> **互換性メモ**: config.yaml の version key は **`jinn.version` のまま**。
+
+## Claude Opus 5 について（2026-07-25 公式 docs 確認）
+
+| 項目 | 値 |
+|---|---|
+| モデル ID | `claude-opus-5`（日付サフィックスなしの固定 ID、Opus 4.8 と同じ命名規則） |
+| 価格 | $5 / MTok 入力・$25 / MTok 出力（**Opus 4.8 と同額**） |
+| コンテキスト | 1M トークン / 最大出力 128K |
+| effort | `low` / `medium` / `high`（既定）/ `xhigh` / `max` すべて対応 |
+| thinking | 未指定なら adaptive thinking が**デフォルトで有効**（4.8 は無効だった） |
+
+> **⚠️ 裸の `opus` エイリアスではなく明示 ID を使う理由**: `opus` は「インストール済み
+> Claude CLI が知っている最新 Opus」に解決されるため、CLI が古いと 4.8 等の旧世代に
+> 留まる。明示 ID は API パススルーなので CLI バージョンに関係なく Opus 5 が使われる。
+> Codex の `gpt-5.6-sol` 明示 ID 統一（2026.7.10）と同じ方針。
+
+> **API 直叩き実装者向けの注意**（gateway は Claude CLI 経由なので影響なし）:
+> Opus 5 では `thinking: {type: "disabled"}` + effort `xhigh`/`max` の組み合わせが
+> 400 になる（4.8 は許容していた）。gateway は thinking を無効化しないため非該当。
+
+## このマイグレーションが行う config 変更
+
+`config-patch.json`:
+
+```json
+[{ "path": "engines.claude.model", "from": "opus", "to": "claude-opus-5" }]
+```
+
+- `engines.claude.model` が **`opus`（旧デフォルト）または未設定**のユーザー → `claude-opus-5` に自動更新
+- 別モデルに**カスタム済み**のユーザー（例: `claude-opus-4-8` をピン留め）→ そのまま（変更されない）
+
+冪等。適用セマンティクスの詳細は [configPatch.ts](../../src/shared/configPatch.ts) を参照。
+
+## Template files changed（新規セットアップ向け、既存ユーザーの config 値には影響なし）
+
+| ファイル | 変更 |
+|---|---|
+| `template/config.default.yaml` | `engines.claude.model: opus → claude-opus-5` |
+| `packages/jimmy/src/shared/models.ts` | synth 既定 fallback `opus → claude-opus-5`（`claudeSupportsXhigh` は既に `opus-5` パターン対応済みでコード変更なし） |
+| `packages/jimmy/src/cli/setup.ts` | フォールバック設定テンプレートの claude model を `claude-opus-5` に |
+| `template/CLAUDE.md` | cron ジョブ例の model を `claude-opus-5` に |
+| `packages/web`（コンパイル済み UI） | Claude モデル選択肢に Opus 5 を追加（既定）、cron 作成 UI 初期値を `claude-opus-5` に、価格表を更新 |
+
+これらは新規 `ryoko setup` にのみ適用。既存ユーザーの config 値は上記 config-patch が担当する。
+
+## Merge instructions
+
+### 1. Config（自動）
+
+`ryoko update` / `ryoko migrate --auto` が config-patch を自動適用し、`jinn.version` を `"2026.7.25"` に更新する。手動操作は不要。
+
+### 2. Gateway 再起動
+
+モデル定義の反映のため gateway を再起動（`ryoko update --restart` なら自動）。
+
+## Breaking changes
+
+なし。config-patch はカスタム値を保護する。既定が `claude-opus-5` になるのは旧デフォルト（`opus`）のままだったユーザーのみ。既存 cron ジョブの `"model": "opus"` はエイリアスとして引き続き動作する。

--- a/packages/jimmy/template/migrations/2026.7.25/config-patch.json
+++ b/packages/jimmy/template/migrations/2026.7.25/config-patch.json
@@ -1,0 +1,3 @@
+[
+  { "path": "engines.claude.model", "from": "opus", "to": "claude-opus-5" }
+]

--- a/packages/web/src/app/org/page.tsx
+++ b/packages/web/src/app/org/page.tsx
@@ -48,7 +48,7 @@ export default function OrgPage() {
           department: "",
           rank: "executive",
           engine: "claude",
-          model: "opus",
+          model: "claude-opus-5",
           persona: "COO and AI gateway daemon",
         };
         setEmployees([coo, ...data.employees]);

--- a/packages/web/src/lib/__tests__/model-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/model-catalog.test.ts
@@ -9,11 +9,17 @@ import {
 } from "@/lib/model-catalog"
 
 describe("model-catalog", () => {
-  it("defaults Codex to GPT-5.6 (Sol) and Claude to opus", () => {
+  it("defaults Codex to GPT-5.6 (Sol) and Claude to Opus 5 (explicit id)", () => {
     expect(DEFAULT_CODEX_MODEL).toBe("gpt-5.6-sol")
-    expect(DEFAULT_CLAUDE_MODEL).toBe("opus")
+    expect(DEFAULT_CLAUDE_MODEL).toBe("claude-opus-5")
     expect(OPENAI_MODELS[0].value).toBe("gpt-5.6-sol")
+    expect(CLAUDE_MODELS[0].value).toBe("claude-opus-5")
     expect(CLAUDE_MODELS.some((m) => m.value === DEFAULT_CLAUDE_MODEL)).toBe(true)
+  })
+
+  it("keeps Opus 4.8 pin and the bare opus alias selectable", () => {
+    const ids = CLAUDE_MODELS.map((m) => m.value)
+    expect(ids).toEqual(expect.arrayContaining(["claude-opus-4-8", "opus"]))
   })
 
   it("exposes the GPT-5.6 松竹梅 tiers (Sol / Terra / Luna)", () => {

--- a/packages/web/src/lib/costs.ts
+++ b/packages/web/src/lib/costs.ts
@@ -85,9 +85,12 @@ export interface CostSummary {
 // ── Pricing table (per 1M tokens) ────────────────────────────
 
 const PRICING: Record<string, ModelPricing> = {
-  'claude-opus-4-8':     { inputPer1M: 15, outputPer1M: 75 },
-  'claude-opus-4-7':     { inputPer1M: 15, outputPer1M: 75 },
-  'claude-opus-4-6':     { inputPer1M: 15, outputPer1M: 75 },
+  // Opus 5 / 4.8 / 4.7 / 4.6 はいずれも $5/$25 per MTok（Anthropic 公式 docs、
+  // 2026-07-25 確認。旧値 $15/$75 は Opus 4.1 世代の価格で誤りだった）。
+  'claude-opus-5':       { inputPer1M: 5, outputPer1M: 25 },
+  'claude-opus-4-8':     { inputPer1M: 5, outputPer1M: 25 },
+  'claude-opus-4-7':     { inputPer1M: 5, outputPer1M: 25 },
+  'claude-opus-4-6':     { inputPer1M: 5, outputPer1M: 25 },
   'claude-sonnet-5':     { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-6':   { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-5':   { inputPer1M: 3, outputPer1M: 15 },

--- a/packages/web/src/lib/model-catalog.ts
+++ b/packages/web/src/lib/model-catalog.ts
@@ -5,8 +5,11 @@
 // rather than a hunt through hardcoded <select> blocks.
 //
 // Values are the exact ids passed to each engine's CLI:
-//   - Claude: the bare tier aliases (`opus`/`sonnet`/`haiku`) resolve to the
-//     latest model of that tier at run time.
+//   - Claude: Opus は明示 ID `claude-opus-5` を既定にする。裸の `opus`
+//     エイリアスは「インストール済み Claude CLI が知っている最新 Opus」に
+//     解決されるため、CLI が古いと旧世代（4.8 等）に留まる。明示 ID なら
+//     CLI バージョンに関係なく Opus 5 が使われる（ID は API パススルー）。
+//     `sonnet`/`haiku` の裸エイリアスは従来どおり最新ティアに解決。
 //   - OpenAI (Codex): GPT-5.6 ships three durable capability tiers —
 //     Sol (上 / flagship), Terra (中 / balanced), Luna (小 / fastest & cheapest).
 //     Always use the explicit tier ids (`gpt-5.6-sol` etc.): the bare
@@ -20,12 +23,14 @@ export interface ModelOption {
 }
 
 /** Default model id for each engine, mirrored by the backend synth defaults. */
-export const DEFAULT_CLAUDE_MODEL = "opus"
+export const DEFAULT_CLAUDE_MODEL = "claude-opus-5"
 export const DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
 
-/** Anthropic tiers. Bare aliases resolve to the latest model of each tier. */
+/** Anthropic tiers. Opus は明示 ID（CLI 版数に依存しない）、他は裸エイリアス。 */
 export const CLAUDE_MODELS: ModelOption[] = [
-  { value: "opus", label: "Opus 4.8 — 上（最上位 / claude-opus-4-8）" },
+  { value: "claude-opus-5", label: "Opus 5 — 上（最上位 / 既定 / claude-opus-5）" },
+  { value: "claude-opus-4-8", label: "Opus 4.8 — 旧世代（ピン留め用 / claude-opus-4-8）" },
+  { value: "opus", label: "Opus — CLI が解決する最新 Opus に自動追従" },
   { value: "sonnet", label: "Sonnet 5 — 中（バランス / claude-sonnet-5）" },
   { value: "haiku", label: "Haiku 4.5 — 小（軽量・高速 / claude-haiku-4-5）" },
 ]


### PR DESCRIPTION
## Summary
- Anthropic **Claude Opus 5**（2026-07-24 発表、ID `claude-opus-5`、$5/$25 per MTok、1M ctx / 128K out、effort low〜max 全対応）に対応
- Claude 既定モデルを `opus`（裸エイリアス）→ `claude-opus-5`（明示 ID）に変更。裸の `opus` はインストール済み Claude CLI が知る最新 Opus 止まりで、CLI が古いと 4.8 に留まるため、Codex の `gpt-5.6-sol` 統一（2026.7.10）と同じ明示 ID 方針に統一
- migration `2026.7.25` の config-patch 同梱: `engines.claude.model` が `opus`（旧デフォルト）または未設定の既存インスタンスのみ自動更新（カスタム値は保護・冪等）
- 設定 UI の Claude モデル選択肢を刷新: Opus 5（既定）/ Opus 4.8（ピン留め用）/ opus（CLI 自動追従）/ sonnet / haiku
- cron 既定値（org UI・template/CLAUDE.md 例）・setup フォールバックテンプレートも `claude-opus-5` に
- コスト価格表: Opus 5 追加＋ Opus 4.8/4.7/4.6 の誤価格（$15/$75 = Opus 4.1 世代の値）を公式 $5/$25 に修正
- `claudeSupportsXhigh` は既存の `opus-5` 正規表現で対応済みのためコード変更なし

## Test plan
- [x] jimmy 全テスト green（562+）
- [x] web lib テスト green（model-catalog の既定値・選択肢を更新）
- [x] `npm pack` で `template/migrations/2026.7.25/` と新 UI チャンク（claude-opus-5 含有）の同梱を確認
- [x] `claude -p --model claude-opus-5` の実応答をローカル CLI で確認
- [ ] publish 後、openclaw-sandbox イメージ再ビルドで実機反映（Dockerfile `OPENRYOKO_VERSION` bump）