### PR TITLE
fix(jobs): Gateway認証下で完了通知が消える問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.8.21] - 2026-08-20
+
+> Gateway認証を有効にした環境で、`ryoko job run` の完了通知が401になり、元のセッションが起床しない問題を修正。
+
+### Reliability / Fixes
+
+- 完了通知の全リトライに、このOpenRyoko instanceのBearer tokenを自動付与。
+- 各リトライ直前にtokenを再読込し、Gateway再起動中にtokenが作成・更新された場合も復旧。
+- Gateway認証を無効化した既存環境との互換性、および通知のdedupe挙動を維持。
+
+### Verification
+
+- Backend: **97 test files / 782 tests pass**
+- backend TypeScript typecheck、production build、`git diff --check`
+- token付与、token未作成時の互換性、401後のtoken再読込、実job monitor経路を回帰テスト化
+
 ## [2026.8.20] - 2026-08-18
 
 > `gateway.host: 0.0.0.0` / `::` の環境で、AIやCLIへ渡されたURLがGateway自身に

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.8.20",
+  "version": "2026.8.21",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/jobs/__tests__/monitor.test.ts
+++ b/packages/jimmy/src/jobs/__tests__/monitor.test.ts
@@ -16,7 +16,7 @@ describe("runJobMonitor", () => {
   let dir: string;
   let server: http.Server;
   let gatewayUrl: string;
-  let received: { url: string; body: { message: string; role: string } }[];
+  let received: { url: string; authorization?: string; body: { message: string; role: string } }[];
 
   beforeEach(async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "job-monitor-"));
@@ -25,7 +25,11 @@ describe("runJobMonitor", () => {
       let raw = "";
       req.on("data", (c) => (raw += c));
       req.on("end", () => {
-        received.push({ url: req.url ?? "", body: JSON.parse(raw) });
+        received.push({
+          url: req.url ?? "",
+          authorization: req.headers.authorization,
+          body: JSON.parse(raw),
+        });
         res.writeHead(200, { "content-type": "application/json" });
         res.end("{}");
       });
@@ -60,7 +64,11 @@ describe("runJobMonitor", () => {
 
   it("success: runs the command, logs output, wakes the session once with exit 0", async () => {
     seedJob();
-    const final = await runJobMonitor("j1", { jobsDir: dir, retryDelaysMs: [10] });
+    const final = await runJobMonitor("j1", {
+      jobsDir: dir,
+      retryDelaysMs: [10],
+      readAuthToken: () => "monitor-gateway-token",
+    });
 
     expect(final?.status).toBe("notified");
     expect(final?.exitCode).toBe(0);
@@ -68,6 +76,7 @@ describe("runJobMonitor", () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].url).toBe("/api/sessions/sess-42/message");
+    expect(received[0].authorization).toBe("Bearer monitor-gateway-token");
     expect(received[0].body.role).toBe("notification");
     expect(received[0].body.message).toContain('✅ Detached job "test-job" completed successfully');
     expect(received[0].body.message).toContain("hello-from-job");

--- a/packages/jimmy/src/jobs/__tests__/notify.test.ts
+++ b/packages/jimmy/src/jobs/__tests__/notify.test.ts
@@ -90,12 +90,45 @@ describe("sendJobNotification", () => {
 
   it("posts the notification to the session message route", async () => {
     const fetchFn = vi.fn(async () => new Response("{}", { status: 200 }));
-    const result = await sendJobNotification(makeState(), "msg", { fetchFn, sleep });
+    const result = await sendJobNotification(makeState(), "msg", {
+      fetchFn,
+      sleep,
+      readAuthToken: () => "test-gateway-token",
+    });
     expect(result.ok).toBe(true);
     expect(fetchFn).toHaveBeenCalledTimes(1);
     const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("http://127.0.0.1:7777/api/sessions/sess-1/message");
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer test-gateway-token");
     expect(JSON.parse(String(init.body))).toEqual({ message: "msg", role: "notification", dedupeKey: "job:pdf-build-1" });
+  });
+
+  it("omits authorization when gateway auth has not been initialized", async () => {
+    const fetchFn = vi.fn(async () => new Response("{}", { status: 200 }));
+    await sendJobNotification(makeState(), "msg", { fetchFn, sleep, readAuthToken: () => null });
+
+    const [, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit];
+    expect(new Headers(init.headers).has("authorization")).toBe(false);
+  });
+
+  it("reloads the gateway token for each retry", async () => {
+    const tokens = ["stale-token", "current-token"];
+    const readAuthToken = vi.fn(() => tokens.shift() ?? null);
+    const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("authorization");
+      return new Response("{}", { status: authorization === "Bearer current-token" ? 200 : 401 });
+    });
+
+    const result = await sendJobNotification(makeState(), "msg", {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      sleep,
+      readAuthToken,
+      retryDelaysMs: [1],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readAuthToken).toHaveBeenCalledTimes(2);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
   it("retries through gateway downtime and succeeds exactly once", async () => {

--- a/packages/jimmy/src/jobs/notify.ts
+++ b/packages/jimmy/src/jobs/notify.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { readGatewayAuthToken } from "../gateway/auth.js";
+import { JINN_HOME } from "../shared/paths.js";
 import type { JobState } from "./state.js";
 
 /**
@@ -98,6 +100,8 @@ export function assertLoopbackGatewayUrl(gatewayUrl: string): void {
 export interface NotifyDeps {
   fetchFn?: typeof fetch;
   sleep?: (ms: number) => Promise<void>;
+  /** Read on every attempt so a gateway restart can create or rotate the token. */
+  readAuthToken?: () => string | null;
   /** Retry delays in ms. Default spans ~10 minutes so a gateway restart is survived. */
   retryDelaysMs?: number[];
 }
@@ -116,6 +120,7 @@ export async function sendJobNotification(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const fetchFn = deps.fetchFn ?? fetch;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const readAuthToken = deps.readAuthToken ?? (() => readGatewayAuthToken(JINN_HOME));
   const delays = deps.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
 
   assertLoopbackGatewayUrl(state.gatewayUrl);
@@ -124,9 +129,13 @@ export async function sendJobNotification(
   let lastError = "unknown";
   for (let attempt = 0; attempt <= delays.length; attempt++) {
     try {
+      const token = readAuthToken();
       const res = await fetchFn(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
         // dedupeKey: if the gateway accepted an earlier attempt but the
         // response was lost, the retry must not enqueue a second turn.
         body: JSON.stringify({ message, role: "notification", dedupeKey: `job:${state.id}` }),


### PR DESCRIPTION
## Summary
- `ryoko job run` の完了通知にinstance固有のBearer tokenを付与
- リトライごとにtokenを再読込し、Gateway再起動・token更新をまたいで復旧
- 認証未初期化／無効化環境と既存dedupe挙動を維持
- release versionを`2026.8.21`へ更新

## Root cause
Gateway API認証導入後もdetached job monitorが`POST /api/sessions/:id/message`を認証なしで呼び、401を6回リトライした後`notify_failed`になっていた。

## Verification
- backend: 97 test files / 782 tests pass
- TypeScript typecheck
- production build
- npm tarball内容・修正済みdist・秘密情報非同梱を確認
- git diff --check