### PR TITLE
fix(slack): sendMessage が target.thread を無視する非対称を解消 (#6)

### DIFF
--- a/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { SlackConnector } from "../index.js";
+import type { Target } from "../../../shared/types.js";
+
+// Issue #6: sendMessage silently dropped target.thread — a "thread reply"
+// sent through the proxy endpoint or MCP tool landed bare in the channel
+// while replyMessage honored the thread. Both paths must be symmetric.
+
+interface PostMessageArgs {
+  channel: string;
+  thread_ts?: string;
+  text: string;
+}
+
+function makeConnector() {
+  const postMessage = vi.fn(async (_args: PostMessageArgs) => ({ ts: "999.000" }));
+  const connector = Object.create(SlackConnector.prototype) as SlackConnector;
+  Object.assign(connector as unknown as Record<string, unknown>, {
+    app: { client: { chat: { postMessage } } },
+    conversations: { recordBotInitiatedThread: vi.fn() },
+    respondTo: undefined,
+    triageConfig: undefined,
+  });
+  return { connector, postMessage };
+}
+
+describe("SlackConnector.sendMessage — thread targeting (issue #6)", () => {
+  it("posts with thread_ts when target.thread is set", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", thread: "111.222" };
+
+    await connector.sendMessage(target, "reply text");
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C123",
+      thread_ts: "111.222",
+      text: "reply text",
+    });
+  });
+
+  it("posts to the channel root when no thread is given", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123" };
+
+    await connector.sendMessage(target, "root text");
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
+  });
+
+  it("ignores a blank thread value", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", thread: "  " };
+
+    await connector.sendMessage(target, "root text");
+
+    expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
+  });
+
+  it("keeps replyMessage behavior unchanged (thread || messageTs)", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", messageTs: "333.444" };
+
+    await connector.replyMessage(target, "reply text");
+
+    expect(postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C123",
+      thread_ts: "333.444",
+    });
+  });
+});

--- a/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
@@ -58,6 +58,24 @@ describe("SlackConnector.sendMessage — thread targeting (issue #6)", () => {
     expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
   });
 
+  it("trims a padded thread before sending it to Slack", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", thread: " 111.222 " };
+
+    await connector.sendMessage(target, "reply text");
+
+    expect(postMessage.mock.calls[0][0].thread_ts).toBe("111.222");
+  });
+
+  it("ignores a non-string thread from an untrusted payload", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target = { channel: "C123", thread: 123 } as unknown as Target;
+
+    await connector.sendMessage(target, "root text");
+
+    expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
+  });
+
   it("keeps replyMessage behavior unchanged (thread || messageTs)", async () => {
     const { connector, postMessage } = makeConnector();
     const target: Target = { channel: "C123", messageTs: "333.444" };

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -807,6 +807,13 @@ export class SlackConnector implements Connector {
 
   async sendMessage(target: Target, text: string): Promise<string | undefined> {
     if (!text || !text.trim()) return undefined;
+    // An explicit thread target must never be dropped: posting a "thread
+    // reply" without thread_ts lands it bare in the channel. Callers that
+    // reach sendMessage with a thread (proxy endpoint, MCP tool) get the
+    // same behavior as replyMessage.
+    if (target.thread && target.thread.trim()) {
+      return this.replyMessage(target, text);
+    }
     const chunks = formatResponse(text);
     let lastTs: string | undefined;
     for (const chunk of chunks) {

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -21,6 +21,7 @@ import {
   respondPolicyNeedsTracking,
 } from "./respond-policy.js";
 import { isOperatorSpeaker } from "../../shared/operator-match.js";
+import { explicitThread } from "../../shared/threading.js";
 import { ConversationTracker } from "./conversation-tracker.js";
 import { AgentsCanvasUpdater } from "./agents-canvas.js";
 import { extractGoalCondition, shouldExtractGoal } from "./goal-extractor.js";
@@ -811,8 +812,9 @@ export class SlackConnector implements Connector {
     // reply" without thread_ts lands it bare in the channel. Callers that
     // reach sendMessage with a thread (proxy endpoint, MCP tool) get the
     // same behavior as replyMessage.
-    if (target.thread && target.thread.trim()) {
-      return this.replyMessage(target, text);
+    const thread = explicitThread(target.thread);
+    if (thread) {
+      return this.replyMessage({ ...target, thread }, text);
     }
     const chunks = formatResponse(text);
     let lastTs: string | undefined;

--- a/packages/jimmy/src/gateway/__tests__/connector-proxy-send.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/connector-proxy-send.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import http from "node:http";
+import { handleApiRequest, type ApiContext } from "../api.js";
+import type { Connector, JinnConfig } from "../../shared/types.js";
+
+// Issue #6: a "thread reply" routed through the generic connector proxy
+// (action: sendMessage) reached connector.sendMessage, which historically
+// dropped target.thread — the reply landed bare in the channel. The proxy
+// must route thread-bearing targets to replyMessage for ALL connectors
+// (Slack, Discord, ...), and must not trust the payload's thread type.
+
+function makeFakeConnector() {
+  return {
+    name: "fake",
+    sendMessage: vi.fn(async () => "root-ts"),
+    replyMessage: vi.fn(async () => "reply-ts"),
+    editMessage: vi.fn(async () => {}),
+    addReaction: vi.fn(async () => {}),
+    removeReaction: vi.fn(async () => {}),
+    getCapabilities: () => ({ threading: true, messageEdits: true, reactions: true, attachments: false }),
+    getHealth: () => ({ ok: true }),
+    start: async () => {},
+    stop: async () => {},
+    onMessage: () => {},
+  } as unknown as Connector & {
+    sendMessage: ReturnType<typeof vi.fn>;
+    replyMessage: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("POST /api/connectors/:id/proxy — sendMessage thread routing", () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let connector: ReturnType<typeof makeFakeConnector>;
+
+  beforeAll(async () => {
+    connector = makeFakeConnector();
+    const context = {
+      config: { gateway: { port: 0, host: "127.0.0.1" } } as JinnConfig,
+      getConfig: () => ({ gateway: { port: 0, host: "127.0.0.1" } }) as JinnConfig,
+      sessionManager: {} as never,
+      startTime: 0,
+      emit: () => {},
+      connectors: new Map([["fake", connector as Connector]]),
+    } as unknown as ApiContext;
+
+    server = http.createServer((req, res) => {
+      handleApiRequest(req, res, context);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "object" && address) {
+      baseUrl = `http://127.0.0.1:${address.port}`;
+    }
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  async function proxySend(target: unknown): Promise<{ status: number; body: { messageId?: string } }> {
+    const res = await fetch(`${baseUrl}/api/connectors/fake/proxy`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "sendMessage", target, text: "hello" }),
+    });
+    return { status: res.status, body: (await res.json()) as { messageId?: string } };
+  }
+
+  it("routes a thread-bearing target to replyMessage with a trimmed thread", async () => {
+    connector.sendMessage.mockClear();
+    connector.replyMessage.mockClear();
+
+    const { status, body } = await proxySend({ channel: "C1", thread: " 111.222 " });
+
+    expect(status).toBe(200);
+    expect(body.messageId).toBe("reply-ts");
+    expect(connector.sendMessage).not.toHaveBeenCalled();
+    expect(connector.replyMessage).toHaveBeenCalledTimes(1);
+    expect(connector.replyMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C1",
+      thread: "111.222",
+    });
+  });
+
+  it("routes a threadless target to sendMessage", async () => {
+    connector.sendMessage.mockClear();
+    connector.replyMessage.mockClear();
+
+    const { status, body } = await proxySend({ channel: "C1" });
+
+    expect(status).toBe(200);
+    expect(body.messageId).toBe("root-ts");
+    expect(connector.replyMessage).not.toHaveBeenCalled();
+    expect(connector.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a blank or non-string thread as no thread", async () => {
+    for (const thread of ["   ", 123, null]) {
+      connector.sendMessage.mockClear();
+      connector.replyMessage.mockClear();
+
+      const { status } = await proxySend({ channel: "C1", thread });
+
+      expect(status).toBe(200);
+      expect(connector.replyMessage).not.toHaveBeenCalled();
+      expect(connector.sendMessage).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -43,6 +43,7 @@ import { getSttStatus, downloadModel, transcribe as sttTranscribe, resolveLangua
 import { JINN_HOME } from "../shared/paths.js";
 import { handleHookPost, LOOPBACK as HOOK_LOOPBACK } from "./hook-endpoint.js";
 import { resolveEffort } from "../shared/effort.js";
+import { explicitThread } from "../shared/threading.js";
 import { effortLevelsForModel, invalidateModelRegistry } from "../shared/models.js";
 import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, recordClaudeRateLimit } from "../shared/usageAwareness.js";
@@ -1608,10 +1609,17 @@ Handle this as a priority request from a colleague.`;
       let messageId: string | undefined;
 
       switch (action) {
-        case "sendMessage":
+        case "sendMessage": {
           if (!target || !body.text) return badRequest(res, "target and text are required");
-          messageId = (await connector.sendMessage(target, body.text)) as string | undefined;
+          // Same contract as /send: an explicit thread on the target means a
+          // thread reply. Connectors' sendMessage historically dropped
+          // target.thread, landing "thread replies" bare in the channel (#6).
+          const proxyThread = explicitThread(target.thread);
+          messageId = proxyThread
+            ? ((await connector.replyMessage({ ...target, thread: proxyThread }, body.text)) as string | undefined)
+            : ((await connector.sendMessage(target, body.text)) as string | undefined);
           break;
+        }
         case "replyMessage":
           if (!target || !body.text) return badRequest(res, "target and text are required");
           messageId = (await connector.replyMessage(target, body.text)) as string | undefined;
@@ -1650,9 +1658,9 @@ Handle this as a priority request from a colleague.`;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const body = _parsed.body as any;
       if (!body.channel || !body.text) return badRequest(res, "channel and text are required");
-      const hasThread = typeof body.thread === "string" && body.thread.trim().length > 0;
-      const target = { channel: body.channel, thread: body.thread };
-      if (hasThread) {
+      const thread = explicitThread(body.thread);
+      const target = { channel: body.channel, thread };
+      if (thread) {
         await connector.replyMessage(target, body.text);
       } else {
         await connector.sendMessage(target, body.text);

--- a/packages/jimmy/src/shared/__tests__/threading.test.ts
+++ b/packages/jimmy/src/shared/__tests__/threading.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { explicitThread } from "../threading.js";
+
+// Issue #6: /send and the connector proxy route a message as a thread reply
+// only when the caller explicitly named a thread. Payloads are untrusted —
+// numbers, blanks, and padded strings must not crash or leak whitespace.
+describe("explicitThread", () => {
+  it("returns the trimmed thread for a valid value", () => {
+    expect(explicitThread("111.222")).toBe("111.222");
+    expect(explicitThread(" 111.222 ")).toBe("111.222");
+  });
+
+  it("returns undefined for missing or blank values", () => {
+    expect(explicitThread(undefined)).toBeUndefined();
+    expect(explicitThread(null)).toBeUndefined();
+    expect(explicitThread("")).toBeUndefined();
+    expect(explicitThread("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string values instead of throwing", () => {
+    expect(explicitThread(123)).toBeUndefined();
+    expect(explicitThread({})).toBeUndefined();
+    expect(explicitThread(["111.222"])).toBeUndefined();
+  });
+});

--- a/packages/jimmy/src/shared/threading.ts
+++ b/packages/jimmy/src/shared/threading.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize an explicit thread id from an untrusted payload.
+ *
+ * Gateway endpoints cast request bodies straight to `Target`, so `thread`
+ * can be a number, empty string, or padded string. A send must only be
+ * routed as a thread reply when the caller really named a thread — and the
+ * value must reach the connector trimmed, or Slack receives a `thread_ts`
+ * with whitespace.
+ */
+export function explicitThread(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}


### PR DESCRIPTION
Closes #6

## 概要

Issue #6 の機械的バグ（`/send` が `thread` を無視）は 2026.5.22 で `/send` エンドポイント側の振り分け修正が入ったが、コネクタの `sendMessage` 自体は依然 `target.thread` を読まないため、**proxy エンドポイント（`action: sendMessage`）経由では今もスレッド指定がチャンネル直下に着弾する**。この残存経路を塞ぎ、どの呼び出し口からでも同じスレッド配送になるようにする。

## 変更内容

- **`shared/threading.ts` に `explicitThread` ヘルパーを新設**: 信頼できないペイロード（数値・空白・前後スペース付き）を安全に正規化。`thread: 123` のような不正 JSON でクラッシュせず、trim 済みの値だけをコネクタに渡す
- **Slack コネクタ `sendMessage`**: thread 指定時は `replyMessage` へ委譲（`replyMessage` との非対称を解消）
- **proxy エンドポイント `action: sendMessage`**: thread 指定時は `replyMessage` へ振り分け。Slack 固有ではなく全コネクタ（Discord 等）共通で解決
- **`/send` エンドポイント**: 既存の振り分けロジックを同じヘルパーに統一

なお Issue #6 のもう片方（内部ナレーションの漏洩）は、`context.ts` の「Replying to the current conversation」ガイダンス（send_message を現在の会話に使わない・最終回答を実返信にする）として対応済み。

## レビュー

Codex によるレビュー2巡（[SHOULD] 3件をすべて反映）。

## テスト

- [x] `send-thread.test.ts` 6件: thread あり/なし/空白/非文字列/trim/replyMessage 既存挙動
- [x] `threading.test.ts` 3件: 正規化ロジック
- [x] `connector-proxy-send.test.ts` 3件: `handleApiRequest` + fake connector で proxy 経路を API レベル検証
- [x] `tsc --noEmit` パス
- [x] 全テスト: 既存の環境依存失敗5件（claude-interactive-race）を除きパス
- [ ] 実機確認: Slack チャンネルで bot にメンション → 返信が元メッセージのスレッド内に着弾すること