### PR TITLE
Fix wildcard gateway self-connect failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.8.20] - 2026-08-18
+
+> `gateway.host: 0.0.0.0` / `::` の環境で、AIやCLIへ渡されたURLがGateway自身に
+> `421 host_not_allowed` で拒否され、CronやSlack投稿が無言で止まる問題を恒久修正。
+
+### このリリースでできるようになったこと
+
+- **ネットワーク待受でも内部処理が止まらない**: 待受アドレス（bind）と接続先URL（connect）を明確に分離。`0.0.0.0` / `::` で待ち受けても、システムプロンプト、`ryoko status`、`ryoko pair`、AIの子プロセスには接続可能なloopback URLを渡す。
+- **認証情報やURLを手書きせずGateway APIを呼べる**: `ryoko api GET /api/status`、`ryoko api POST /api/sessions --data '{...}'` を追加。正しい接続先とBearer tokenを自動選択し、外部URLへのtoken送信を拒否。401 / 421を含むHTTPエラーも終了コードと本文で確認できる。
+- **既存のスキルやCronをアップデート時に修復できる**: `ryoko update` が `~/.ryoko` 内の `http://0.0.0.0:<port>` / `http://[::]:<port>` を検出し、バックアップ後にloopbackへ自動置換。`ryoko migrate --check` で確認、`ryoko migrate --fix` で手動修復もできる。
+- **Bearer付け忘れ候補に気づける**: マイグレーション監査が、保護APIを直接curlしているのに認証処理が見当たらないファイルを警告し、`ryoko api`への移行を案内する。
+
+### 安全性と信頼性
+
+- Hostガードは緩和しない。`Host: 0.0.0.0` / `Host: [::]` は、ブラウザらしいヘッダーの有無に関係なく拒否する。
+- `gateway.allowedHosts` にワイルドカードbindを追加しても安全なHost名として扱わず、警告して無視する。DNS rebinding / “0.0.0.0 day” への防御を維持。
+- 421レスポンスとwarnログに、拒否理由と使うべきloopback URLを表示。ログはHostごとに一度、最大50種類までに制限してログ洪水を防ぐ。
+- 自動置換はテキストファイルだけを対象にし、symlink、ログ、DB、モデル、ソースcheckout、巨大ファイルを除外。変更前ファイルをユーザー専用backup directoryへ保存し、元のpermissionを維持してatomic置換する。
+- AIへ渡す標準の委任・コネクタ・同期例を、認証なしcurlから`ryoko api`へ変更。
+
+### 互換性に関する注意
+
+- `http://0.0.0.0:<port>` は待受指定であり、クライアントの接続先としては使えない。`~/.ryoko` 外にある独自スクリプトは `ryoko api` または `$RYOKO_GATEWAY_URL` + Bearer認証へ変更する。
+- 応急処置で `gateway.allowedHosts: [0.0.0.0]` を追加していた場合、この値は本リリースから無視されるため削除できる。
+
+### Verification
+
+- Backend: **97 test files / 780 tests pass**
+- Web: **12 test files / 85 tests pass**
+- backend / WebのTypeScript typecheck、production build、`git diff --check`
+- strict Hostガード、URL変換、token付与、外部URL拒否、バックアップ付き移行監査を回帰テスト化
+- ワイルドカードbindの実Gatewayでloopback成功、wildcard Host拒否、401 / 421診断、`ryoko api`を実測
+- production依存監査とnpm公開物のsecret・秘密鍵・個人絶対パス走査
+
 ## [2026.8.19] - 2026-08-18
 
 > 2026.8.18 と同日の追加リリース。OpenRyoko自身の更新をダッシュボードとチャットで見逃さないための通知機能を追加。

--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ OpenRyoko は **個人マシン or 信頼境界内の VPS で 1 人 / 1 チー�
   OpenRyokoの端末認証が自動的に有効になるが、通信を暗号化する機能は内蔵しない。
   **Tailscale/VPN内で利用するか、HTTPSリバースプロキシ**（Cloudflare Access、Caddy、
   nginx等）を前段に置くこと。平文HTTPのままインターネットへ公開しない。
+- `gateway.host` は待受アドレスであり接続先URLではない。`0.0.0.0` / `::` で待ち受ける
+  場合もローカルAPIは `ryoko api GET /api/status` のように呼ぶ。`ryoko api` は安全な
+  loopback URLを選び、Bearer認証を自動付与する。直接HTTPを使う必要がある子プロセスには
+  接続可能なURLが `$RYOKO_GATEWAY_URL` で渡される。
 - リバースプロキシの公開名は `gateway.allowedHosts` に列挙する。プロキシが設定する
   `X-Forwarded-Proto`をCookieの`Secure`判定に使う場合だけ
   `gateway.trustProxyHeaders: true`を設定し、プロキシの接続元IPを

--- a/packages/jimmy/bin/jimmy.ts
+++ b/packages/jimmy/bin/jimmy.ts
@@ -66,6 +66,15 @@ program
   });
 
 program
+  .command("api <method> <path>")
+  .description("認証付きでこのインスタンスのGateway APIを呼び出す")
+  .option("-d, --data <json>", "JSONリクエスト本文（POST/PUT/PATCH/DELETE用）")
+  .action(async (method: string, apiPath: string, opts: { data?: string }) => {
+    const { runApi } = await import("../src/cli/api.js");
+    await runApi({ method, path: apiPath, data: opts.data });
+  });
+
+program
   .command("create <name>")
   .description("新しいOpenRyokoインスタンスを作成する")
   .option("-p, --port <port>", "ゲートウェイのポート（省略時は自動割当）")
@@ -115,6 +124,7 @@ program
   .description("未適用のテンプレート・マイグレーションを適用する")
   .option("--check", "未適用のマイグレーションをチェックのみ（適用はしない）")
   .option("--auto", "安全な変更のみをAI起動なしで自動適用")
+  .option("--fix", "旧gateway URLをバックアップ後に安全なloopback URLへ置換")
   .action(async (opts) => {
     const { runMigrate } = await import("../src/cli/migrate.js");
     await runMigrate(opts);

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.8.19",
+  "version": "2026.8.20",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/cli/__tests__/api.test.ts
+++ b/packages/jimmy/src/cli/__tests__/api.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { requestGatewayApi } from "../api.js";
+
+describe("requestGatewayApi", () => {
+  it("normalizes wildcard binds and adds the stored bearer token", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const result = await requestGatewayApi(
+      { method: "get", path: "/api/status" },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: "secret-token" },
+    );
+
+    expect(result).toEqual({ ok: true, status: 200, body: '{"ok":true}' });
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [URL, RequestInit];
+    expect(String(url)).toBe("http://127.0.0.1:7777/api/status");
+    expect(init.headers).toMatchObject({ Authorization: "Bearer secret-token" });
+    expect(init.redirect).toBe("error");
+  });
+
+  it("sends validated JSON for write requests", async () => {
+    const fetchImpl = vi.fn(async () => new Response("created", { status: 201 }));
+    await requestGatewayApi(
+      { method: "POST", path: "/api/sessions", data: '{ "prompt": "hello" }' },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: null },
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [URL, RequestInit];
+    expect(init.body).toBe('{"prompt":"hello"}');
+    expect(init.headers).toMatchObject({ "Content-Type": "application/json" });
+  });
+
+  it("never sends the token to a full or escaped URL", async () => {
+    const fetchImpl = vi.fn();
+    await expect(requestGatewayApi(
+      { method: "GET", path: "https://evil.example/api/status" },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: "secret" },
+    )).rejects.toThrow("must start with /api/");
+    await expect(requestGatewayApi(
+      { method: "GET", path: "/not-api" },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: "secret" },
+    )).rejects.toThrow("must start with /api/");
+    await expect(requestGatewayApi(
+      { method: "GET", path: "/api/../../outside" },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: "secret" },
+    )).rejects.toThrow("must stay within");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported methods and malformed JSON before fetching", async () => {
+    const fetchImpl = vi.fn();
+    await expect(requestGatewayApi(
+      { method: "TRACE", path: "/api/status" },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: null },
+    )).rejects.toThrow("Unsupported method");
+    await expect(requestGatewayApi(
+      { method: "POST", path: "/api/sessions", data: "not-json" },
+      { fetchImpl: fetchImpl as typeof fetch, gatewayUrl: "http://127.0.0.1:7777", token: null },
+    )).rejects.toThrow("valid JSON");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jimmy/src/cli/__tests__/gateway-audit.test.ts
+++ b/packages/jimmy/src/cli/__tests__/gateway-audit.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { auditGatewayReferences } from "../gateway-audit.js";
+
+const homes: string[] = [];
+
+function makeHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "ryoko-gateway-audit-"));
+  homes.push(home);
+  return home;
+}
+
+afterEach(() => {
+  for (const home of homes.splice(0)) fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("auditGatewayReferences", () => {
+  it("finds legacy wildcard URLs without changing files by default", () => {
+    const home = makeHome();
+    fs.mkdirSync(path.join(home, "skills", "demo"), { recursive: true });
+    const file = path.join(home, "skills", "demo", "SKILL.md");
+    fs.writeFileSync(file, "curl http://0.0.0.0:7777/api/status\n");
+    const report = auditGatewayReferences(home);
+    expect(report.legacyOccurrences).toBe(1);
+    expect(report.legacyFiles).toEqual(["skills/demo/SKILL.md"]);
+    expect(report.fixedFiles).toEqual([]);
+    expect(fs.readFileSync(file, "utf8")).toContain("0.0.0.0");
+  });
+
+  it("backs up and atomically fixes IPv4 and IPv6 wildcard URLs", () => {
+    const home = makeHome();
+    fs.mkdirSync(path.join(home, "cron"), { recursive: true });
+    const file = path.join(home, "cron", "jobs.json");
+    const original = '{"a":"http://0.0.0.0:7777/api/status","b":"http://[::]:9000/api/health"}';
+    fs.writeFileSync(file, original, { mode: 0o600 });
+    const report = auditGatewayReferences(home, { fix: true, now: new Date("2026-08-18T12:00:00.000Z") });
+    expect(report.fixedFiles).toEqual(["cron/jobs.json"]);
+    expect(fs.readFileSync(file, "utf8")).toContain("http://127.0.0.1:7777");
+    expect(fs.readFileSync(file, "utf8")).toContain("http://[::1]:9000");
+    expect(report.backupDir).toBeDefined();
+    expect(fs.readFileSync(path.join(report.backupDir!, "cron", "jobs.json"), "utf8")).toBe(original);
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("skips symlinks, runtime trees, and binary files", () => {
+    const home = makeHome();
+    fs.mkdirSync(path.join(home, "logs"), { recursive: true });
+    fs.writeFileSync(path.join(home, "logs", "gateway.log"), "http://0.0.0.0:7777/api/status");
+    fs.writeFileSync(path.join(home, "sessions.db"), "http://0.0.0.0:7777/api/status");
+    const outside = path.join(os.tmpdir(), `outside-${process.pid}.md`);
+    fs.writeFileSync(outside, "http://0.0.0.0:7777/api/status");
+    fs.symlinkSync(outside, path.join(home, "linked.md"));
+    try { expect(auditGatewayReferences(home).legacyOccurrences).toBe(0); }
+    finally { fs.rmSync(outside, { force: true }); }
+  });
+
+  it("flags direct API curl candidates without auth but ignores health and ryoko api", () => {
+    const home = makeHome();
+    fs.mkdirSync(path.join(home, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(home, "scripts", "bad.sh"), "curl http://127.0.0.1:7777/api/sessions\n");
+    fs.writeFileSync(path.join(home, "scripts", "health.sh"), "curl http://127.0.0.1:7777/api/health\n");
+    fs.writeFileSync(path.join(home, "scripts", "good.sh"), "ryoko api GET /api/sessions\n");
+    expect(auditGatewayReferences(home).unauthenticatedCurlCandidates).toEqual(["scripts/bad.sh"]);
+  });
+});

--- a/packages/jimmy/src/cli/__tests__/migrate.test.ts
+++ b/packages/jimmy/src/cli/__tests__/migrate.test.ts
@@ -105,6 +105,8 @@ describe("migrate: AI session launcher", () => {
     const fileEntry = {
       name: "CLAUDE.md",
       isDirectory: () => false,
+      isFile: () => true,
+      isSymbolicLink: () => false,
     };
     mockReaddirSync.mockReturnValue([fileEntry] as any);
 

--- a/packages/jimmy/src/cli/api.ts
+++ b/packages/jimmy/src/cli/api.ts
@@ -1,0 +1,88 @@
+import { readGatewayAuthToken } from "../gateway/auth.js";
+import { loadConfig } from "../shared/config.js";
+import { gatewayUrlFromConfig } from "../shared/gateway-url.js";
+import { JINN_HOME } from "../shared/paths.js";
+
+const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+export interface GatewayApiOptions {
+  method: string;
+  path: string;
+  data?: string;
+}
+
+export interface GatewayApiResult {
+  ok: boolean;
+  status: number;
+  body: string;
+}
+
+interface GatewayApiDeps {
+  fetchImpl?: typeof fetch;
+  gatewayUrl?: string;
+  token?: string | null;
+}
+
+/**
+ * Call this instance's own gateway without making callers hand-copy its bind
+ * address or bearer token. Only local `/api` paths are accepted so the token
+ * can never be redirected or sent to an arbitrary URL.
+ */
+export async function requestGatewayApi(
+  opts: GatewayApiOptions,
+  deps: GatewayApiDeps = {},
+): Promise<GatewayApiResult> {
+  const method = opts.method.trim().toUpperCase();
+  if (!ALLOWED_METHODS.has(method)) {
+    throw new Error(`Unsupported method "${opts.method}". Use GET, POST, PUT, PATCH, or DELETE.`);
+  }
+
+  const rawPath = opts.path.trim();
+  if (!rawPath.startsWith("/api/") && rawPath !== "/api") {
+    throw new Error("Gateway path must start with /api/ (full URLs are not accepted).");
+  }
+
+  const gatewayUrl = (deps.gatewayUrl ?? gatewayUrlFromConfig(loadConfig())).replace(/\/$/, "");
+  const url = new URL(rawPath, `${gatewayUrl}/`);
+  if (url.origin !== new URL(gatewayUrl).origin || (!url.pathname.startsWith("/api/") && url.pathname !== "/api")) {
+    throw new Error("Gateway path must stay within this instance's /api/ namespace.");
+  }
+
+  let body: string | undefined;
+  if (opts.data !== undefined) {
+    if (method === "GET") throw new Error("GET requests cannot include --data.");
+    try {
+      body = JSON.stringify(JSON.parse(opts.data));
+    } catch {
+      throw new Error("--data must be valid JSON.");
+    }
+  }
+
+  const token = deps.token === undefined ? readGatewayAuthToken(JINN_HOME) : deps.token;
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+
+  const response = await (deps.fetchImpl ?? fetch)(url, {
+    method,
+    headers,
+    body,
+    redirect: "error",
+    signal: AbortSignal.timeout(30_000),
+  });
+  return { ok: response.ok, status: response.status, body: await response.text() };
+}
+
+export async function runApi(opts: GatewayApiOptions): Promise<void> {
+  try {
+    const result = await requestGatewayApi(opts);
+    if (result.body) process.stdout.write(`${result.body}${result.body.endsWith("\n") ? "" : "\n"}`);
+    if (!result.ok) {
+      console.error(`ryoko api: gateway returned HTTP ${result.status}`);
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`ryoko api: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/jimmy/src/cli/gateway-audit.ts
+++ b/packages/jimmy/src/cli/gateway-audit.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const MAX_TEXT_FILE_BYTES = 2 * 1024 * 1024;
+const SKIP_DIRECTORIES = new Set([
+  ".git", "node_modules", "dist", "sessions", "logs", "tmp", "jobs",
+  "files", "models", "backups", "src", "updates", "runs", "migrations",
+  "knowledge", "memory",
+]);
+const TEXT_EXTENSIONS = new Set([
+  ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".js", ".mjs",
+  ".cjs", ".ts", ".tsx", ".py", ".sh", ".bash", ".zsh",
+]);
+const TEXT_BASENAMES = new Set(["CLAUDE.md", "AGENTS.md", "SOUL.md", "TOOLS.md", "MEMORY.md"]);
+const LEGACY_V4 = /http:\/\/0\.0\.0\.0:(\d{1,5})/g;
+const LEGACY_V6 = /http:\/\/\[::\]:(\d{1,5})/g;
+
+export interface GatewayAuditReport {
+  legacyFiles: string[];
+  legacyOccurrences: number;
+  fixedFiles: string[];
+  unauthenticatedCurlCandidates: string[];
+  backupDir?: string;
+}
+
+export interface GatewayAuditOptions {
+  fix?: boolean;
+  now?: Date;
+}
+
+function isScannableTextFile(file: string, size: number): boolean {
+  if (size > MAX_TEXT_FILE_BYTES) return false;
+  return TEXT_BASENAMES.has(path.basename(file)) || TEXT_EXTENSIONS.has(path.extname(file).toLowerCase());
+}
+
+function collectTextFiles(home: string): string[] {
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+    catch { return; }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRECTORIES.has(entry.name)) walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const stat = fs.statSync(full);
+        if (isScannableTextFile(full, stat.size)) files.push(full);
+      } catch { /* file disappeared during scan */ }
+    }
+  };
+  walk(home);
+  return files;
+}
+
+function replacementCount(content: string): number {
+  return (content.match(LEGACY_V4) ?? []).length + (content.match(LEGACY_V6) ?? []).length;
+}
+
+function replaceLegacyGatewayUrls(content: string): string {
+  return content
+    .replace(LEGACY_V4, "http://127.0.0.1:$1")
+    .replace(LEGACY_V6, "http://[::1]:$1");
+}
+
+function looksLikeUnauthenticatedGatewayCurl(content: string): boolean {
+  const apiLines = content.split(/\r?\n/).filter((line) => /curl\b/.test(line) && /\/api\//.test(line));
+  if (apiLines.length === 0 || apiLines.every((line) => /\/api\/health(?:\b|[?"'])/.test(line))) return false;
+  return !/(?:Authorization\s*:.*Bearer|gateway-auth\.json|readGatewayAuthToken|ryoko\s+api\s+)/i.test(content);
+}
+
+function timestampForPath(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+function atomicWritePreservingMode(file: string, content: string, mode: number): void {
+  const temporary = `${file}.tmp-gateway-url-${process.pid}`;
+  fs.writeFileSync(temporary, content, { encoding: "utf8", mode });
+  fs.renameSync(temporary, file);
+  fs.chmodSync(file, mode);
+}
+
+/** Audit and optionally repair unsafe bind-address URLs under one instance home. */
+export function auditGatewayReferences(home: string, options: GatewayAuditOptions = {}): GatewayAuditReport {
+  const report: GatewayAuditReport = {
+    legacyFiles: [],
+    legacyOccurrences: 0,
+    fixedFiles: [],
+    unauthenticatedCurlCandidates: [],
+  };
+  let backupDir: string | undefined;
+
+  for (const file of collectTextFiles(home)) {
+    let content: string;
+    try {
+      const loaded = fs.readFileSync(file, "utf8");
+      if (typeof loaded !== "string") continue;
+      content = loaded;
+    }
+    catch { continue; }
+
+    const relative = path.relative(home, file);
+    const occurrences = replacementCount(content);
+    if (occurrences > 0) {
+      report.legacyFiles.push(relative);
+      report.legacyOccurrences += occurrences;
+      if (options.fix) {
+        backupDir ??= path.join(home, "backups", `gateway-url-${timestampForPath(options.now ?? new Date())}`);
+        const backupFile = path.join(backupDir, relative);
+        fs.mkdirSync(path.dirname(backupFile), { recursive: true, mode: 0o700 });
+        const mode = fs.statSync(file).mode & 0o777;
+        fs.copyFileSync(file, backupFile);
+        fs.chmodSync(backupFile, mode);
+        content = replaceLegacyGatewayUrls(content);
+        atomicWritePreservingMode(file, content, mode);
+        report.fixedFiles.push(relative);
+      }
+    }
+    if (looksLikeUnauthenticatedGatewayCurl(content)) report.unauthenticatedCurlCandidates.push(relative);
+  }
+
+  if (backupDir) report.backupDir = backupDir;
+  return report;
+}

--- a/packages/jimmy/src/cli/migrate.ts
+++ b/packages/jimmy/src/cli/migrate.ts
@@ -25,6 +25,7 @@ import {
   buildTemplateReplacements,
 } from "../shared/templateReplacements.js";
 import { parseConfigPatch, applyPatchOps, type PatchOutcome } from "../shared/configPatch.js";
+import { auditGatewayReferences } from "./gateway-audit.js";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -150,11 +151,29 @@ function buildMigrateArgs(engine: string, prompt: string): string[] {
   }
 }
 
-export async function runMigrate(opts: { check?: boolean; auto?: boolean }): Promise<void> {
+export async function runMigrate(opts: { check?: boolean; auto?: boolean; fix?: boolean }): Promise<void> {
   // Ensure instance exists
   if (!fs.existsSync(JINN_HOME)) {
     console.error(`${RED}エラー:${RESET} ${JINN_HOME} が存在しません。"ryoko setup" を実行してください。`);
     process.exit(1);
+  }
+
+  const shouldFixGatewayUrls = opts.fix === true || opts.auto === true;
+  const gatewayAudit = auditGatewayReferences(JINN_HOME, { fix: shouldFixGatewayUrls });
+  if (gatewayAudit.legacyOccurrences > 0) {
+    if (shouldFixGatewayUrls) {
+      console.log(`${GREEN}[gateway URL]${RESET} ${gatewayAudit.legacyOccurrences}箇所 / ${gatewayAudit.fixedFiles.length}ファイルをloopback URLへ修正しました。`);
+      if (gatewayAudit.backupDir) console.log(`${DIM}バックアップ: ${gatewayAudit.backupDir}${RESET}`);
+    } else {
+      console.log(`${YELLOW}[gateway URL warning]${RESET} ${gatewayAudit.legacyOccurrences}箇所 / ${gatewayAudit.legacyFiles.length}ファイルに http://0.0.0.0 または http://[::] が残っています。`);
+      console.log(`${YELLOW}ryoko migrate --fix${RESET} でバックアップ後にloopback URLへ置換できます。`);
+    }
+  }
+  if (gatewayAudit.unauthenticatedCurlCandidates.length > 0) {
+    console.log(`${YELLOW}[gateway auth warning]${RESET} 認証なしで保護APIを呼ぶ可能性があるcurlを ${gatewayAudit.unauthenticatedCurlCandidates.length}ファイルで検出しました。`);
+    for (const file of gatewayAudit.unauthenticatedCurlCandidates.slice(0, 10)) console.log(`  - ${file}`);
+    if (gatewayAudit.unauthenticatedCurlCandidates.length > 10) console.log(`  ...ほか ${gatewayAudit.unauthenticatedCurlCandidates.length - 10}ファイル`);
+    console.log(`${YELLOW}直接curlする代わりに ryoko api METHOD /api/... を使用してください。${RESET}`);
   }
 
   const packageVersion = getPackageVersion();

--- a/packages/jimmy/src/cli/pair.ts
+++ b/packages/jimmy/src/cli/pair.ts
@@ -2,18 +2,12 @@ import fs from "node:fs";
 import { JINN_HOME } from "../shared/paths.js";
 import { loadConfig } from "../shared/config.js";
 import { readGatewayAuthToken } from "../gateway/auth.js";
+import { localGatewayUrl } from "../shared/gateway-url.js";
 
 export interface PairingCodeResponse {
   code: string;
   expiresAt: string;
   ttlSeconds: number;
-}
-
-function localGatewayUrl(host: string, port: number): string {
-  if (host === "0.0.0.0") return `http://127.0.0.1:${port}`;
-  if (host === "::" || host === "[::]") return `http://[::1]:${port}`;
-  const formatted = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
-  return `http://${formatted}:${port}`;
 }
 
 export async function requestPairingCode(options?: { fetchImpl?: typeof fetch }): Promise<PairingCodeResponse> {

--- a/packages/jimmy/src/cli/status.ts
+++ b/packages/jimmy/src/cli/status.ts
@@ -1,5 +1,6 @@
 import { getStatus } from "../gateway/lifecycle.js";
 import { loadConfig } from "../shared/config.js";
+import { gatewayUrlFromConfig } from "../shared/gateway-url.js";
 import { JINN_HOME, PID_FILE } from "../shared/paths.js";
 import fs from "node:fs";
 import { readGatewayAuthToken } from "../gateway/auth.js";
@@ -39,7 +40,7 @@ export async function runStatus(): Promise<void> {
   // ゲートウェイからライブ統計を取得
   try {
     const config = loadConfig();
-    const url = `http://${config.gateway.host}:${config.gateway.port}/api/status`;
+    const url = `${gatewayUrlFromConfig(config)}/api/status`;
     const token = readGatewayAuthToken(JINN_HOME);
     const res = await fetch(url, {
       signal: AbortSignal.timeout(3000),
@@ -62,12 +63,20 @@ export async function runStatus(): Promise<void> {
       if (data.uptime !== undefined) {
         console.log(`  サーバー稼働時間: ${data.uptime}秒`);
       }
+    } else {
+      let detail = "";
+      try {
+        const payload = await res.json() as { error?: unknown; hint?: unknown };
+        const message = typeof payload.hint === "string" ? payload.hint : payload.error;
+        if (typeof message === "string") detail = `: ${message}`;
+      } catch { /* non-JSON error body */ }
+      console.log(`  ポート: ${config.gateway.port}（HTTP ${res.status}${detail}）`);
     }
-  } catch {
-    // HTTPに応答しない場合はスキップ
+  } catch (error) {
     try {
       const config = loadConfig();
-      console.log(`  ポート: ${config.gateway.port}（HTTPに応答なし）`);
+      const reason = error instanceof Error ? `: ${error.message}` : "";
+      console.log(`  ポート: ${config.gateway.port}（HTTPに応答なし${reason}）`);
     } catch {
       // no config
     }

--- a/packages/jimmy/src/gateway/__tests__/host-guard.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/host-guard.test.ts
@@ -17,4 +17,13 @@ describe("gateway Host guard", () => {
     expect(hostHeaderAllowed("ryoko.example.com:443", "0.0.0.0", ["ryoko.example.com"], [])).toBe(true);
     expect(hostHeaderAllowed("RYOKO.EXAMPLE.COM.:443", "::", ["ryoko.example.com"], [])).toBe(true);
   });
+
+  it("always rejects wildcard Host values, even on a wildcard bind", () => {
+    expect(hostHeaderAllowed("0.0.0.0:7777", "0.0.0.0", [], [])).toBe(false);
+    expect(hostHeaderAllowed("[::]:7777", "::", [], [])).toBe(false);
+    expect(hostHeaderAllowed("0.0.0.0:7777", "0.0.0.0", ["0.0.0.0"], [])).toBe(false);
+    expect(hostHeaderAllowed("[::]:7777", "::", ["::"], [])).toBe(false);
+    expect(hostHeaderAllowed("attacker.example:7777", "0.0.0.0", [], [])).toBe(false);
+    expect(hostHeaderAllowed(undefined, "0.0.0.0", [], [])).toBe(false);
+  });
 });

--- a/packages/jimmy/src/gateway/host-guard.ts
+++ b/packages/jimmy/src/gateway/host-guard.ts
@@ -40,11 +40,12 @@ export function hostHeaderAllowed(
   if (LOOPBACK_HOSTS.has(requested)) return true;
 
   const configured = normalizeHost(configuredHost);
+
   const explicitHosts = Array.isArray(allowedHosts) ? allowedHosts.filter((host) => typeof host === "string") : [];
   const allowed = new Set(
     [...explicitHosts, ...(configured && WILDCARD_HOSTS.has(configured) ? interfaceHosts : [])]
       .map((host) => normalizeHost(host))
-      .filter((host): host is string => Boolean(host)),
+      .filter((host): host is string => host !== null && !WILDCARD_HOSTS.has(host)),
   );
   if (configured && !WILDCARD_HOSTS.has(configured)) allowed.add(configured);
   return allowed.has(requested);

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -49,6 +49,7 @@ import { createDailyDatabaseBackup } from "../sessions/backup.js";
 import { getDiskSpaceStatus } from "../shared/storage-health.js";
 import { requestOriginAllowed } from "./request-origin.js";
 import { hostHeaderAllowed, localInterfaceHosts } from "./host-guard.js";
+import { isWildcardBindHost, localGatewayUrl } from "../shared/gateway-url.js";
 import { staticPathWithinRoot } from "./static-path.js";
 
 
@@ -939,8 +940,37 @@ export async function startGateway(
   // `Host` is not loopback, a local interface, or explicitly configured.
   const configuredHost = config.gateway.host || "127.0.0.1";
   const interfaceHosts = localInterfaceHosts();
-  function hostIsAllowed(hostHeader: string | undefined): boolean {
-    return hostHeaderAllowed(hostHeader, configuredHost, currentConfig.gateway.allowedHosts, interfaceHosts);
+  const connectUrl = localGatewayUrl(configuredHost, config.gateway.port || 7777);
+  const configuredAllowedHosts = Array.isArray(currentConfig.gateway.allowedHosts) ? currentConfig.gateway.allowedHosts : [];
+  const ignoredWildcardAllowedHosts = configuredAllowedHosts.filter((host) => isWildcardBindHost(host));
+  if (ignoredWildcardAllowedHosts.length > 0) {
+    logger.warn(
+      `Ignoring wildcard value(s) in gateway.allowedHosts (${ignoredWildcardAllowedHosts.join(", ")}). `
+        + `Wildcard bind addresses are never safe Host allowlist entries; connect to ${connectUrl} instead.`,
+    );
+  }
+  // Publish the *connectable* URL to every child process we spawn (engine CLIs
+  // inherit process.env via buildChildEnv). Skills and scripts should read
+  // $RYOKO_GATEWAY_URL rather than hard-coding a host they can get wrong.
+  process.env.RYOKO_GATEWAY_URL = connectUrl;
+  function hostIsAllowed(req: http.IncomingMessage): boolean {
+    return hostHeaderAllowed(req.headers.host, configuredHost, currentConfig.gateway.allowedHosts, interfaceHosts);
+  }
+
+  // A silent 421 is how this guard bites: a cron script gets an empty body, the
+  // run is still recorded "success", and the Slack post just never happens. Say
+  // out loud what was rejected and what to use instead — but only once per
+  // distinct Host, so a hostile tab in a retry loop can't flood the log.
+  const warnedRejectedHosts = new Set<string>();
+  function warnHostRejected(hostHeader: string | undefined): void {
+    const key = (hostHeader || "<missing>").toLowerCase().replace(/[^\x20-\x7e]/g, "?").slice(0, 200);
+    if (warnedRejectedHosts.has(key)) return;
+    if (warnedRejectedHosts.size >= 50) return;
+    warnedRejectedHosts.add(key);
+    logger.warn(
+      `host_not_allowed: rejected Host="${key}". `
+        + `Connect to ${connectUrl} instead. Real proxy hostnames may be added to gateway.allowedHosts; wildcard bind addresses cannot.`,
+    );
   }
 
   // Create HTTP server
@@ -950,9 +980,15 @@ export async function startGateway(
     // Host header check before anything else — applies to both API and
     // static asset paths so a malicious cross-origin browser tab can't
     // pull session JSON either.
-    if (!hostIsAllowed(req.headers.host)) {
+    if (!hostIsAllowed(req)) {
+      warnHostRejected(req.headers.host);
       res.writeHead(421, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "host_not_allowed" }));
+      res.end(JSON.stringify({
+        error: "host_not_allowed",
+        host: req.headers.host ?? null,
+        hint: `Use ${connectUrl} — "${configuredHost}" is the bind address, not a connectable host. `
+          + `Real proxy hostnames may be added to gateway.allowedHosts; wildcard bind addresses cannot.`,
+      }));
       return;
     }
 
@@ -1035,7 +1071,7 @@ export async function startGateway(
     const reqUrl = req.url || "";
     // DNS-rebinding / cross-host guard — mirror the HTTP request path so a WS
     // upgrade can't bypass it. Applies to both /ws and /ws/pty.
-    if (!hostIsAllowed(req.headers.host)) { socket.destroy(); return; }
+    if (!hostIsAllowed(req)) { warnHostRejected(req.headers.host); socket.destroy(); return; }
     if (!requestOriginAllowed(req.headers.origin, req.headers.host, configuredHost)) { socket.destroy(); return; }
     if (authRequired && !verifyGatewayAuth(req.headers, authToken, JINN_HOME)) { socket.destroy(); return; }
     if (reqUrl === "/ws") {
@@ -1175,7 +1211,12 @@ export async function startGateway(
       reject(err);
     });
     server.listen(port, host, () => {
-      logger.info(`${gatewayName} gateway listening on http://${host}:${port} (boot ${bootId})`);
+      logger.info(`${gatewayName} gateway listening on ${host}:${port} (boot ${bootId})`);
+      if (isWildcardBindHost(host)) {
+        // Wildcard/network binds are the case people get wrong: they copy the
+        // bind address into a client URL and get 421'd by the guard above.
+        logger.info(`Local clients must connect to ${localGatewayUrl(host, port)} — not http://${host}:${port}`);
+      }
       resolve();
     });
   });

--- a/packages/jimmy/src/sessions/__tests__/gateway-connect-context.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/gateway-connect-context.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildContext } from "../context.js";
+
+const config = {
+  jinn: { version: "2026.8.20" },
+  gateway: { host: "0.0.0.0", port: 7777 },
+  engines: {
+    default: "claude",
+    claude: { bin: "claude", model: "" },
+    codex: { bin: "codex", model: "" },
+  },
+  connectors: {},
+  logging: { level: "info", stdout: false, file: "" },
+};
+
+describe("buildContext gateway instructions", () => {
+  it("never turns a wildcard bind into a client URL", () => {
+    const context = buildContext({
+      source: "slack",
+      channel: "C123",
+      user: "U123",
+      config: config as never,
+    });
+
+    expect(context).toContain("Gateway: http://127.0.0.1:7777");
+    expect(context).not.toContain("http://0.0.0.0:7777");
+  });
+
+  it("uses the authenticated CLI helper in delegation examples", () => {
+    const context = buildContext({
+      source: "slack",
+      channel: "C123",
+      user: "U123",
+      config: config as never,
+    });
+
+    expect(context).toContain("ryoko api POST /api/sessions");
+    expect(context).toContain("ryoko api GET /api/sessions/<your-session-id>/children");
+    expect(context).toContain("adds the instance's bearer token");
+  });
+});

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { Employee, JinnConfig } from "../shared/types.js";
+import { gatewayUrlFromConfig } from "../shared/gateway-url.js";
 import { JINN_HOME, ORG_DIR, CRON_JOBS, DOCS_DIR } from "../shared/paths.js";
 import { isOperatorSpeaker } from "../shared/operator-match.js";
 import { scanOrg } from "../gateway/org.js";
@@ -84,10 +85,11 @@ export function buildContext(opts: {
   const maxChars = opts.config?.context?.maxChars ?? DEFAULT_MAX_CONTEXT_CHARS;
   const sections: Section[] = [];
 
-  // Compute gateway URL once — used by multiple sections
-  const gatewayUrl = opts.config
-    ? `http://${opts.config.gateway.host || "127.0.0.1"}:${opts.config.gateway.port || 7777}`
-    : "http://127.0.0.1:7777";
+  // Compute gateway URL once — used by multiple sections.
+  // MUST go through gatewayUrlFromConfig: `gateway.host` is a *bind* address, and
+  // a wildcard bind (0.0.0.0) is not a connectable target — the host guard would
+  // 421 every curl example we bake into this prompt.
+  const gatewayUrl = gatewayUrlFromConfig(opts.config);
 
   // Resolve personalized names from config
   const portalName = opts.portalName || opts.config?.portal?.portalName || "Ryoko";
@@ -193,7 +195,7 @@ export function buildContext(opts: {
         tier: Tier.STANDARD,
         marker: "## Available services",
         content: svcCtx,
-        summary: `## Available services\nUse \`POST ${gatewayUrl}/api/org/cross-request\` to request services from other employees.`,
+        summary: "## Available services\nUse `ryoko api POST /api/org/cross-request --data '{...}'` to request services from other employees.",
       });
     }
   }
@@ -257,7 +259,7 @@ export function buildContext(opts: {
       tier: Tier.OPTIONAL,
       marker: "## Employee Delegation",
       content: buildDelegationProtocol(gatewayUrl, portalName, opts.config),
-      summary: `## Employee Delegation Protocol\nDelegate via \`POST ${gatewayUrl}/api/sessions\` with \`{prompt, employee, parentSessionId}\`. Check children via \`GET /api/sessions/:id/children\`.`,
+      summary: "## Employee Delegation Protocol\nDelegate via `ryoko api POST /api/sessions --data '{...}'`. Check children via `ryoko api GET /api/sessions/:id/children`.",
     });
   }
 
@@ -368,7 +370,7 @@ function buildChainOfCommand(
   return "\n" + lines.join("\n") + "\n";
 }
 
-function buildServicesContext(employee: Employee, gatewayUrl: string): string | null {
+function buildServicesContext(employee: Employee, _gatewayUrl: string): string | null {
   try {
     const registry = scanOrg();
     const services = buildServiceRegistry(registry);
@@ -376,7 +378,7 @@ function buildServicesContext(employee: Employee, gatewayUrl: string): string | 
 
     const lines: string[] = ["## Available services"];
     lines.push("Other employees provide the following services. To request one, use the cross-request API:");
-    lines.push(`\`POST ${gatewayUrl}/api/org/cross-request\` with \`{"fromEmployee": "${employee.name}", "service": "<name>", "prompt": "<what you need>"}\``);
+    lines.push(`\`ryoko api POST /api/org/cross-request --data '{"fromEmployee": "${employee.name}", "service": "<name>", "prompt": "<what you need>"}'\``);
     lines.push("");
 
     for (const [svcName, entry] of services) {
@@ -740,7 +742,7 @@ export function buildDetachedJobsContext(sessionId?: string, jobsDir?: string): 
   return lines.join("\n");
 }
 
-function buildConnectorContext(connectors: string[], gatewayUrl: string, portalName: string): string {
+function buildConnectorContext(connectors: string[], _gatewayUrl: string, portalName: string): string {
   const lines: string[] = [`## Available connectors: ${connectors.join(", ")}`];
   lines.push(`You can send messages and interact with external services via the ${portalName} gateway API.`);
   lines.push("Use connector messaging only for proactive messages to a different channel or conversation.\n");
@@ -763,7 +765,7 @@ function buildConnectorContext(connectors: string[], gatewayUrl: string, portalN
   lines.push("  The `internal` field is never posted publicly (saved for the operator). `react` makes the public reply a single emoji reaction; `suppressPublic` omits the public body.");
   lines.push("- When you are directly addressed (mentioned / asked), ALWAYS give a non-empty public reply. Use react-only for pure acknowledgments or social confirmations — never as the answer to a substantive question.");
 
-  lines.push(`\n- **List all connectors**: \`curl ${gatewayUrl}/api/connectors\``);
+  lines.push("\n- **List all connectors**: `ryoko api GET /api/connectors`");
   lines.push(`- Channel IDs and connector config can be found in \`~/.jinn/config.yaml\``);
   return lines.join("\n");
 }
@@ -873,7 +875,7 @@ function buildEvolutionContext(portalName: string, config?: JinnConfig): string 
         `- OR the user just successfully connected Slack and is exploring what to do next.`,
       );
       lines.push(
-        `When you do bring it up, keep it to one sentence and point them to **Settings → Slack → Agents View Canvas** in the Web UI. The user can also delegate the toggling to you (Bash tool: \`curl -X PUT http://...:7777/api/config\`) if they ask.`,
+        `When you do bring it up, keep it to one sentence and point them to **Settings → Slack → Agents View Canvas** in the Web UI. The user can also delegate the toggling to you (Bash tool: \`ryoko api PUT /api/config --data '{...}'\`) if they ask.`,
       );
     }
   }
@@ -885,7 +887,7 @@ function buildEvolutionContext(portalName: string, config?: JinnConfig): string 
  * Delegation protocol: condensed version focusing on the essential API patterns.
  * Verbose examples and multi-paragraph explanations have been trimmed.
  */
-function buildDelegationProtocol(gatewayUrl: string, _portalName: string, config?: JinnConfig): string {
+function buildDelegationProtocol(_gatewayUrl: string, _portalName: string, config?: JinnConfig): string {
   const defaultEngine = config?.engines.default || "claude";
   const engineConfig = defaultEngine === "codex"
     ? config?.engines.codex
@@ -908,7 +910,7 @@ You are the COO. You orchestrate employees by creating **linked child sessions**
 
 2. **Check for existing children first**:
 \`\`\`bash
-curl -s ${gatewayUrl}/api/sessions/<your-session-id>/children
+ryoko api GET /api/sessions/<your-session-id>/children
 \`\`\`
 If a child exists for this employee, reuse it (skip to step 5).
 
@@ -916,16 +918,14 @@ If a child exists for this employee, reuse it (skip to step 5).
 
 4. **Spawn**:
 \`\`\`bash
-curl -s -X POST ${gatewayUrl}/api/sessions \\
-  -H 'Content-Type: application/json' \\
-  -d '{"prompt": "<brief>", "employee": "<name>", "parentSessionId": "<your-session-id>"}'
+ryoko api POST /api/sessions \\
+  --data '{"prompt": "<brief>", "employee": "<name>", "parentSessionId": "<your-session-id>"}'
 \`\`\`
 
 5. **Follow up** (existing child):
 \`\`\`bash
-curl -s -X POST ${gatewayUrl}/api/sessions/<child-id>/message \\
-  -H 'Content-Type: application/json' \\
-  -d '{"message": "<follow-up>"}'
+ryoko api POST /api/sessions/<child-id>/message \\
+  --data '{"message": "<follow-up>"}'
 \`\`\`
 
 6. **Respond immediately**: Tell the user you've delegated and will follow up when it's done. **Do NOT poll or wait** — end your turn now.
@@ -961,7 +961,14 @@ Your current session ID is in the "Current session" section above. Use it as \`p
 function buildApiReference(gatewayUrl: string, portalName: string): string {
   return `## ${portalName} Gateway API (${gatewayUrl})
 
-You can call these endpoints with curl to inspect and manage the gateway:
+Use \`ryoko api GET /api/status\` (or \`POST ... --data '{...}'\`) for local API calls.
+It chooses a connectable loopback URL, adds the instance's bearer token, refuses external URLs,
+and reports non-2xx responses instead of failing silently. For tools that cannot invoke the CLI,
+the connectable URL is exported as \`$RYOKO_GATEWAY_URL\`; those callers must still add the bearer
+token. Never turn the bind address from config (\`gateway.host\`) into a URL: a wildcard bind like
+\`0.0.0.0\` is not a client destination and the gateway answers \`421 host_not_allowed\`.
+
+You can call these endpoints with \`ryoko api\` to inspect and manage the gateway:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|

--- a/packages/jimmy/src/shared/__tests__/gateway-url.test.ts
+++ b/packages/jimmy/src/shared/__tests__/gateway-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { gatewayUrlFromConfig, isWildcardBindHost, localGatewayUrl } from "../gateway-url.js";
+
+describe("localGatewayUrl", () => {
+  it("collapses a wildcard bind to loopback", () => {
+    expect(localGatewayUrl("0.0.0.0", 7777)).toBe("http://127.0.0.1:7777");
+    expect(localGatewayUrl("::", 7777)).toBe("http://[::1]:7777");
+    expect(localGatewayUrl("[::]", 7777)).toBe("http://[::1]:7777");
+  });
+
+  it("keeps a specific bind address as the connect host", () => {
+    expect(localGatewayUrl("127.0.0.1", 7777)).toBe("http://127.0.0.1:7777");
+    expect(localGatewayUrl("192.168.1.5", 8080)).toBe("http://192.168.1.5:8080");
+    expect(localGatewayUrl("ryoko.example.com", 443)).toBe("http://ryoko.example.com:443");
+  });
+
+  it("brackets a bare IPv6 address so the result stays a valid URL", () => {
+    expect(localGatewayUrl("fd00::1", 7777)).toBe("http://[fd00::1]:7777");
+    expect(new URL(localGatewayUrl("fd00::1", 7777)).hostname).toBe("[fd00::1]");
+  });
+
+  it("falls back to loopback and the default port", () => {
+    expect(localGatewayUrl(undefined, undefined)).toBe("http://127.0.0.1:7777");
+    expect(localGatewayUrl("  ", 0)).toBe("http://127.0.0.1:7777");
+    expect(gatewayUrlFromConfig(undefined)).toBe("http://127.0.0.1:7777");
+    expect(gatewayUrlFromConfig({ gateway: { host: "0.0.0.0", port: 9000 } })).toBe("http://127.0.0.1:9000");
+  });
+
+  it("identifies wildcard binds", () => {
+    expect(isWildcardBindHost("0.0.0.0")).toBe(true);
+    expect(isWildcardBindHost("::")).toBe(true);
+    expect(isWildcardBindHost("[::]")).toBe(true);
+    expect(isWildcardBindHost("127.0.0.1")).toBe(false);
+    expect(isWildcardBindHost(undefined)).toBe(false);
+  });
+});

--- a/packages/jimmy/src/shared/gateway-url.ts
+++ b/packages/jimmy/src/shared/gateway-url.ts
@@ -1,0 +1,41 @@
+/**
+ * Bind address → connect URL.
+ *
+ * `gateway.host` answers "where do we listen", never "where do clients connect".
+ * A wildcard bind (`0.0.0.0` / `::`) is not a valid client destination: sending
+ * `Host: 0.0.0.0` gets rejected by the gateway's own DNS-rebinding guard
+ * (`host-guard.ts`). Every caller that turns the configured host into a URL must
+ * go through here, or it hands out a URL the gateway will answer with 421.
+ */
+
+const WILDCARD_V4 = new Set(["0.0.0.0", "0.0.0.0.", "*"]);
+const WILDCARD_V6 = new Set(["::", "[::]", "0:0:0:0:0:0:0:0", "[0:0:0:0:0:0:0:0]"]);
+
+export const DEFAULT_GATEWAY_PORT = 7777;
+
+/** True when the host is a wildcard bind address rather than a routable target. */
+export function isWildcardBindHost(host: string | undefined | null): boolean {
+  if (!host) return false;
+  const raw = host.trim().toLowerCase();
+  return WILDCARD_V4.has(raw) || WILDCARD_V6.has(raw);
+}
+
+/**
+ * The loopback URL a local client should use to reach the gateway.
+ * Wildcard binds collapse to loopback; a specific bind is returned as-is
+ * (bracketing bare IPv6 so the result stays a valid URL).
+ */
+export function localGatewayUrl(host: string | undefined | null, port: number | undefined | null): string {
+  const resolvedPort = port || DEFAULT_GATEWAY_PORT;
+  const raw = (host || "").trim();
+  if (!raw) return `http://127.0.0.1:${resolvedPort}`;
+  if (WILDCARD_V4.has(raw.toLowerCase())) return `http://127.0.0.1:${resolvedPort}`;
+  if (WILDCARD_V6.has(raw.toLowerCase())) return `http://[::1]:${resolvedPort}`;
+  const formatted = raw.includes(":") && !raw.startsWith("[") ? `[${raw}]` : raw;
+  return `http://${formatted}:${resolvedPort}`;
+}
+
+/** Convenience wrapper for the common `config.gateway` shape. */
+export function gatewayUrlFromConfig(config?: { gateway?: { host?: string; port?: number } } | null): string {
+  return localGatewayUrl(config?.gateway?.host, config?.gateway?.port);
+}

--- a/packages/jimmy/template/config.default.yaml
+++ b/packages/jimmy/template/config.default.yaml
@@ -4,7 +4,10 @@ jinn:
 gateway:
   port: 7777
   host: "127.0.0.1"
-  # 0.0.0.0 / :: で公開する場合、実NICのIP以外のHost名は明示許可する
+  # host は「どこで待ち受けるか」であって「どこへ接続するか」ではない。
+  # 0.0.0.0 / :: で公開しても、ローカルからの接続先は http://127.0.0.1:7777 を使う
+  # （接続可能なURLは $RYOKO_GATEWAY_URL として全プロセスに渡される）。
+  # リバースプロキシ等で実NICのIP以外のHost名を使う場合は明示許可する
   # allowedHosts: ["ryoko.example.com"]
   # 信頼できるHTTPSリバースプロキシの直後でのみ有効化する
   # trustProxyHeaders: false

--- a/packages/jimmy/template/migrations/2026.8.20/MIGRATION.md
+++ b/packages/jimmy/template/migrations/2026.8.20/MIGRATION.md
@@ -1,0 +1,46 @@
+# Migration: 2026.8.20（Gateway bind / connect URL分離）
+
+## 概要
+
+`gateway.host` はGatewayが待ち受けるアドレスであり、AI、Cron、CLI、スクリプトが
+接続するURLではありません。`0.0.0.0` / `::` を接続先に使うとHostガードに拒否され、
+2026.8.19では `421 host_not_allowed` による無言の失敗が発生する場合がありました。
+
+本バージョンでは内部の接続先をloopbackへ統一し、認証付きの `ryoko api` コマンドを
+追加します。
+
+## 自動マイグレーション
+
+`ryoko update` / `ryoko migrate --auto` は、インスタンスホーム内のテキストファイルから
+以下を探し、変更前のバックアップを作成して置換します。
+
+- `http://0.0.0.0:<port>` → `http://127.0.0.1:<port>`
+- `http://[::]:<port>` → `http://[::1]:<port>`
+
+対象は `~/.ryoko` 内の設定、Cron定義、スキル、ドキュメント、スクリプトです。
+symlink、ログ、DB、モデル、source checkout、2 MiBを超えるファイルは変更しません。
+バックアップは `~/.ryoko/backups/gateway-url-<timestamp>/` に保存します。
+
+また、保護された `/api/` を直接curlしているのにBearer認証処理が見当たらないファイルは
+警告します。認証処理は自動推測で書き換えず、次のCLIへ移行してください。
+
+```bash
+ryoko api GET /api/status
+ryoko api POST /api/sessions --data '{"prompt":"..."}'
+```
+
+## 手動確認・再実行
+
+```bash
+ryoko migrate --check
+ryoko migrate --fix
+```
+
+`~/.ryoko` 外の独自スクリプトは自動変更されません。直接HTTPが必要な場合は、子プロセスへ
+渡される `$RYOKO_GATEWAY_URL` を接続先にし、`gateway-auth.json` のtokenをBearerとして
+付与してください。通常はtokenを手書きしない `ryoko api` を推奨します。
+
+## セキュリティ
+
+Hostガードは緩和しません。`gateway.allowedHosts` に `0.0.0.0` / `::` を追加しても無視されます。
+応急処置で追加していた場合は設定から削除できます。

--- a/packages/jimmy/template/skills/sync/SKILL.md
+++ b/packages/jimmy/template/skills/sync/SKILL.md
@@ -22,21 +22,21 @@ You fetch the conversation yourself using the gateway API. No magic injection â€
 2. **List all sessions** to find the employee's most recent one:
 
 ```bash
-curl -s $GATEWAY_URL/api/sessions | jq '[.[] | select(.employee == "EMPLOYEE_NAME")] | sort_by(.lastActivity) | reverse | .[0]'
+ryoko api GET /api/sessions | jq '[.[] | select(.employee == "EMPLOYEE_NAME")] | sort_by(.lastActivity) | reverse | .[0]'
 ```
 
-Replace `EMPLOYEE_NAME` with the target and `$GATEWAY_URL` with the gateway URL from your system prompt. This gives you the most recent session for that employee.
+Replace `EMPLOYEE_NAME` with the target. `ryoko api` selects the safe local URL and adds gateway authentication automatically. This gives you the most recent session for that employee.
 
 **Tip**: Your own session ID is in the "Current session" section of your system prompt. If you want to exclude child sessions of the current session (to avoid circular references), filter with:
 
 ```bash
-curl -s $GATEWAY_URL/api/sessions | jq '[.[] | select(.employee == "EMPLOYEE_NAME" and .parentSessionId != "YOUR_SESSION_ID")] | sort_by(.lastActivity) | reverse | .[0]'
+ryoko api GET /api/sessions | jq '[.[] | select(.employee == "EMPLOYEE_NAME" and .parentSessionId != "YOUR_SESSION_ID")] | sort_by(.lastActivity) | reverse | .[0]'
 ```
 
 3. **Fetch the full conversation** using the session ID from step 2:
 
 ```bash
-curl -s $GATEWAY_URL/api/sessions/SESSION_ID | jq '.messages'
+ryoko api GET /api/sessions/SESSION_ID | jq '.messages'
 ```
 
 This returns all messages with `role` and `content` fields. Read through them to understand what was discussed.
@@ -55,7 +55,7 @@ After fetching and reading the conversation:
 
 - **No sessions found**: If no sessions exist for that employee, tell the user: "I don't see any recent conversations with @employee-name."
 - **Empty messages**: If the session exists but has no messages, note that the session was created but no conversation happened yet.
-- **Employee not found**: If the name doesn't match any sessions, suggest the user check the org with `curl -s $GATEWAY_URL/api/org` to see available employees.
+- **Employee not found**: If the name doesn't match any sessions, suggest the user check the org with `ryoko api GET /api/org` to see available employees.
 - **Very long conversations**: You decide how much to read. You can fetch the full conversation and focus on the most recent messages, or read everything if it's short. No artificial limits.
 
 ## Examples


### PR DESCRIPTION
## What changed

- Separate gateway bind addresses from client connection URLs across prompts, status, pairing, and child-process environments.
- Add `ryoko api METHOD /api/...`, which selects the local URL, adds the instance bearer token, rejects external URLs and redirects, validates JSON, and returns non-2xx failures visibly.
- Add update-time migration auditing for legacy `0.0.0.0` / `[::]` URLs with restrictive backups and atomic fixes.
- Warn about likely unauthenticated direct API curls.
- Add actionable 421 responses and bounded Host rejection logging.
- Update shipped examples and documentation to use the authenticated helper.

## Root cause

`gateway.host` describes where the server listens, but it was also interpolated into client URLs. With a wildcard bind, OpenRyoko told AI sessions and CLI commands to connect to `0.0.0.0`; the strict Host guard correctly rejected those requests with 421. Some callers swallowed the HTTP failure, so Cron or Slack delivery could disappear while the task looked successful.

## Security design

- The Host guard stays strict. Wildcard Host values are rejected regardless of browser metadata.
- Wildcard entries in `gateway.allowedHosts` are ignored and warned about.
- The API helper accepts only local `/api` paths and uses `redirect: "error"`, preventing bearer-token exfiltration.
- Migration scanning skips symlinks, runtime data, logs, databases, models, source checkouts, backups, and large files.
- Modified files are backed up under a private directory and replaced atomically with their original permissions.

## User impact

Network-bound instances no longer hand their own agents unusable URLs. Existing instance files are repaired automatically by `ryoko update`; manual inspection and repair remain available through `ryoko migrate --check` and `ryoko migrate --fix`.

## Verification

- Backend: 97 test files / 780 tests passed.
- Web: 12 test files / 85 tests passed.
- TypeScript typecheck and production build passed.
- Real isolated wildcard-bind gateway:
  - loopback health: 200
  - wildcard and attacker Host: 421
  - unauthenticated protected API: 401
  - `ryoko api`: authenticated 200
  - repeated rejected Host: one bounded warning
- Production dependency audit: no known vulnerabilities.
- npm artifact secret/private-path and contents scans passed.

Claude review was intentionally skipped at the user's request after the CLI review process failed to return output.