### PR TITLE
fix(context): バックグラウンドタスクがターン終了で消えることを system prompt で警告する

### DIFF
--- a/packages/jimmy/src/sessions/__tests__/context-long-running.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/context-long-running.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// paths.ts resolves the home once at import time, so the temp home has to be in
+// place before the context module (and the registry it pulls in) is imported.
+const HOME = mkdtempSync(path.join(tmpdir(), "ryoko-longrun-"));
+process.env.RYOKO_HOME = HOME;
+
+type Context = typeof import("../context.js");
+let context: Context;
+
+beforeAll(async () => {
+  context = await import("../context.js");
+});
+
+const build = (extra: Partial<Parameters<Context["buildContext"]>[0]> = {}) =>
+  context.buildContext({
+    source: "slack",
+    channel: "C_TEST",
+    user: "U_TEST",
+    ...extra,
+  });
+
+describe("long-running work section", () => {
+  it("warns that background tasks do not survive the turn", () => {
+    const prompt = build();
+    expect(prompt).toContain("## Long-running work");
+    expect(prompt).toContain("Background tasks do NOT survive the end of a turn");
+  });
+
+  it("gives a concrete way to detach work that outlives the turn", () => {
+    expect(build()).toContain("setsid nohup");
+  });
+
+  it("is present for employees too, not just the COO", () => {
+    const prompt = build({
+      employee: {
+        name: "tako",
+        displayName: "タコ",
+        persona: "advisor",
+        department: "advisory",
+        rank: "senior",
+      } as Parameters<Context["buildContext"]>[0]["employee"],
+    });
+    expect(prompt).toContain("## Long-running work");
+  });
+
+  it("keeps the warning when the budget forces every trimmable section to its summary", () => {
+    // maxChars=1 drives trimContext through the full OPTIONAL → STANDARD pass,
+    // so the section survives only if its summary carries the warning too.
+    const prompt = build({
+      config: {
+        gateway: { host: "127.0.0.1", port: 7777 },
+        engines: { default: "claude" },
+        context: { maxChars: 1 },
+      } as Parameters<Context["buildContext"]>[0]["config"],
+    });
+    expect(prompt).toContain("## Long-running work");
+    expect(prompt).toContain("killed when the turn ends");
+  });
+});

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -242,6 +242,14 @@ export function buildContext(opts: {
     summary: `## ${portalName} Gateway API (${gatewayUrl})\nEndpoints: /api/status, /api/sessions, /api/cron, /api/org, /api/skills, /api/config, /api/connectors, /api/logs`,
   });
 
+  // ── STANDARD: Long-running work ─────────────────────────────
+  sections.push({
+    tier: Tier.STANDARD,
+    marker: "## Long-running work",
+    content: buildLongRunningWorkContext(),
+    summary: LONG_RUNNING_WORK_SUMMARY,
+  });
+
   // ── Assemble with progressive trimming by tier ──────────────
   return trimContext(sections, maxChars);
 }
@@ -887,6 +895,36 @@ You can call these endpoints with curl to inspect and manage the gateway:
 | \`/api/connectors\` | GET | List connectors |
 | \`/api/connectors/:name/send\` | POST | Proactively send to a different connector conversation; never use it to reply to the current conversation |
 | \`/api/logs\` | GET | Recent log lines |`;
+}
+
+const LONG_RUNNING_WORK_SUMMARY = `## Long-running work
+Background shell tasks are killed when the turn ends — the engine runs one-shot and its whole process group dies with it. Detach anything longer than the turn with \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 < /dev/null &\` and check the log on a later turn. Never promise "I'll report back when it finishes" for a plain background task.`;
+
+/**
+ * Warn the agent that background work does not outlive the turn.
+ *
+ * The engine is spawned one-shot per turn as a process-group leader (see
+ * `ClaudeEngine.runOnce`), and the group is torn down once the final answer is
+ * emitted. Anything the agent launched in the background — a large download,
+ * a build, a render — dies at that moment with no error and no notification,
+ * so the agent happily reports "running, I'll follow up" for work that has
+ * already been killed. Telling it the rule up front is the cheap fix.
+ */
+function buildLongRunningWorkContext(): string {
+  return `## Long-running work
+
+**Background tasks do NOT survive the end of a turn.** Each turn runs the engine as a one-shot process that leads its own process group. The moment you emit your final answer, that process group is terminated — a background shell task still running at that point is killed silently: no error, no notification, and the next turn sees only whatever it managed to leave on disk.
+
+Consequences:
+- **Never** say "it's running, I'll report back when it finishes" about a plain background task. It will not finish.
+- Work that completes within the turn: run it in the foreground and wait for it.
+- Work that outlives the turn (large downloads/uploads, long builds, media renders): detach it from the process group and pick it up later:
+  \`\`\`bash
+  setsid nohup <cmd> > /tmp/<job>.log 2>&1 < /dev/null &
+  \`\`\`
+  Then tell the user it is running, and read \`/tmp/<job>.log\` on a later turn (or schedule a cron job to finish and report).
+- Make detached jobs **resumable and idempotent**: download to a temp path, verify the result, and only then clean up. A job killed mid-flight must not discard completed work or leave a half-finished artifact behind.
+- If a previous turn started something, check whether it actually finished before reporting success — verify the end state (the uploaded file, the built artifact), not just the absence of an error.`;
 }
 
 /**


### PR DESCRIPTION
Fixes #38

## 何を直すか

エンジンはターンごとに one-shot で spawn され、`detached: true` で自分のプロセスグループのリーダーになる（`engines/claude.ts:284-288`）。最終回答を出した瞬間にそのプロセスが終了し、走行中のバックグラウンドシェルタスクも道連れになる。`kill()` / `killAll()` も `process.kill(-pid, …)` でグループごと落とす。

**エージェントはこの挙動を知らされていない。** 対話 CLI ではバックグラウンドタスクがターンをまたいで生き残るので、その経験則のまま「実行中です、終わったら報告します」と言い、ジョブは無言で死ぬ。エラーも通知も残らないので誤報告に気づけない（実例は #38）。

## 変更内容

`buildContext` に `## Long-running work` セクション（STANDARD tier）を追加し、ルールを先に伝える:

- 素のバックグラウンドタスクに「後で報告します」と**言わない**
- ターン内で終わる仕事はフォアグラウンドで待つ
- ターンを越える仕事は切り離す: `setsid nohup <cmd> > /tmp/<job>.log 2>&1 < /dev/null &` → 次のターンでログを読む（または cron に投げる）
- 切り離したジョブは resumable / idempotent に。一時パスに書く → 検証する → **その後で**後片付け
- 前のターンが始めた仕事は、成功と報告する前に最終状態（アップロード済みファイル、生成物）を検証する

## 設計判断

- **tier は STANDARD** — ESSENTIAL ほど常時必須ではないが、OPTIONAL（環境スキャンや委任プロトコル）より先に落ちてはいけない。
- **summary にも警告本体を残す** — 予算逼迫で summary に落ちても「バックグラウンドはターン終了で死ぬ」「`setsid nohup` で切り離す」は消えない。テストで担保している。
- **プロンプト側の対処に留めた** — エンジン側で残存プロセスを検出して通知する案 (B)、正式な detached job runner (C) は挙動変更が大きいので #38 で別途。まず一番安い層を塞ぐ。

## テスト

`packages/jimmy/src/sessions/__tests__/context-long-running.test.ts` を追加（4ケース）:

- 警告文が system prompt に入る
- `setsid nohup` の具体手順が入る
- employee セッションでも入る（COO 限定にしない）
- `maxChars: 1` で全 trimmable セクションが summary に落ちても警告が残る

検証:

```
$ npm run typecheck   # クリーン
$ npx vitest run      # 59 files / 606 tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)