### PR TITLE
fix(sessions): バックグラウンドタスクの寿命を system prompt で警告 (#38)

### DIFF
--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -2275,6 +2275,14 @@ async function runWebSession(
       connectors: Array.from(context.connectors.keys()),
       config,
       sessionId: currentSession.id,
+      // Interactive PTY survives across turns; everything else is a one-shot
+      // process whose background tasks die at turn end (#38).
+      processLifetime:
+        currentSession.engine === "claude" &&
+        config.engines.claude?.interactive === true &&
+        !employee?.sshHost
+          ? "persistent"
+          : "one-shot",
       hierarchy: orgHierarchy,
     });
 

--- a/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
@@ -11,38 +11,57 @@ describe("buildContext — process lifetime section", () => {
     user: "U123",
   };
 
-  it("includes the process lifetime warning as an essential section", () => {
+  const stubConfig = {
+    jinn: { version: "0.0.0" },
+    gateway: { port: 7777, host: "127.0.0.1" },
+    engines: {
+      default: "claude",
+      claude: { bin: "claude", model: "" },
+      codex: { bin: "codex", model: "" },
+    },
+    connectors: {},
+    logging: { level: "info", stdout: false, file: "" },
+  };
+
+  it("warns about one-shot process death by default", () => {
     const ctx = buildContext(baseOpts);
     expect(ctx).toContain("## Process lifetime");
     expect(ctx).toContain("background tasks die when your turn ends");
+    expect(ctx).toContain("Your process is one-shot");
+  });
+
+  it("gives OS-specific detach commands (setsid is Linux-only)", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toContain("setsid nohup");
+    expect(ctx).toMatch(/macOS/);
+    expect(ctx).toMatch(/disown/);
+  });
+
+  it("says the agent cannot be woken up and must verify before reporting done", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toContain("You will NOT be notified");
+    expect(ctx).toMatch(/never claim completion you have not verified/i);
+  });
+
+  it("does not claim one-shot death for persistent (interactive PTY) sessions", () => {
+    const ctx = buildContext({ ...baseOpts, processLifetime: "persistent" });
+    expect(ctx).not.toContain("Your process is one-shot");
+    expect(ctx).toContain("## Process lifetime");
+    expect(ctx).toContain("persistent interactive process");
+    // Detach guidance still applies: the PTY dies with the session/gateway.
     expect(ctx).toContain("setsid nohup");
   });
 
-  it("tells the agent to verify detached jobs via logfile in a later turn", () => {
-    const ctx = buildContext(baseOpts);
-    expect(ctx).toMatch(/LATER turn/);
-    expect(ctx).toMatch(/logfile/i);
-  });
-
-  it("survives aggressive trimming (essential tier is never dropped)", () => {
-    const stubConfig = {
-      jinn: { version: "0.0.0" },
-      gateway: { port: 7777, host: "127.0.0.1" },
-      engines: {
-        default: "claude",
-        claude: { bin: "claude", model: "" },
-        codex: { bin: "codex", model: "" },
-      },
-      connectors: {},
-      logging: { level: "info", stdout: false, file: "" },
-      context: { maxChars: 4000 },
-    };
+  it("is essential tier: full content survives trimming that summarizes standard sections", () => {
     const ctx = buildContext({
       ...baseOpts,
-      config: stubConfig as never,
+      config: { ...stubConfig, context: { maxChars: 2000 } } as never,
       connectors: ["slack"],
     });
-    expect(ctx.length).toBeGreaterThan(0);
-    expect(ctx).toContain("## Process lifetime");
+    // A standard-tier section (connectors) collapsed to its summary…
+    expect(ctx).not.toContain("**Send message**");
+    // …while the full lifetime warning (this phrase is absent from any
+    // summary) must remain intact.
+    expect(ctx).toContain("NEVER start a plain background job");
   });
 });

--- a/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { buildContext } from "../context.js";
+
+// Issue #38: background tasks are killed with the one-shot engine process when
+// the turn ends. The agent must be told this up front (option A), otherwise it
+// confidently promises "I'll report back later" and the job dies silently.
+describe("buildContext — process lifetime section", () => {
+  const baseOpts = {
+    source: "slack",
+    channel: "C123",
+    user: "U123",
+  };
+
+  it("includes the process lifetime warning as an essential section", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toContain("## Process lifetime");
+    expect(ctx).toContain("background tasks die when your turn ends");
+    expect(ctx).toContain("setsid nohup");
+  });
+
+  it("tells the agent to verify detached jobs via logfile in a later turn", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toMatch(/LATER turn/);
+    expect(ctx).toMatch(/logfile/i);
+  });
+
+  it("survives aggressive trimming (essential tier is never dropped)", () => {
+    const stubConfig = {
+      jinn: { version: "0.0.0" },
+      gateway: { port: 7777, host: "127.0.0.1" },
+      engines: {
+        default: "claude",
+        claude: { bin: "claude", model: "" },
+        codex: { bin: "codex", model: "" },
+      },
+      connectors: {},
+      logging: { level: "info", stdout: false, file: "" },
+      context: { maxChars: 4000 },
+    };
+    const ctx = buildContext({
+      ...baseOpts,
+      config: stubConfig as never,
+      connectors: ["slack"],
+    });
+    expect(ctx.length).toBeGreaterThan(0);
+    expect(ctx).toContain("## Process lifetime");
+  });
+});

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -137,6 +137,14 @@ export function buildContext(opts: {
     summary: "", // always included, no trimming
   });
 
+  // ── ESSENTIAL: Process lifetime (background tasks die at turn end) ──
+  sections.push({
+    tier: Tier.ESSENTIAL,
+    marker: "## Process lifetime",
+    content: buildProcessLifetimeContext(),
+    summary: "## Process lifetime\nBackground tasks are killed when your turn ends. Detach long jobs with `setsid nohup <cmd> > <logfile> 2>&1 &` and verify via the logfile in a later turn.",
+  });
+
   // ── ESSENTIAL: Configuration awareness ──────────────────────
   if (opts.config) {
     sections.push({
@@ -642,6 +650,20 @@ function buildKnowledgeContext(): string | null {
   }
 
   return lines.join("\n");
+}
+
+function buildProcessLifetimeContext(): string {
+  return [
+    `## Process lifetime (background tasks die when your turn ends)`,
+    `Your process is one-shot: it is spawned for this turn and exits as soon as you deliver your final answer. Anything you started in the background (\`&\`, run_in_background Bash tasks) lives in the SAME process group and is killed with it — silently, with no error and no notification.`,
+    ``,
+    `- NEVER start a background job and reply "I'll report back when it's done" — the job dies the moment your turn ends, and nobody is told. This is different from an interactive CLI, where the CLI outlives the turn.`,
+    `- If a job fits within this turn, run it in the FOREGROUND and wait for it to finish before answering.`,
+    `- If a job must outlive the turn, fully detach it from your process group and capture its output:`,
+    `  \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 &\``,
+    `  Then tell the user it is running detached, and in a LATER turn verify by reading the logfile and checking the expected artifact (uploaded file, build output, etc.).`,
+    `- Never report a detached job as done without verifying the artifact. If the logfile is missing or incomplete, say so.`,
+  ].join("\n");
 }
 
 function buildConnectorContext(connectors: string[], gatewayUrl: string, portalName: string): string {

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -71,6 +71,13 @@ export function buildContext(opts: {
   speakerIsBot?: boolean;
   /** Speaker's IANA timezone */
   speakerTz?: string;
+  /**
+   * How the engine process for this turn lives. "one-shot" (default): a fresh
+   * process is spawned per turn and exits — with its whole process group —
+   * when the final answer is delivered. "persistent": an interactive PTY that
+   * survives across turns (config.engines.claude.interactive, local only).
+   */
+  processLifetime?: "one-shot" | "persistent";
   hierarchy?: import("../shared/types.js").OrgHierarchy;
 }): string {
   const maxChars = opts.config?.context?.maxChars ?? DEFAULT_MAX_CONTEXT_CHARS;
@@ -137,12 +144,12 @@ export function buildContext(opts: {
     summary: "", // always included, no trimming
   });
 
-  // ── ESSENTIAL: Process lifetime (background tasks die at turn end) ──
+  // ── ESSENTIAL: Process lifetime (background tasks die with the process) ──
   sections.push({
     tier: Tier.ESSENTIAL,
     marker: "## Process lifetime",
-    content: buildProcessLifetimeContext(),
-    summary: "## Process lifetime\nBackground tasks are killed when your turn ends. Detach long jobs with `setsid nohup <cmd> > <logfile> 2>&1 &` and verify via the logfile in a later turn.",
+    content: buildProcessLifetimeContext(opts.processLifetime !== "persistent"),
+    summary: "", // always included
   });
 
   // ── ESSENTIAL: Configuration awareness ──────────────────────
@@ -652,17 +659,33 @@ function buildKnowledgeContext(): string | null {
   return lines.join("\n");
 }
 
-function buildProcessLifetimeContext(): string {
+function buildProcessLifetimeContext(oneShot: boolean): string {
+  const detachAndVerify = [
+    `- To detach a job so it survives, escape your process group and capture output:`,
+    `  - Linux: \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 &\``,
+    `  - macOS (no \`setsid\`): \`nohup <cmd> > /tmp/<job>.log 2>&1 &\` then \`disown\` (survives normal exit, but not a forced kill of the process group)`,
+    `  - Check \`command -v setsid\` when unsure which applies.`,
+    `- You will NOT be notified when a detached job finishes — you cannot wake yourself up. Either ask the user to check back later, or register a cron job (gateway \`/api/cron\`) to follow up.`,
+    `- Verify BEFORE reporting done: read the logfile and check the expected artifact (uploaded file, build output, etc.). If the logfile is missing or incomplete, say so — never claim completion you have not verified.`,
+  ];
+
+  if (!oneShot) {
+    return [
+      `## Process lifetime`,
+      `This session runs in a persistent interactive process: background tasks survive across turns, but they are killed when the session ends, times out, or the gateway restarts.`,
+      ``,
+      `- For a job that must survive session shutdown, detach it (below) instead of relying on a plain background task.`,
+      ...detachAndVerify,
+    ].join("\n");
+  }
+
   return [
     `## Process lifetime (background tasks die when your turn ends)`,
-    `Your process is one-shot: it is spawned for this turn and exits as soon as you deliver your final answer. Anything you started in the background (\`&\`, run_in_background Bash tasks) lives in the SAME process group and is killed with it — silently, with no error and no notification.`,
+    `Your process is one-shot: it is spawned for this turn and exits as soon as you deliver your final answer. Anything you started in the background (\`&\`, run_in_background Bash tasks) lives in the SAME process group and dies with it — silently, with no error and no notification.`,
     ``,
-    `- NEVER start a background job and reply "I'll report back when it's done" — the job dies the moment your turn ends, and nobody is told. This is different from an interactive CLI, where the CLI outlives the turn.`,
+    `- NEVER start a plain background job and reply "I'll report back when it's done" — the job dies the moment your turn ends, and nobody is told. This is different from an interactive CLI, where the CLI outlives the turn.`,
     `- If a job fits within this turn, run it in the FOREGROUND and wait for it to finish before answering.`,
-    `- If a job must outlive the turn, fully detach it from your process group and capture its output:`,
-    `  \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 &\``,
-    `  Then tell the user it is running detached, and in a LATER turn verify by reading the logfile and checking the expected artifact (uploaded file, build output, etc.).`,
-    `- Never report a detached job as done without verifying the artifact. If the logfile is missing or incomplete, say so.`,
+    ...detachAndVerify,
   ].join("\n");
 }
 

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -433,6 +433,15 @@ export class SessionManager {
         speakerSlackId: (meta.speakerSlackId as string) || undefined,
         speakerIsBot: (meta.speakerIsBot as boolean | null) ?? undefined,
         speakerTz: (meta.speakerTz as string) || undefined,
+        // Interactive PTY survives across turns; everything else (headless
+        // claude -p, codex, gemini, SSH fallback) is a one-shot process whose
+        // background tasks die at turn end (#38).
+        processLifetime:
+          session.engine === "claude" &&
+          this.config.engines.claude?.interactive === true &&
+          !employee?.sshHost
+            ? "persistent"
+            : "one-shot",
         hierarchy,
       });
 


### PR DESCRIPTION
Closes #38

## 概要

エンジンはターンごとに one-shot プロセスを spawn し、ターン終了時にプロセスグループごと終了する。Bash のバックグラウンドタスクも同じグループに入るため、「後で報告します」と返した長時間ジョブは無言で殺される（実例: 627MB の講義録画が Drive にアップロードされないまま消えた）。

Issue #38 の方針 **(A)**: `buildContext` に ESSENTIAL セクション `## Process lifetime` を追加し、エージェント自身に伝える。

## 変更内容

- **`processLifetime` (`one-shot` | `persistent`) を `buildContext` に追加**
  - one-shot（既定）: 「バックグラウンドタスクはターン終了で死ぬ。ターン内で終わる仕事はフォアグラウンドで待て」と警告
  - persistent: interactive PTY（`config.engines.claude.interactive`、ローカルのみ）はターンをまたぐため one-shot 断定はせず、セッション終了・gateway 再起動で死ぬ旨のみ注入。SSH employee は interactive 設定でも headless フォールバックのため one-shot 扱い
- **切り離し手順を OS 別に案内**: Linux は `setsid nohup ... > log 2>&1 &`、macOS（setsid なし）は `nohup ... & disown`
- **完了通知は来ないことを明記**: 自発的に次ターンを開始できない。ユーザーへの再確認依頼か cron (`/api/cron`) 登録を案内。ログと成果物を検証するまで完了報告しない

## レビュー

Codex によるレビュー2巡（[MUST FIX] 2件・[SHOULD] 2件をすべて反映し、2巡目で承認）。

## テスト

- [x] `context-process-lifetime.test.ts` 5件: one-shot 警告 / OS別コマンド / 通知不可の明記 / persistent 変種 / ESSENTIAL tier 検証（STANDARD が summary 化される小予算下で全文が残る）
- [x] `tsc --noEmit` パス
- [x] 全テスト: 既存の環境依存失敗5件（claude-interactive-race、`fix/oauth-gate-test-isolation` で修正中）を除きパス