### PR TITLE
release: 2026.8.4 — Issue #6 / #38 修正 + PTYテスト安定化

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.7.26",
+  "version": "2026.8.4",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { SlackConnector } from "../index.js";
+import type { Target } from "../../../shared/types.js";
+
+// Issue #6: sendMessage silently dropped target.thread — a "thread reply"
+// sent through the proxy endpoint or MCP tool landed bare in the channel
+// while replyMessage honored the thread. Both paths must be symmetric.
+
+interface PostMessageArgs {
+  channel: string;
+  thread_ts?: string;
+  text: string;
+}
+
+function makeConnector() {
+  const postMessage = vi.fn(async (_args: PostMessageArgs) => ({ ts: "999.000" }));
+  const connector = Object.create(SlackConnector.prototype) as SlackConnector;
+  Object.assign(connector as unknown as Record<string, unknown>, {
+    app: { client: { chat: { postMessage } } },
+    conversations: { recordBotInitiatedThread: vi.fn() },
+    respondTo: undefined,
+    triageConfig: undefined,
+  });
+  return { connector, postMessage };
+}
+
+describe("SlackConnector.sendMessage — thread targeting (issue #6)", () => {
+  it("posts with thread_ts when target.thread is set", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", thread: "111.222" };
+
+    await connector.sendMessage(target, "reply text");
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C123",
+      thread_ts: "111.222",
+      text: "reply text",
+    });
+  });
+
+  it("posts to the channel root when no thread is given", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123" };
+
+    await connector.sendMessage(target, "root text");
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
+  });
+
+  it("ignores a blank thread value", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", thread: "  " };
+
+    await connector.sendMessage(target, "root text");
+
+    expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
+  });
+
+  it("keeps replyMessage behavior unchanged (thread || messageTs)", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", messageTs: "333.444" };
+
+    await connector.replyMessage(target, "reply text");
+
+    expect(postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C123",
+      thread_ts: "333.444",
+    });
+  });
+});

--- a/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/send-thread.test.ts
@@ -58,6 +58,24 @@ describe("SlackConnector.sendMessage — thread targeting (issue #6)", () => {
     expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
   });
 
+  it("trims a padded thread before sending it to Slack", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target: Target = { channel: "C123", thread: " 111.222 " };
+
+    await connector.sendMessage(target, "reply text");
+
+    expect(postMessage.mock.calls[0][0].thread_ts).toBe("111.222");
+  });
+
+  it("ignores a non-string thread from an untrusted payload", async () => {
+    const { connector, postMessage } = makeConnector();
+    const target = { channel: "C123", thread: 123 } as unknown as Target;
+
+    await connector.sendMessage(target, "root text");
+
+    expect(postMessage.mock.calls[0][0].thread_ts).toBeUndefined();
+  });
+
   it("keeps replyMessage behavior unchanged (thread || messageTs)", async () => {
     const { connector, postMessage } = makeConnector();
     const target: Target = { channel: "C123", messageTs: "333.444" };

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -807,6 +807,13 @@ export class SlackConnector implements Connector {
 
   async sendMessage(target: Target, text: string): Promise<string | undefined> {
     if (!text || !text.trim()) return undefined;
+    // An explicit thread target must never be dropped: posting a "thread
+    // reply" without thread_ts lands it bare in the channel. Callers that
+    // reach sendMessage with a thread (proxy endpoint, MCP tool) get the
+    // same behavior as replyMessage.
+    if (target.thread && target.thread.trim()) {
+      return this.replyMessage(target, text);
+    }
     const chunks = formatResponse(text);
     let lastTs: string | undefined;
     for (const chunk of chunks) {

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -21,6 +21,7 @@ import {
   respondPolicyNeedsTracking,
 } from "./respond-policy.js";
 import { isOperatorSpeaker } from "../../shared/operator-match.js";
+import { explicitThread } from "../../shared/threading.js";
 import { ConversationTracker } from "./conversation-tracker.js";
 import { AgentsCanvasUpdater } from "./agents-canvas.js";
 import { extractGoalCondition, shouldExtractGoal } from "./goal-extractor.js";
@@ -811,8 +812,9 @@ export class SlackConnector implements Connector {
     // reply" without thread_ts lands it bare in the channel. Callers that
     // reach sendMessage with a thread (proxy endpoint, MCP tool) get the
     // same behavior as replyMessage.
-    if (target.thread && target.thread.trim()) {
-      return this.replyMessage(target, text);
+    const thread = explicitThread(target.thread);
+    if (thread) {
+      return this.replyMessage({ ...target, thread }, text);
     }
     const chunks = formatResponse(text);
     let lastTs: string | undefined;

--- a/packages/jimmy/src/engines/__tests__/claude-interactive-race.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude-interactive-race.test.ts
@@ -52,6 +52,16 @@ vi.mock("../sse-pty-proxy.js", () => ({
 vi.mock("../shared/claude-settings.js", () => ({
   writeSessionSettings: () => "/tmp/fake-settings.json",
 }));
+// spawn() awaits the shared-OAuth refresh gate before pty.spawn(). Unmocked, it
+// reads the real ~/.claude/.credentials.json — and when that token is within 90s
+// of expiry (or expired), the gate serializes the spawn herd: the first spawn
+// leads and opens a 25s refresh window that blocks every later spawn, so
+// pty.spawn() is never reached within the test's 15ms flush and ptys[] stays
+// empty. These tests exercise the PTY lifecycle, not the OAuth gate — stub it to
+// resolve instantly so they don't depend on the runner's real credential state.
+vi.mock("../../shared/claude-oauth-gate.js", () => ({
+  awaitFreshClaudeCredentials: async () => {},
+}));
 
 import { InteractiveClaudeEngine } from "../claude-interactive.js";
 import { PtyLifecycleManager } from "../pty-lifecycle.js";

--- a/packages/jimmy/src/gateway/__tests__/connector-proxy-send.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/connector-proxy-send.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import http from "node:http";
+import { handleApiRequest, type ApiContext } from "../api.js";
+import type { Connector, JinnConfig } from "../../shared/types.js";
+
+// Issue #6: a "thread reply" routed through the generic connector proxy
+// (action: sendMessage) reached connector.sendMessage, which historically
+// dropped target.thread — the reply landed bare in the channel. The proxy
+// must route thread-bearing targets to replyMessage for ALL connectors
+// (Slack, Discord, ...), and must not trust the payload's thread type.
+
+function makeFakeConnector() {
+  return {
+    name: "fake",
+    sendMessage: vi.fn(async () => "root-ts"),
+    replyMessage: vi.fn(async () => "reply-ts"),
+    editMessage: vi.fn(async () => {}),
+    addReaction: vi.fn(async () => {}),
+    removeReaction: vi.fn(async () => {}),
+    getCapabilities: () => ({ threading: true, messageEdits: true, reactions: true, attachments: false }),
+    getHealth: () => ({ ok: true }),
+    start: async () => {},
+    stop: async () => {},
+    onMessage: () => {},
+  } as unknown as Connector & {
+    sendMessage: ReturnType<typeof vi.fn>;
+    replyMessage: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("POST /api/connectors/:id/proxy — sendMessage thread routing", () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let connector: ReturnType<typeof makeFakeConnector>;
+
+  beforeAll(async () => {
+    connector = makeFakeConnector();
+    const context = {
+      config: { gateway: { port: 0, host: "127.0.0.1" } } as JinnConfig,
+      getConfig: () => ({ gateway: { port: 0, host: "127.0.0.1" } }) as JinnConfig,
+      sessionManager: {} as never,
+      startTime: 0,
+      emit: () => {},
+      connectors: new Map([["fake", connector as Connector]]),
+    } as unknown as ApiContext;
+
+    server = http.createServer((req, res) => {
+      handleApiRequest(req, res, context);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "object" && address) {
+      baseUrl = `http://127.0.0.1:${address.port}`;
+    }
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  async function proxySend(target: unknown): Promise<{ status: number; body: { messageId?: string } }> {
+    const res = await fetch(`${baseUrl}/api/connectors/fake/proxy`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "sendMessage", target, text: "hello" }),
+    });
+    return { status: res.status, body: (await res.json()) as { messageId?: string } };
+  }
+
+  it("routes a thread-bearing target to replyMessage with a trimmed thread", async () => {
+    connector.sendMessage.mockClear();
+    connector.replyMessage.mockClear();
+
+    const { status, body } = await proxySend({ channel: "C1", thread: " 111.222 " });
+
+    expect(status).toBe(200);
+    expect(body.messageId).toBe("reply-ts");
+    expect(connector.sendMessage).not.toHaveBeenCalled();
+    expect(connector.replyMessage).toHaveBeenCalledTimes(1);
+    expect(connector.replyMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C1",
+      thread: "111.222",
+    });
+  });
+
+  it("routes a threadless target to sendMessage", async () => {
+    connector.sendMessage.mockClear();
+    connector.replyMessage.mockClear();
+
+    const { status, body } = await proxySend({ channel: "C1" });
+
+    expect(status).toBe(200);
+    expect(body.messageId).toBe("root-ts");
+    expect(connector.replyMessage).not.toHaveBeenCalled();
+    expect(connector.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a blank or non-string thread as no thread", async () => {
+    for (const thread of ["   ", 123, null]) {
+      connector.sendMessage.mockClear();
+      connector.replyMessage.mockClear();
+
+      const { status } = await proxySend({ channel: "C1", thread });
+
+      expect(status).toBe(200);
+      expect(connector.replyMessage).not.toHaveBeenCalled();
+      expect(connector.sendMessage).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -2275,6 +2275,14 @@ async function runWebSession(
       connectors: Array.from(context.connectors.keys()),
       config,
       sessionId: currentSession.id,
+      // Interactive PTY survives across turns; everything else is a one-shot
+      // process whose background tasks die at turn end (#38).
+      processLifetime:
+        currentSession.engine === "claude" &&
+        config.engines.claude?.interactive === true &&
+        !employee?.sshHost
+          ? "persistent"
+          : "one-shot",
       hierarchy: orgHierarchy,
     });
 

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -43,6 +43,7 @@ import { getSttStatus, downloadModel, transcribe as sttTranscribe, resolveLangua
 import { JINN_HOME } from "../shared/paths.js";
 import { handleHookPost, LOOPBACK as HOOK_LOOPBACK } from "./hook-endpoint.js";
 import { resolveEffort } from "../shared/effort.js";
+import { explicitThread } from "../shared/threading.js";
 import { effortLevelsForModel, invalidateModelRegistry } from "../shared/models.js";
 import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, recordClaudeRateLimit } from "../shared/usageAwareness.js";
@@ -1608,10 +1609,17 @@ Handle this as a priority request from a colleague.`;
       let messageId: string | undefined;
 
       switch (action) {
-        case "sendMessage":
+        case "sendMessage": {
           if (!target || !body.text) return badRequest(res, "target and text are required");
-          messageId = (await connector.sendMessage(target, body.text)) as string | undefined;
+          // Same contract as /send: an explicit thread on the target means a
+          // thread reply. Connectors' sendMessage historically dropped
+          // target.thread, landing "thread replies" bare in the channel (#6).
+          const proxyThread = explicitThread(target.thread);
+          messageId = proxyThread
+            ? ((await connector.replyMessage({ ...target, thread: proxyThread }, body.text)) as string | undefined)
+            : ((await connector.sendMessage(target, body.text)) as string | undefined);
           break;
+        }
         case "replyMessage":
           if (!target || !body.text) return badRequest(res, "target and text are required");
           messageId = (await connector.replyMessage(target, body.text)) as string | undefined;
@@ -1650,9 +1658,9 @@ Handle this as a priority request from a colleague.`;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const body = _parsed.body as any;
       if (!body.channel || !body.text) return badRequest(res, "channel and text are required");
-      const hasThread = typeof body.thread === "string" && body.thread.trim().length > 0;
-      const target = { channel: body.channel, thread: body.thread };
-      if (hasThread) {
+      const thread = explicitThread(body.thread);
+      const target = { channel: body.channel, thread };
+      if (thread) {
         await connector.replyMessage(target, body.text);
       } else {
         await connector.sendMessage(target, body.text);

--- a/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
@@ -11,38 +11,57 @@ describe("buildContext — process lifetime section", () => {
     user: "U123",
   };
 
-  it("includes the process lifetime warning as an essential section", () => {
+  const stubConfig = {
+    jinn: { version: "0.0.0" },
+    gateway: { port: 7777, host: "127.0.0.1" },
+    engines: {
+      default: "claude",
+      claude: { bin: "claude", model: "" },
+      codex: { bin: "codex", model: "" },
+    },
+    connectors: {},
+    logging: { level: "info", stdout: false, file: "" },
+  };
+
+  it("warns about one-shot process death by default", () => {
     const ctx = buildContext(baseOpts);
     expect(ctx).toContain("## Process lifetime");
     expect(ctx).toContain("background tasks die when your turn ends");
+    expect(ctx).toContain("Your process is one-shot");
+  });
+
+  it("gives OS-specific detach commands (setsid is Linux-only)", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toContain("setsid nohup");
+    expect(ctx).toMatch(/macOS/);
+    expect(ctx).toMatch(/disown/);
+  });
+
+  it("says the agent cannot be woken up and must verify before reporting done", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toContain("You will NOT be notified");
+    expect(ctx).toMatch(/never claim completion you have not verified/i);
+  });
+
+  it("does not claim one-shot death for persistent (interactive PTY) sessions", () => {
+    const ctx = buildContext({ ...baseOpts, processLifetime: "persistent" });
+    expect(ctx).not.toContain("Your process is one-shot");
+    expect(ctx).toContain("## Process lifetime");
+    expect(ctx).toContain("persistent interactive process");
+    // Detach guidance still applies: the PTY dies with the session/gateway.
     expect(ctx).toContain("setsid nohup");
   });
 
-  it("tells the agent to verify detached jobs via logfile in a later turn", () => {
-    const ctx = buildContext(baseOpts);
-    expect(ctx).toMatch(/LATER turn/);
-    expect(ctx).toMatch(/logfile/i);
-  });
-
-  it("survives aggressive trimming (essential tier is never dropped)", () => {
-    const stubConfig = {
-      jinn: { version: "0.0.0" },
-      gateway: { port: 7777, host: "127.0.0.1" },
-      engines: {
-        default: "claude",
-        claude: { bin: "claude", model: "" },
-        codex: { bin: "codex", model: "" },
-      },
-      connectors: {},
-      logging: { level: "info", stdout: false, file: "" },
-      context: { maxChars: 4000 },
-    };
+  it("is essential tier: full content survives trimming that summarizes standard sections", () => {
     const ctx = buildContext({
       ...baseOpts,
-      config: stubConfig as never,
+      config: { ...stubConfig, context: { maxChars: 2000 } } as never,
       connectors: ["slack"],
     });
-    expect(ctx.length).toBeGreaterThan(0);
-    expect(ctx).toContain("## Process lifetime");
+    // A standard-tier section (connectors) collapsed to its summary…
+    expect(ctx).not.toContain("**Send message**");
+    // …while the full lifetime warning (this phrase is absent from any
+    // summary) must remain intact.
+    expect(ctx).toContain("NEVER start a plain background job");
   });
 });

--- a/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/context-process-lifetime.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { buildContext } from "../context.js";
+
+// Issue #38: background tasks are killed with the one-shot engine process when
+// the turn ends. The agent must be told this up front (option A), otherwise it
+// confidently promises "I'll report back later" and the job dies silently.
+describe("buildContext — process lifetime section", () => {
+  const baseOpts = {
+    source: "slack",
+    channel: "C123",
+    user: "U123",
+  };
+
+  it("includes the process lifetime warning as an essential section", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toContain("## Process lifetime");
+    expect(ctx).toContain("background tasks die when your turn ends");
+    expect(ctx).toContain("setsid nohup");
+  });
+
+  it("tells the agent to verify detached jobs via logfile in a later turn", () => {
+    const ctx = buildContext(baseOpts);
+    expect(ctx).toMatch(/LATER turn/);
+    expect(ctx).toMatch(/logfile/i);
+  });
+
+  it("survives aggressive trimming (essential tier is never dropped)", () => {
+    const stubConfig = {
+      jinn: { version: "0.0.0" },
+      gateway: { port: 7777, host: "127.0.0.1" },
+      engines: {
+        default: "claude",
+        claude: { bin: "claude", model: "" },
+        codex: { bin: "codex", model: "" },
+      },
+      connectors: {},
+      logging: { level: "info", stdout: false, file: "" },
+      context: { maxChars: 4000 },
+    };
+    const ctx = buildContext({
+      ...baseOpts,
+      config: stubConfig as never,
+      connectors: ["slack"],
+    });
+    expect(ctx.length).toBeGreaterThan(0);
+    expect(ctx).toContain("## Process lifetime");
+  });
+});

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -137,6 +137,14 @@ export function buildContext(opts: {
     summary: "", // always included, no trimming
   });
 
+  // ── ESSENTIAL: Process lifetime (background tasks die at turn end) ──
+  sections.push({
+    tier: Tier.ESSENTIAL,
+    marker: "## Process lifetime",
+    content: buildProcessLifetimeContext(),
+    summary: "## Process lifetime\nBackground tasks are killed when your turn ends. Detach long jobs with `setsid nohup <cmd> > <logfile> 2>&1 &` and verify via the logfile in a later turn.",
+  });
+
   // ── ESSENTIAL: Configuration awareness ──────────────────────
   if (opts.config) {
     sections.push({
@@ -642,6 +650,20 @@ function buildKnowledgeContext(): string | null {
   }
 
   return lines.join("\n");
+}
+
+function buildProcessLifetimeContext(): string {
+  return [
+    `## Process lifetime (background tasks die when your turn ends)`,
+    `Your process is one-shot: it is spawned for this turn and exits as soon as you deliver your final answer. Anything you started in the background (\`&\`, run_in_background Bash tasks) lives in the SAME process group and is killed with it — silently, with no error and no notification.`,
+    ``,
+    `- NEVER start a background job and reply "I'll report back when it's done" — the job dies the moment your turn ends, and nobody is told. This is different from an interactive CLI, where the CLI outlives the turn.`,
+    `- If a job fits within this turn, run it in the FOREGROUND and wait for it to finish before answering.`,
+    `- If a job must outlive the turn, fully detach it from your process group and capture its output:`,
+    `  \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 &\``,
+    `  Then tell the user it is running detached, and in a LATER turn verify by reading the logfile and checking the expected artifact (uploaded file, build output, etc.).`,
+    `- Never report a detached job as done without verifying the artifact. If the logfile is missing or incomplete, say so.`,
+  ].join("\n");
 }
 
 function buildConnectorContext(connectors: string[], gatewayUrl: string, portalName: string): string {

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -71,6 +71,13 @@ export function buildContext(opts: {
   speakerIsBot?: boolean;
   /** Speaker's IANA timezone */
   speakerTz?: string;
+  /**
+   * How the engine process for this turn lives. "one-shot" (default): a fresh
+   * process is spawned per turn and exits — with its whole process group —
+   * when the final answer is delivered. "persistent": an interactive PTY that
+   * survives across turns (config.engines.claude.interactive, local only).
+   */
+  processLifetime?: "one-shot" | "persistent";
   hierarchy?: import("../shared/types.js").OrgHierarchy;
 }): string {
   const maxChars = opts.config?.context?.maxChars ?? DEFAULT_MAX_CONTEXT_CHARS;
@@ -137,12 +144,12 @@ export function buildContext(opts: {
     summary: "", // always included, no trimming
   });
 
-  // ── ESSENTIAL: Process lifetime (background tasks die at turn end) ──
+  // ── ESSENTIAL: Process lifetime (background tasks die with the process) ──
   sections.push({
     tier: Tier.ESSENTIAL,
     marker: "## Process lifetime",
-    content: buildProcessLifetimeContext(),
-    summary: "## Process lifetime\nBackground tasks are killed when your turn ends. Detach long jobs with `setsid nohup <cmd> > <logfile> 2>&1 &` and verify via the logfile in a later turn.",
+    content: buildProcessLifetimeContext(opts.processLifetime !== "persistent"),
+    summary: "", // always included
   });
 
   // ── ESSENTIAL: Configuration awareness ──────────────────────
@@ -652,17 +659,33 @@ function buildKnowledgeContext(): string | null {
   return lines.join("\n");
 }
 
-function buildProcessLifetimeContext(): string {
+function buildProcessLifetimeContext(oneShot: boolean): string {
+  const detachAndVerify = [
+    `- To detach a job so it survives, escape your process group and capture output:`,
+    `  - Linux: \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 &\``,
+    `  - macOS (no \`setsid\`): \`nohup <cmd> > /tmp/<job>.log 2>&1 &\` then \`disown\` (survives normal exit, but not a forced kill of the process group)`,
+    `  - Check \`command -v setsid\` when unsure which applies.`,
+    `- You will NOT be notified when a detached job finishes — you cannot wake yourself up. Either ask the user to check back later, or register a cron job (gateway \`/api/cron\`) to follow up.`,
+    `- Verify BEFORE reporting done: read the logfile and check the expected artifact (uploaded file, build output, etc.). If the logfile is missing or incomplete, say so — never claim completion you have not verified.`,
+  ];
+
+  if (!oneShot) {
+    return [
+      `## Process lifetime`,
+      `This session runs in a persistent interactive process: background tasks survive across turns, but they are killed when the session ends, times out, or the gateway restarts.`,
+      ``,
+      `- For a job that must survive session shutdown, detach it (below) instead of relying on a plain background task.`,
+      ...detachAndVerify,
+    ].join("\n");
+  }
+
   return [
     `## Process lifetime (background tasks die when your turn ends)`,
-    `Your process is one-shot: it is spawned for this turn and exits as soon as you deliver your final answer. Anything you started in the background (\`&\`, run_in_background Bash tasks) lives in the SAME process group and is killed with it — silently, with no error and no notification.`,
+    `Your process is one-shot: it is spawned for this turn and exits as soon as you deliver your final answer. Anything you started in the background (\`&\`, run_in_background Bash tasks) lives in the SAME process group and dies with it — silently, with no error and no notification.`,
     ``,
-    `- NEVER start a background job and reply "I'll report back when it's done" — the job dies the moment your turn ends, and nobody is told. This is different from an interactive CLI, where the CLI outlives the turn.`,
+    `- NEVER start a plain background job and reply "I'll report back when it's done" — the job dies the moment your turn ends, and nobody is told. This is different from an interactive CLI, where the CLI outlives the turn.`,
     `- If a job fits within this turn, run it in the FOREGROUND and wait for it to finish before answering.`,
-    `- If a job must outlive the turn, fully detach it from your process group and capture its output:`,
-    `  \`setsid nohup <cmd> > /tmp/<job>.log 2>&1 &\``,
-    `  Then tell the user it is running detached, and in a LATER turn verify by reading the logfile and checking the expected artifact (uploaded file, build output, etc.).`,
-    `- Never report a detached job as done without verifying the artifact. If the logfile is missing or incomplete, say so.`,
+    ...detachAndVerify,
   ].join("\n");
 }
 

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -433,6 +433,15 @@ export class SessionManager {
         speakerSlackId: (meta.speakerSlackId as string) || undefined,
         speakerIsBot: (meta.speakerIsBot as boolean | null) ?? undefined,
         speakerTz: (meta.speakerTz as string) || undefined,
+        // Interactive PTY survives across turns; everything else (headless
+        // claude -p, codex, gemini, SSH fallback) is a one-shot process whose
+        // background tasks die at turn end (#38).
+        processLifetime:
+          session.engine === "claude" &&
+          this.config.engines.claude?.interactive === true &&
+          !employee?.sshHost
+            ? "persistent"
+            : "one-shot",
         hierarchy,
       });
 

--- a/packages/jimmy/src/shared/__tests__/threading.test.ts
+++ b/packages/jimmy/src/shared/__tests__/threading.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { explicitThread } from "../threading.js";
+
+// Issue #6: /send and the connector proxy route a message as a thread reply
+// only when the caller explicitly named a thread. Payloads are untrusted —
+// numbers, blanks, and padded strings must not crash or leak whitespace.
+describe("explicitThread", () => {
+  it("returns the trimmed thread for a valid value", () => {
+    expect(explicitThread("111.222")).toBe("111.222");
+    expect(explicitThread(" 111.222 ")).toBe("111.222");
+  });
+
+  it("returns undefined for missing or blank values", () => {
+    expect(explicitThread(undefined)).toBeUndefined();
+    expect(explicitThread(null)).toBeUndefined();
+    expect(explicitThread("")).toBeUndefined();
+    expect(explicitThread("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string values instead of throwing", () => {
+    expect(explicitThread(123)).toBeUndefined();
+    expect(explicitThread({})).toBeUndefined();
+    expect(explicitThread(["111.222"])).toBeUndefined();
+  });
+});

--- a/packages/jimmy/src/shared/threading.ts
+++ b/packages/jimmy/src/shared/threading.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize an explicit thread id from an untrusted payload.
+ *
+ * Gateway endpoints cast request bodies straight to `Target`, so `thread`
+ * can be a number, empty string, or padded string. A send must only be
+ * routed as a thread reply when the caller really named a thread — and the
+ * value must reach the connector trimmed, or Slack receives a `thread_ts`
+ * with whitespace.
+ */
+export function explicitThread(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}


### PR DESCRIPTION
## 含まれる変更

- #40 — fix(sessions): バックグラウンドタスクの寿命を system prompt で警告 (Closes #38)
- #41 — fix(slack): sendMessage が target.thread を無視する非対称を解消 (Closes #6)
- #36 — test(engines): PTY レーステストの claude-oauth-gate 依存を解消
- version bump 2026.7.26 → 2026.8.4

## 検証済み

- [x] 全619テスト green（#36 取り込みで既存の環境依存失敗5件も解消）
- [x] `npm run build` 成功・修正が dist に反映・`dist/web` 同梱（38ファイル）
- [x] `npm pack` で同梱内容確認（dist/bin・dist/web・template/migrations）
- [x] Codex レビュー2巡・承認済み（#40/#41）

このPRをマージすると #36 / #40 / #41 も同時にマージ扱いになります。マージ後に npm publish 2026.8.4 → openclaw-sandbox デプロイ。