### PR TITLE
test(engines): PTY レーステストの claude-oauth-gate 依存を解消

### DIFF
--- a/packages/jimmy/src/engines/__tests__/claude-interactive-race.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude-interactive-race.test.ts
@@ -52,6 +52,16 @@ vi.mock("../sse-pty-proxy.js", () => ({
 vi.mock("../shared/claude-settings.js", () => ({
   writeSessionSettings: () => "/tmp/fake-settings.json",
 }));
+// spawn() awaits the shared-OAuth refresh gate before pty.spawn(). Unmocked, it
+// reads the real ~/.claude/.credentials.json — and when that token is within 90s
+// of expiry (or expired), the gate serializes the spawn herd: the first spawn
+// leads and opens a 25s refresh window that blocks every later spawn, so
+// pty.spawn() is never reached within the test's 15ms flush and ptys[] stays
+// empty. These tests exercise the PTY lifecycle, not the OAuth gate — stub it to
+// resolve instantly so they don't depend on the runner's real credential state.
+vi.mock("../../shared/claude-oauth-gate.js", () => ({
+  awaitFreshClaudeCredentials: async () => {},
+}));
 
 import { InteractiveClaudeEngine } from "../claude-interactive.js";
 import { PtyLifecycleManager } from "../pty-lifecycle.js";


### PR DESCRIPTION
## 背景
`claude-interactive-race.test.ts` の5件が、実行マシンの実 `~/.claude/.credentials.json` の状態に依存して落ちていた（トークン期限切れの mac で再現、有効トークンの環境では通る）。

## 根本原因
`InteractiveClaudeEngine.spawn()` は `pty.spawn` の前に `awaitFreshClaudeCredentials()`（共有OAuthリフレッシュゲート）を await する。実トークンが期限切れ間近（`NEAR_EXPIRY_MS` = 90秒）以内だと spawn を直列化: 最初の spawn がリーダーとして即 return しつつ25秒の refresh window を開き、後続 spawn はフォロワーとして最大25秒ブロックされる。テストの 15ms flush 内に `pty.spawn` へ到達せず `ptys[]` が空になり、`expected undefined to be defined` / timeout で落ちていた。プロダクションのバグではなくテスト分離の欠陥。

## 修正
テストで `../../shared/claude-oauth-gate.js` をモックし `awaitFreshClaudeCredentials` を即解決させる（node-pty / sse-pty-proxy / claude-settings と同じ扱い）。プロダクション挙動は不変。

## Test plan
- [x] 対象5件が green（実行時間 5s → 0.3s）
- [x] jimmy 全スイート 602/602 green