### PR TITLE
fix: デフォルトセットアップ体験の修復（config テンプレ / skills.json / メモリプロンプト）

### DIFF
--- a/packages/jimmy/src/cli/__tests__/initial-config.test.ts
+++ b/packages/jimmy/src/cli/__tests__/initial-config.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import fs from "node:fs";
 import yaml from "js-yaml";
 import { CONFIG_TEMPLATE_PATH, buildInitialConfig } from "../initial-config.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("initial config generation", () => {
   it("finds the packaged template (regression: lookup used config.yaml, template ships config.default.yaml)", () => {
@@ -10,10 +14,7 @@ describe("initial config generation", () => {
   });
 
   it("uses the template so documented defaults (mcp.fetch etc.) actually apply", () => {
-    const { source, usedTemplate } = buildInitialConfig("claude", "Ryoko");
-    expect(usedTemplate).toBe(true);
-
-    const parsed = yaml.load(source) as any;
+    const parsed = yaml.load(buildInitialConfig("claude", "Ryoko")) as any;
     expect(parsed.mcp?.fetch?.enabled).toBe(true);
     expect(parsed.mcp?.browser?.enabled).toBe(true);
     expect(parsed.mcp?.gateway?.enabled).toBe(true);
@@ -22,16 +23,26 @@ describe("initial config generation", () => {
   });
 
   it("stamps the real package version over the template placeholder", () => {
-    const { source } = buildInitialConfig("claude", "Ryoko");
-    const parsed = yaml.load(source) as any;
+    const parsed = yaml.load(buildInitialConfig("claude", "Ryoko")) as any;
     expect(parsed.jinn?.version).not.toBe("0.3.0");
     expect(parsed.jinn?.version).toMatch(/^\d{4}\.\d+\.\d+/);
   });
 
   it("applies interactive choices (engine and portal name)", () => {
-    const { source } = buildInitialConfig("codex", "Momo");
-    const parsed = yaml.load(source) as any;
+    const parsed = yaml.load(buildInitialConfig("codex", "Momo")) as any;
     expect(parsed.engines?.default).toBe("codex");
     expect(parsed.portal?.portalName).toBe("Momo");
+  });
+
+  it("keeps hostile names literal — quotes, backslashes, $-patterns must not corrupt the YAML", () => {
+    for (const name of ['Ry"oko', "Back\\slash", "A$&B", "$'$`x"]) {
+      const parsed = yaml.load(buildInitialConfig("claude", name)) as any;
+      expect(parsed.portal?.portalName).toBe(name);
+    }
+  });
+
+  it("fails loudly when the packaged template is missing (corrupt install)", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(() => buildInitialConfig("claude", "Ryoko")).toThrow(/再インストール/);
   });
 });

--- a/packages/jimmy/src/cli/__tests__/initial-config.test.ts
+++ b/packages/jimmy/src/cli/__tests__/initial-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import yaml from "js-yaml";
+import { CONFIG_TEMPLATE_PATH, buildInitialConfig } from "../initial-config.js";
+
+describe("initial config generation", () => {
+  it("finds the packaged template (regression: lookup used config.yaml, template ships config.default.yaml)", () => {
+    expect(fs.existsSync(CONFIG_TEMPLATE_PATH)).toBe(true);
+    expect(CONFIG_TEMPLATE_PATH.endsWith("config.default.yaml")).toBe(true);
+  });
+
+  it("uses the template so documented defaults (mcp.fetch etc.) actually apply", () => {
+    const { source, usedTemplate } = buildInitialConfig("claude", "Ryoko");
+    expect(usedTemplate).toBe(true);
+
+    const parsed = yaml.load(source) as any;
+    expect(parsed.mcp?.fetch?.enabled).toBe(true);
+    expect(parsed.mcp?.browser?.enabled).toBe(true);
+    expect(parsed.mcp?.gateway?.enabled).toBe(true);
+    expect(parsed.engines?.default).toBe("claude");
+    expect(parsed.engines?.claude?.model).toBe("claude-opus-5");
+  });
+
+  it("stamps the real package version over the template placeholder", () => {
+    const { source } = buildInitialConfig("claude", "Ryoko");
+    const parsed = yaml.load(source) as any;
+    expect(parsed.jinn?.version).not.toBe("0.3.0");
+    expect(parsed.jinn?.version).toMatch(/^\d{4}\.\d+\.\d+/);
+  });
+
+  it("applies interactive choices (engine and portal name)", () => {
+    const { source } = buildInitialConfig("codex", "Momo");
+    const parsed = yaml.load(source) as any;
+    expect(parsed.engines?.default).toBe("codex");
+    expect(parsed.portal?.portalName).toBe("Momo");
+  });
+});

--- a/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
+++ b/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => true),
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+    },
+  };
+});
+
+import fs from "node:fs";
+import {
+  readManifest,
+  writeManifest,
+  upsertManifest,
+  SKILLS_JSON,
+} from "../skills.js";
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+
+function lastWrittenJson(): any {
+  const calls = mockWriteFileSync.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const [file, data] = calls[calls.length - 1];
+  expect(file).toBe(SKILLS_JSON);
+  return JSON.parse(String(data));
+}
+
+describe("skills.json manifest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  it("reads the canonical object format shipped in template/skills.json", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        installed: {
+          "deploy-fly": { source: "owner/repo@deploy-fly", installedAt: "2026-01-01T00:00:00Z" },
+        },
+      }),
+    );
+    expect(readManifest()).toEqual([
+      { name: "deploy-fly", source: "owner/repo@deploy-fly", installedAt: "2026-01-01T00:00:00Z" },
+    ]);
+  });
+
+  it("returns [] for the pristine template ({\"installed\": {}}) instead of crashing", () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ installed: {} }));
+    const manifest = readManifest();
+    expect(manifest).toEqual([]);
+    // Regression: the old implementation returned the raw object, so
+    // Array methods used by skillsList/skillsUpdate threw TypeError.
+    expect(() => manifest.map((e) => e.name)).not.toThrow();
+  });
+
+  it("still reads the legacy flat-array format", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ name: "a", source: "s", installedAt: "t" }]),
+    );
+    expect(readManifest()).toEqual([{ name: "a", source: "s", installedAt: "t" }]);
+  });
+
+  it("returns [] for malformed JSON or a missing file", () => {
+    mockReadFileSync.mockReturnValue("not json");
+    expect(readManifest()).toEqual([]);
+    mockExistsSync.mockReturnValue(false);
+    expect(readManifest()).toEqual([]);
+  });
+
+  it("writes the canonical object format", () => {
+    writeManifest([{ name: "a", source: "s", installedAt: "t" }]);
+    expect(lastWrittenJson()).toEqual({
+      installed: { a: { source: "s", installedAt: "t" } },
+    });
+  });
+
+  it("upserts into a pristine template manifest end to end", () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ installed: {} }));
+    upsertManifest("deploy-fly", "owner/repo@deploy-fly");
+    const written = lastWrittenJson();
+    expect(written.installed["deploy-fly"].source).toBe("owner/repo@deploy-fly");
+    expect(typeof written.installed["deploy-fly"].installedAt).toBe("string");
+  });
+});

--- a/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
+++ b/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
@@ -9,6 +9,9 @@ vi.mock("node:fs", async () => {
       existsSync: vi.fn(() => true),
       readFileSync: vi.fn(),
       writeFileSync: vi.fn(),
+      // paths.ts runs migrateLegacyHome() at module load — never let a
+      // per-path existsSync mock reach the real renameSync.
+      renameSync: vi.fn(),
     },
   };
 });
@@ -18,6 +21,7 @@ import {
   readManifest,
   writeManifest,
   upsertManifest,
+  removeFromManifest,
   SKILLS_JSON,
 } from "../skills.js";
 
@@ -63,9 +67,16 @@ describe("skills.json manifest", () => {
 
   it("still reads the legacy flat-array format", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify([{ name: "a", source: "s", installedAt: "t" }]),
+      JSON.stringify([{ name: "a", source: "own/rep@a", installedAt: "t" }]),
     );
-    expect(readManifest()).toEqual([{ name: "a", source: "s", installedAt: "t" }]);
+    expect(readManifest()).toEqual([{ name: "a", source: "own/rep@a", installedAt: "t" }]);
+  });
+
+  it("rejects {\"installed\": [...]} instead of mis-parsing array indices as names", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ installed: [{ name: "a", source: "own/rep@a", installedAt: "t" }] }),
+    );
+    expect(readManifest()).toEqual([]);
   });
 
   it("returns [] for malformed JSON or a missing file", () => {
@@ -73,6 +84,22 @@ describe("skills.json manifest", () => {
     expect(readManifest()).toEqual([]);
     mockExistsSync.mockReturnValue(false);
     expect(readManifest()).toEqual([]);
+  });
+
+  it("blanks a source that is not owner/repo[@skill]-shaped — it later reaches npx argv", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        installed: {
+          evil: { source: "owner/repo@x; echo PWNED > /tmp/pwned.txt", installedAt: "t" },
+          fine: { source: "owner/repo@skill", installedAt: "t" },
+          repo: { source: "owner/repo", installedAt: "t" },
+        },
+      }),
+    );
+    const byName = Object.fromEntries(readManifest().map((e) => [e.name, e.source]));
+    expect(byName.evil).toBe("");
+    expect(byName.fine).toBe("owner/repo@skill");
+    expect(byName.repo).toBe("owner/repo");
   });
 
   it("writes the canonical object format", () => {
@@ -88,5 +115,47 @@ describe("skills.json manifest", () => {
     const written = lastWrittenJson();
     expect(written.installed["deploy-fly"].source).toBe("owner/repo@deploy-fly");
     expect(typeof written.installed["deploy-fly"].installedAt).toBe("string");
+  });
+
+  it("preserves fields other writers added — per entry and top-level", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        schemaVersion: 1,
+        installed: {
+          a: { source: "own/rep@a", installedAt: "t", description: "keep me" },
+        },
+      }),
+    );
+    upsertManifest("a", "own/rep@a2");
+    const written = lastWrittenJson();
+    expect(written.schemaVersion).toBe(1);
+    expect(written.installed.a.description).toBe("keep me");
+    expect(written.installed.a.source).toBe("own/rep@a2");
+  });
+
+  it("preserves extra legacy-array fields through the object migration", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ name: "a", source: "own/rep@a", installedAt: "t", version: "1.2.3" }]),
+    );
+    upsertManifest("b", "own/rep@b");
+    const written = lastWrittenJson();
+    expect(written.installed.a.version).toBe("1.2.3");
+    expect(written.installed.b.source).toBe("own/rep@b");
+  });
+
+  it("removeFromManifest keeps unrelated entries and top-level fields", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        schemaVersion: 1,
+        installed: {
+          a: { source: "own/rep@a", installedAt: "t" },
+          b: { source: "own/rep@b", installedAt: "t" },
+        },
+      }),
+    );
+    expect(removeFromManifest("a")).toBe(true);
+    const written = lastWrittenJson();
+    expect(written.schemaVersion).toBe(1);
+    expect(written.installed).toEqual({ b: { source: "own/rep@b", installedAt: "t" } });
   });
 });

--- a/packages/jimmy/src/cli/initial-config.ts
+++ b/packages/jimmy/src/cli/initial-config.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import { TEMPLATE_DIR } from "../shared/paths.js";
+import { getPackageVersion } from "../shared/version.js";
+
+/** The packaged template's file name is config.default.yaml — keep this
+ *  lookup in sync with template/, or setup silently falls back to
+ *  FALLBACK_CONFIG and documented defaults (mcp, sessions, portal) are lost. */
+export const CONFIG_TEMPLATE_PATH = path.join(TEMPLATE_DIR, "config.default.yaml");
+
+export const FALLBACK_CONFIG = `jinn:
+  version: "0.0.0"
+
+gateway:
+  port: 7777
+  host: "127.0.0.1"
+  # allowedHosts: ["ryoko.example.com"]
+  # trustProxyHeaders: false
+  # trustedProxyAddresses: ["127.0.0.1"]
+engines:
+  default: claude
+  claude:
+    bin: claude
+    model: claude-opus-5
+    effortLevel: xhigh
+  codex:
+    bin: codex
+    model: gpt-5.6-sol
+connectors: {}
+mcp:
+  browser:
+    enabled: true
+    provider: playwright
+  fetch:
+    enabled: true
+  gateway:
+    enabled: true
+portal: {}
+logging:
+  file: true
+  stdout: true
+  level: info
+`;
+
+/**
+ * Build the config.yaml contents for a fresh setup: template (or fallback)
+ * with the package version stamped and the interactive choices applied.
+ */
+export function buildInitialConfig(
+  chosenEngine: "claude" | "codex",
+  chosenName: string,
+): { source: string; usedTemplate: boolean } {
+  const usedTemplate = fs.existsSync(CONFIG_TEMPLATE_PATH);
+  let source = usedTemplate
+    ? fs.readFileSync(CONFIG_TEMPLATE_PATH, "utf-8")
+    : FALLBACK_CONFIG;
+
+  source = source.replace(/version:\s*"[^"]*"/, `version: "${getPackageVersion()}"`);
+  source = source.replace(/default:\s*claude/, `default: ${chosenEngine}`);
+
+  if (chosenName !== "Ryoko") {
+    if (source.includes("portalName: Ryoko")) {
+      source = source.replace("portalName: Ryoko", `portalName: "${chosenName}"`);
+    } else {
+      source = source.replace("portal: {}", `portal:\n  portalName: "${chosenName}"`);
+    }
+  }
+
+  return { source, usedTemplate };
+}

--- a/packages/jimmy/src/cli/initial-config.ts
+++ b/packages/jimmy/src/cli/initial-config.ts
@@ -4,67 +4,44 @@ import { TEMPLATE_DIR } from "../shared/paths.js";
 import { getPackageVersion } from "../shared/version.js";
 
 /** The packaged template's file name is config.default.yaml — keep this
- *  lookup in sync with template/, or setup silently falls back to
- *  FALLBACK_CONFIG and documented defaults (mcp, sessions, portal) are lost. */
+ *  lookup in sync with template/, or fresh setups lose the documented
+ *  defaults (mcp, portal, connectors guidance). */
 export const CONFIG_TEMPLATE_PATH = path.join(TEMPLATE_DIR, "config.default.yaml");
 
-export const FALLBACK_CONFIG = `jinn:
-  version: "0.0.0"
-
-gateway:
-  port: 7777
-  host: "127.0.0.1"
-  # allowedHosts: ["ryoko.example.com"]
-  # trustProxyHeaders: false
-  # trustedProxyAddresses: ["127.0.0.1"]
-engines:
-  default: claude
-  claude:
-    bin: claude
-    model: claude-opus-5
-    effortLevel: xhigh
-  codex:
-    bin: codex
-    model: gpt-5.6-sol
-connectors: {}
-mcp:
-  browser:
-    enabled: true
-    provider: playwright
-  fetch:
-    enabled: true
-  gateway:
-    enabled: true
-portal: {}
-logging:
-  file: true
-  stdout: true
-  level: info
-`;
-
 /**
- * Build the config.yaml contents for a fresh setup: template (or fallback)
+ * Build the config.yaml contents for a fresh setup: the packaged template
  * with the package version stamped and the interactive choices applied.
+ * The template ships in the npm package (`files` includes `template/`), so
+ * a missing file means a corrupt install — fail loudly instead of silently
+ * generating a divergent config.
  */
 export function buildInitialConfig(
   chosenEngine: "claude" | "codex",
   chosenName: string,
-): { source: string; usedTemplate: boolean } {
-  const usedTemplate = fs.existsSync(CONFIG_TEMPLATE_PATH);
-  let source = usedTemplate
-    ? fs.readFileSync(CONFIG_TEMPLATE_PATH, "utf-8")
-    : FALLBACK_CONFIG;
+): string {
+  if (!fs.existsSync(CONFIG_TEMPLATE_PATH)) {
+    throw new Error(
+      `config テンプレートが見つかりません: ${CONFIG_TEMPLATE_PATH}\n` +
+        `パッケージが壊れている可能性があります。npm install -g openryoko で再インストールしてください。`,
+    );
+  }
+  let source = fs.readFileSync(CONFIG_TEMPLATE_PATH, "utf-8");
 
-  source = source.replace(/version:\s*"[^"]*"/, `version: "${getPackageVersion()}"`);
-  source = source.replace(/default:\s*claude/, `default: ${chosenEngine}`);
+  // Replacer functions throughout — replacement *strings* would expand
+  // `$&`-style patterns hidden in user-provided names.
+  source = source.replace(/version:\s*"[^"]*"/, () => `version: "${getPackageVersion()}"`);
+  source = source.replace(/default:\s*claude/, () => `default: ${chosenEngine}`);
 
   if (chosenName !== "Ryoko") {
+    // JSON.stringify yields a valid YAML double-quoted scalar for any name,
+    // including quotes and backslashes.
+    const quoted = JSON.stringify(chosenName);
     if (source.includes("portalName: Ryoko")) {
-      source = source.replace("portalName: Ryoko", `portalName: "${chosenName}"`);
+      source = source.replace("portalName: Ryoko", () => `portalName: ${quoted}`);
     } else {
-      source = source.replace("portal: {}", `portal:\n  portalName: "${chosenName}"`);
+      source = source.replace("portal: {}", () => `portal:\n  portalName: ${quoted}`);
     }
   }
 
-  return { source, usedTemplate };
+  return source;
 }

--- a/packages/jimmy/src/cli/setup.ts
+++ b/packages/jimmy/src/cli/setup.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
-import yaml from "js-yaml";
 import {
   JINN_HOME,
   CONFIG_PATH,
@@ -20,7 +19,6 @@ import {
   MIGRATIONS_DIR,
 } from "../shared/paths.js";
 import { initDb } from "../sessions/registry.js";
-import { getPackageVersion } from "../shared/version.js";
 import {
   applyTemplateReplacements,
   isTemplateFile,
@@ -28,6 +26,7 @@ import {
   buildTemplateReplacements,
 } from "../shared/templateReplacements.js";
 import { ensureOwnerOnlyDirectory } from "../shared/owner-only.js";
+import { buildInitialConfig, CONFIG_TEMPLATE_PATH } from "./initial-config.js";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -230,36 +229,10 @@ function detectProjectContext(portalSlug: string): void {
   }
 }
 
-const DEFAULT_CONFIG = `jinn:
-  version: "${getPackageVersion()}"
-
-gateway:
-  port: 7777
-  host: "127.0.0.1"
-  # allowedHosts: ["ryoko.example.com"]
-  # trustProxyHeaders: false
-  # trustedProxyAddresses: ["127.0.0.1"]
-engines:
-  default: claude
-  claude:
-    bin: claude
-    model: claude-opus-5
-    effortLevel: xhigh
-  codex:
-    bin: codex
-    model: gpt-5.6-sol
-connectors: {}
-portal: {}
-logging:
-  file: true
-  stdout: true
-  level: info
-`;
-
 function defaultClaudeMd(portalName: string) {
   return `# ${portalName} AI Gateway
 
-This is the ${portalName} home directory (~/.jinn).
+This is the ${portalName} home directory (~/.ryoko).
 ${portalName} orchestrates Claude Code and Codex as AI engines.
 `;
 }
@@ -350,7 +323,7 @@ export async function runSetup(opts?: { force?: boolean }): Promise<void> {
     }
   }
 
-  // 6. Create ~/.jinn directory structure
+  // 6. Create ~/.ryoko directory structure
   console.log("");
   const created: string[] = [];
 
@@ -359,26 +332,13 @@ export async function runSetup(opts?: { force?: boolean }): Promise<void> {
   if (homePermission.changed) created.push(JINN_HOME);
 
   // Copy or create config files
-  const templateConfig = path.join(TEMPLATE_DIR, "config.yaml");
   const templateClaude = path.join(TEMPLATE_DIR, "CLAUDE.md");
   const templateAgents = path.join(TEMPLATE_DIR, "AGENTS.md");
 
   if (!fs.existsSync(CONFIG_PATH)) {
-    let source = fs.existsSync(templateConfig)
-      ? fs.readFileSync(templateConfig, "utf-8")
-      : DEFAULT_CONFIG;
-    // Stamp the current package version into the config
-    source = source.replace(/version:\s*"[^"]*"/, `version: "${getPackageVersion()}"`);
-    // Apply interactive choices
-    source = source.replace(/default:\s*claude/, `default: ${chosenEngine}`);
-    if (chosenName !== "Ryoko") {
-      // Template already has `portalName: Ryoko` under portal. Substitute.
-      // Also handle the legacy `portal: {}` form for back-compat.
-      if (source.includes("portalName: Ryoko")) {
-        source = source.replace("portalName: Ryoko", `portalName: "${chosenName}"`);
-      } else {
-        source = source.replace("portal: {}", `portal:\n  portalName: "${chosenName}"`);
-      }
+    const { source, usedTemplate } = buildInitialConfig(chosenEngine, chosenName);
+    if (!usedTemplate) {
+      warn(`config テンプレート (${CONFIG_TEMPLATE_PATH}) が見つからないため、最小構成で生成します`);
     }
     ensureFile(CONFIG_PATH, source);
     created.push(CONFIG_PATH);

--- a/packages/jimmy/src/cli/setup.ts
+++ b/packages/jimmy/src/cli/setup.ts
@@ -26,7 +26,7 @@ import {
   buildTemplateReplacements,
 } from "../shared/templateReplacements.js";
 import { ensureOwnerOnlyDirectory } from "../shared/owner-only.js";
-import { buildInitialConfig, CONFIG_TEMPLATE_PATH } from "./initial-config.js";
+import { buildInitialConfig } from "./initial-config.js";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -336,11 +336,7 @@ export async function runSetup(opts?: { force?: boolean }): Promise<void> {
   const templateAgents = path.join(TEMPLATE_DIR, "AGENTS.md");
 
   if (!fs.existsSync(CONFIG_PATH)) {
-    const { source, usedTemplate } = buildInitialConfig(chosenEngine, chosenName);
-    if (!usedTemplate) {
-      warn(`config テンプレート (${CONFIG_TEMPLATE_PATH}) が見つからないため、最小構成で生成します`);
-    }
-    ensureFile(CONFIG_PATH, source);
+    ensureFile(CONFIG_PATH, buildInitialConfig(chosenEngine, chosenName));
     created.push(CONFIG_PATH);
   }
 

--- a/packages/jimmy/src/cli/skills.ts
+++ b/packages/jimmy/src/cli/skills.ts
@@ -27,63 +27,93 @@ export interface SkillManifestEntry {
   installedAt: string;
 }
 
+/** skills.json is written freely by the agent (see find-and-install), so
+ *  `source` is untrusted input that later reaches `npx skills add`. Only
+ *  accept the "owner/repo" / "owner/repo@skill" shapes. */
+const SOURCE_RE = /^[\w.-]+\/[\w.-]+(@[\w.-]+)?$/;
+
+function sanitizeSource(v: unknown): string {
+  return typeof v === "string" && SOURCE_RE.test(v) ? v : "";
+}
+
+interface RawManifest {
+  installed: Record<string, Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
 /** Canonical skills.json shape — must match template/skills.json and the
  *  find-and-install skill, which write `{"installed": {<name>: {...}}}`.
- *  The legacy flat-array form is still accepted on read. */
-export function readManifest(): SkillManifestEntry[] {
-  if (!fs.existsSync(SKILLS_JSON)) return [];
+ *  The legacy flat-array form is still accepted on read. Fields this CLI
+ *  doesn't know about (per entry or top-level) are preserved on write. */
+function readRawManifest(): RawManifest {
+  if (!fs.existsSync(SKILLS_JSON)) return { installed: {} };
   try {
     const parsed = JSON.parse(fs.readFileSync(SKILLS_JSON, "utf-8"));
     if (Array.isArray(parsed)) {
-      return parsed.filter(
-        (e): e is SkillManifestEntry => !!e && typeof e.name === "string",
+      const installed = Object.fromEntries(
+        parsed
+          .filter((e) => !!e && typeof e.name === "string")
+          .map(({ name, ...rest }) => [name, rest as Record<string, unknown>]),
       );
+      return { installed };
     }
-    if (parsed && typeof parsed.installed === "object" && parsed.installed !== null) {
-      return Object.entries(parsed.installed).map(([name, meta]) => {
-        const m = (meta ?? {}) as Partial<SkillManifestEntry>;
-        return {
-          name,
-          source: typeof m.source === "string" ? m.source : "",
-          installedAt: typeof m.installedAt === "string" ? m.installedAt : "",
-        };
-      });
+    if (
+      parsed && typeof parsed === "object" &&
+      parsed.installed && typeof parsed.installed === "object" &&
+      !Array.isArray(parsed.installed)
+    ) {
+      return parsed as RawManifest;
     }
-    return [];
+    return { installed: {} };
   } catch {
-    return [];
+    return { installed: {} };
   }
 }
 
+function writeRawManifest(raw: RawManifest): void {
+  fs.writeFileSync(SKILLS_JSON, JSON.stringify(raw, null, 2) + "\n");
+}
+
+export function readManifest(): SkillManifestEntry[] {
+  return Object.entries(readRawManifest().installed).map(([name, meta]) => {
+    const m = (meta ?? {}) as Record<string, unknown>;
+    return {
+      name,
+      source: sanitizeSource(m.source),
+      installedAt: typeof m.installedAt === "string" ? m.installedAt : "",
+    };
+  });
+}
+
+/** Full replace in canonical form. Prefer upsertManifest/removeFromManifest,
+ *  which preserve fields other writers may have added. */
 export function writeManifest(entries: SkillManifestEntry[]): void {
   const installed = Object.fromEntries(
     entries.map((e) => [e.name, { source: e.source, installedAt: e.installedAt }]),
   );
-  fs.writeFileSync(SKILLS_JSON, JSON.stringify({ installed }, null, 2) + "\n");
+  writeRawManifest({ installed });
 }
 
 export function upsertManifest(name: string, source: string): void {
-  const manifest = readManifest();
-  const idx = manifest.findIndex((e) => e.name === name);
-  const entry: SkillManifestEntry = {
-    name,
-    source,
-    installedAt: new Date().toISOString(),
-  };
-  if (idx >= 0) {
-    manifest[idx] = entry;
-  } else {
-    manifest.push(entry);
-  }
-  writeManifest(manifest);
+  const raw = readRawManifest();
+  writeRawManifest({
+    ...raw,
+    installed: {
+      ...raw.installed,
+      [name]: {
+        ...(raw.installed[name] ?? {}),
+        source,
+        installedAt: new Date().toISOString(),
+      },
+    },
+  });
 }
 
 export function removeFromManifest(name: string): boolean {
-  const manifest = readManifest();
-  const idx = manifest.findIndex((e) => e.name === name);
-  if (idx < 0) return false;
-  manifest.splice(idx, 1);
-  writeManifest(manifest);
+  const raw = readRawManifest();
+  if (!(name in raw.installed)) return false;
+  const { [name]: _removed, ...rest } = raw.installed;
+  writeRawManifest({ ...raw, installed: rest });
   return true;
 }
 
@@ -167,7 +197,7 @@ export function skillsFind(query?: string): void {
   if (query) args.push(query);
   const result = spawnSync("npx", args, {
     stdio: "inherit",
-    shell: true,
+    // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
   });
   process.exitCode = result.status ?? 1;
 }
@@ -181,7 +211,7 @@ export function skillsAdd(pkg: string): void {
   // Run npx skills add
   const result = spawnSync("npx", ["skills", "add", pkg, "-g", "-y"], {
     stdio: "inherit",
-    shell: true,
+    // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
   });
 
   if (result.status !== 0) {
@@ -273,11 +303,15 @@ export function skillsUpdate(): void {
 
   console.log(`\n${manifest.length} 件のスキルを更新中...\n`);
   for (const entry of manifest) {
+    if (!entry.source) {
+      console.log(`  ${YELLOW}${entry.name}: source が不正または未記録のためスキップ${RESET}`);
+      continue;
+    }
     console.log(`  ${entry.name} を ${entry.source} から更新中...`);
     const before = snapshotDirs();
     const result = spawnSync("npx", ["skills", "add", entry.source, "-g", "-y"], {
       stdio: "pipe",
-      shell: true,
+      // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
     });
 
     if (result.status !== 0) {
@@ -316,11 +350,15 @@ export function skillsRestore(): void {
       continue;
     }
 
+    if (!entry.source) {
+      console.log(`  ${YELLOW}${entry.name}: source が不正または未記録のためスキップ${RESET}`);
+      continue;
+    }
     console.log(`  Installing ${entry.name} from ${entry.source}...`);
     const before = snapshotDirs();
     const result = spawnSync("npx", ["skills", "add", entry.source, "-g", "-y"], {
       stdio: "pipe",
-      shell: true,
+      // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
     });
 
     if (result.status !== 0) {

--- a/packages/jimmy/src/cli/skills.ts
+++ b/packages/jimmy/src/cli/skills.ts
@@ -27,17 +27,39 @@ export interface SkillManifestEntry {
   installedAt: string;
 }
 
+/** Canonical skills.json shape — must match template/skills.json and the
+ *  find-and-install skill, which write `{"installed": {<name>: {...}}}`.
+ *  The legacy flat-array form is still accepted on read. */
 export function readManifest(): SkillManifestEntry[] {
   if (!fs.existsSync(SKILLS_JSON)) return [];
   try {
-    return JSON.parse(fs.readFileSync(SKILLS_JSON, "utf-8"));
+    const parsed = JSON.parse(fs.readFileSync(SKILLS_JSON, "utf-8"));
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (e): e is SkillManifestEntry => !!e && typeof e.name === "string",
+      );
+    }
+    if (parsed && typeof parsed.installed === "object" && parsed.installed !== null) {
+      return Object.entries(parsed.installed).map(([name, meta]) => {
+        const m = (meta ?? {}) as Partial<SkillManifestEntry>;
+        return {
+          name,
+          source: typeof m.source === "string" ? m.source : "",
+          installedAt: typeof m.installedAt === "string" ? m.installedAt : "",
+        };
+      });
+    }
+    return [];
   } catch {
     return [];
   }
 }
 
 export function writeManifest(entries: SkillManifestEntry[]): void {
-  fs.writeFileSync(SKILLS_JSON, JSON.stringify(entries, null, 2) + "\n");
+  const installed = Object.fromEntries(
+    entries.map((e) => [e.name, { source: e.source, installedAt: e.installedAt }]),
+  );
+  fs.writeFileSync(SKILLS_JSON, JSON.stringify({ installed }, null, 2) + "\n");
 }
 
 export function upsertManifest(name: string, source: string): void {

--- a/packages/jimmy/src/sessions/__tests__/evolution-context.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/evolution-context.test.ts
@@ -8,6 +8,9 @@ vi.mock("node:fs", async () => {
       ...actual,
       existsSync: vi.fn(() => true),
       readFileSync: vi.fn(),
+      // paths.ts runs migrateLegacyHome() at module load — never let a
+      // per-path existsSync mock reach the real renameSync.
+      renameSync: vi.fn(),
     },
   };
 });
@@ -16,6 +19,7 @@ vi.mock("../../gateway/services.js", () => ({ buildServiceRegistry: vi.fn(() => 
 vi.mock("../../jobs/state.js", () => ({ findJobsNeedingAttention: vi.fn(() => []) }));
 
 import fs from "node:fs";
+import { JINN_HOME } from "../../shared/paths.js";
 import { buildEvolutionContext } from "../context.js";
 
 const mockExistsSync = vi.mocked(fs.existsSync);
@@ -46,6 +50,19 @@ describe("buildEvolutionContext", () => {
     const out = buildEvolutionContext("Ryoko");
     expect(out).toContain("ONBOARDING MODE");
     expect(out).toContain("BOOTSTRAP.md");
+  });
+
+  it("embeds the real instance home, not a hardcoded ~/.ryoko (custom RYOKO_INSTANCE installs)", () => {
+    setWorkspace({ bootstrap: true });
+    const out = buildEvolutionContext("Ryoko");
+    expect(out).toContain(`${JINN_HOME}/BOOTSTRAP.md`);
+    expect(out).not.toContain("~/.jinn");
+  });
+
+  it("does NOT trap an upgraded veteran (BOOTSTRAP.md pending + rich legacy profile) in onboarding", () => {
+    setWorkspace({ bootstrap: true, legacyProfile: "x".repeat(200) });
+    const out = buildEvolutionContext("Ryoko");
+    expect(out).not.toContain("ONBOARDING MODE");
   });
 
   it("steady state teaches the two-layer memory scheme (regression: upstream 3-file scheme contradicted AGENTS.md)", () => {

--- a/packages/jimmy/src/sessions/__tests__/evolution-context.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/evolution-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => true),
+      readFileSync: vi.fn(),
+    },
+  };
+});
+vi.mock("../../gateway/org.js", () => ({ scanOrg: vi.fn(() => ({ departments: [] })) }));
+vi.mock("../../gateway/services.js", () => ({ buildServiceRegistry: vi.fn(() => new Map()) }));
+vi.mock("../../jobs/state.js", () => ({ findJobsNeedingAttention: vi.fn(() => []) }));
+
+import fs from "node:fs";
+import { buildEvolutionContext } from "../context.js";
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+function setWorkspace(opts: { bootstrap?: boolean; memory?: boolean; legacyProfile?: string }) {
+  mockExistsSync.mockImplementation((p) => {
+    const s = String(p);
+    if (s.endsWith("BOOTSTRAP.md")) return opts.bootstrap === true;
+    if (s.endsWith("MEMORY.md")) return opts.memory === true;
+    return false;
+  });
+  mockReadFileSync.mockImplementation((p) => {
+    if (String(p).endsWith("user-profile.md") && opts.legacyProfile !== undefined) {
+      return opts.legacyProfile;
+    }
+    throw new Error("ENOENT");
+  });
+}
+
+describe("buildEvolutionContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("points a fresh install at BOOTSTRAP.md instead of a parallel question flow", () => {
+    setWorkspace({ bootstrap: true });
+    const out = buildEvolutionContext("Ryoko");
+    expect(out).toContain("ONBOARDING MODE");
+    expect(out).toContain("BOOTSTRAP.md");
+  });
+
+  it("steady state teaches the two-layer memory scheme (regression: upstream 3-file scheme contradicted AGENTS.md)", () => {
+    setWorkspace({ memory: true });
+    const out = buildEvolutionContext("Ryoko");
+    expect(out).toContain("MEMORY.md");
+    expect(out).toContain("knowledge/<topic>.md");
+    expect(out).not.toContain("user-profile.md");
+    expect(out).not.toContain("preferences.md");
+    expect(out).not.toContain("~/.jinn");
+  });
+
+  it("treats a legacy workspace with a filled user profile as already onboarded", () => {
+    setWorkspace({ legacyProfile: "x".repeat(100) });
+    const out = buildEvolutionContext("Ryoko");
+    expect(out).not.toContain("ONBOARDING MODE");
+  });
+
+  it("falls back to inline onboarding questions when neither BOOTSTRAP.md nor persona files exist", () => {
+    setWorkspace({});
+    const out = buildEvolutionContext("Ryoko");
+    expect(out).toContain("ONBOARDING MODE");
+    expect(out).not.toContain("BOOTSTRAP.md");
+    expect(out).toContain("MEMORY.md");
+  });
+});

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -135,7 +135,7 @@ export function buildContext(opts: {
       tier: Tier.STANDARD,
       marker: "## Self-evolution",
       content: buildEvolutionContext(portalName, opts.config),
-      summary: `## Self-evolution\nUpdate knowledge files in \`~/.jinn/knowledge/\` when you learn new info about the user or their projects.`,
+      summary: `## Self-evolution\nRecord short durable facts in \`~/.ryoko/MEMORY.md\` and long-form context in \`~/.ryoko/knowledge/<topic>.md\` when you learn new info about the user or their projects.`,
     });
   }
 
@@ -207,7 +207,7 @@ export function buildContext(opts: {
       tier: Tier.STANDARD,
       marker: "## Scheduled cron",
       content: cronCtx,
-      summary: "## Scheduled cron jobs\nCron definitions are in `~/.jinn/cron/jobs.json`. Read directly when needed.",
+      summary: "## Scheduled cron jobs\nCron definitions are in `~/.ryoko/cron/jobs.json`. Read directly when needed.",
     });
   }
 
@@ -218,7 +218,7 @@ export function buildContext(opts: {
       tier: Tier.OPTIONAL,
       marker: "## Knowledge base",
       content: knowledgeCtx,
-      summary: "## Knowledge base\nKnowledge files are in `~/.jinn/knowledge/` and `~/.jinn/docs/`. Read them directly when needed.",
+      summary: "## Knowledge base\nKnowledge files are in `~/.ryoko/knowledge/` and `~/.ryoko/docs/`. Read them directly when needed.",
     });
   }
 
@@ -308,7 +308,7 @@ ${languageInstruction}
 - **Model**: ${employee.model}
 ${chainOfCommand}
 ## System context
-You are part of the ${portalName} AI gateway — a system that orchestrates AI workers. You have access to the filesystem, can run commands, call APIs, and send messages via connectors. Your working directory is \`~/.jinn\` (${JINN_HOME}).
+You are part of the ${portalName} AI gateway — a system that orchestrates AI workers. You have access to the filesystem, can run commands, call APIs, and send messages via connectors. Your working directory is \`~/.ryoko\` (${JINN_HOME}).
 
 You can:
 - Read and write files in the home directory
@@ -425,12 +425,16 @@ ${portalName} is a personal AI assistant and gateway daemon. You are proactive, 
 - **Remember context**: You're part of a persistent system. Sessions can be resumed. Build on previous work.
 ${languageInstruction}
 ## Your home directory
-Your working directory is \`~/.jinn\` (${JINN_HOME}). This contains:
+Your working directory is \`~/.ryoko\` (${JINN_HOME}). This contains:
 - \`config.yaml\` — your configuration (engines, connectors, logging)
+- \`IDENTITY.md\` / \`SOUL.md\` — who you are and how you behave
+- \`MEMORY.md\` — long-term memory: short durable facts, preferences, decisions
+- \`TOOLS.md\` — tool usage notes and gotchas
 - \`org/\` — employee definitions (YAML files defining AI workers)
 - \`skills/\` — reusable skill prompts
 - \`docs/\` — documentation and knowledge base
-- \`knowledge/\` — persistent knowledge files
+- \`knowledge/\` — long-form reference memory, one topic per file
+- \`memory/\` — daily notes (\`YYYY-MM-DD.md\`)
 - \`cron/\` — scheduled job definitions and run history
 - \`sessions/\` — session database
 - \`logs/\` — gateway logs
@@ -610,7 +614,7 @@ function buildCronContext(): string | null {
       lines.push(`- **${job.name}**: \`${job.schedule}\`${job.employee ? ` → ${job.employee}` : ""}`);
     }
     if (disabledCount > 0) {
-      lines.push(`\n_${disabledCount} disabled jobs not shown. See \`~/.jinn/cron/jobs.json\` for the full list._`);
+      lines.push(`\n_${disabledCount} disabled jobs not shown. See \`~/.ryoko/cron/jobs.json\` for the full list._`);
     }
     return lines.join("\n");
   } catch {
@@ -655,7 +659,7 @@ function buildKnowledgeContext(): string | null {
 
   const lines: string[] = [
     `## Knowledge base`,
-    `Knowledge files are in \`~/.jinn/knowledge/\` and \`~/.jinn/docs/\`. Read them directly when needed.`,
+    `Knowledge files are in \`~/.ryoko/knowledge/\` and \`~/.ryoko/docs/\`. Read them directly when needed.`,
     ``,
   ];
 
@@ -766,7 +770,7 @@ function buildConnectorContext(connectors: string[], _gatewayUrl: string, portal
   lines.push("- When you are directly addressed (mentioned / asked), ALWAYS give a non-empty public reply. Use react-only for pure acknowledgments or social confirmations — never as the answer to a substantive question.");
 
   lines.push("\n- **List all connectors**: `ryoko api GET /api/connectors`");
-  lines.push(`- Channel IDs and connector config can be found in \`~/.jinn/config.yaml\``);
+  lines.push(`- Channel IDs and connector config can be found in \`~/.ryoko/config.yaml\``);
   return lines.join("\n");
 }
 
@@ -818,12 +822,20 @@ function buildEnvironmentContext(): string | null {
   return lines.join("\n");
 }
 
-function buildEvolutionContext(portalName: string, config?: JinnConfig): string {
-  const profilePath = path.join(JINN_HOME, "knowledge", "user-profile.md");
-  let profileContent = "";
-  try { profileContent = fs.readFileSync(profilePath, "utf-8").trim(); } catch {}
-
-  const isNew = profileContent.length < 50;
+export function buildEvolutionContext(portalName: string, config?: JinnConfig): string {
+  // Onboarding is pending while BOOTSTRAP.md exists (setup places it; the
+  // agent deletes it after the onboarding skill completes). Legacy fallback:
+  // pre-persona workspaces have neither BOOTSTRAP.md nor MEMORY.md — treat
+  // them as onboarded only if the old-style user profile has content.
+  const bootstrapPending = fs.existsSync(path.join(JINN_HOME, "BOOTSTRAP.md"));
+  const hasMemoryFile = fs.existsSync(path.join(JINN_HOME, "MEMORY.md"));
+  let legacyProfileContent = "";
+  try {
+    legacyProfileContent = fs
+      .readFileSync(path.join(JINN_HOME, "knowledge", "user-profile.md"), "utf-8")
+      .trim();
+  } catch {}
+  const isNew = bootstrapPending || (!hasMemoryFile && legacyProfileContent.length < 50);
 
   // Conversational discovery hint: a Slack workspace is wired up but the
   // user hasn't enabled the Agents View canvas. Surface it in steady-state
@@ -838,13 +850,13 @@ function buildEvolutionContext(portalName: string, config?: JinnConfig): string 
   const lines: string[] = [`## Self-evolution`];
 
   if (isNew) {
-    lines.push(`**ONBOARDING MODE**: This is a new or unconfigured ${portalName} installation.`);
-    lines.push(`Before answering the user's request, introduce yourself briefly and ask them:`);
-    lines.push(`1. What's your name and what do you do? (business, role, projects)`);
-    lines.push(`2. What should ${portalName} help you automate? (code reviews, deployments, monitoring, etc.)`);
-    lines.push(`3. Communication preferences — emoji style, verbosity (concise vs detailed), language`);
-    lines.push(`4. Any active projects ${portalName} should know about?`);
-    lines.push(`\nAfter the user responds, write their answers to \`~/.jinn/knowledge/user-profile.md\` and \`~/.jinn/knowledge/preferences.md\`.`);
+    lines.push(`**ONBOARDING MODE**: This is a new or not-yet-onboarded ${portalName} installation.`);
+    if (bootstrapPending) {
+      lines.push(`Before answering the user's request, read \`~/.ryoko/BOOTSTRAP.md\` and follow it to completion — it walks you through the onboarding skill (filling IDENTITY.md / SOUL.md / MEMORY.md) and is deleted when done.`);
+    } else {
+      lines.push(`Before answering the user's request, introduce yourself briefly and ask who they are, what ${portalName} should help with, their communication preferences, and any active projects.`);
+      lines.push(`Write short durable facts, preferences, and decisions to \`~/.ryoko/MEMORY.md\`; put long-form context in \`~/.ryoko/knowledge/<topic>.md\`.`);
+    }
     lines.push(`Then proceed to help with their original request.`);
     if (canvasHintApplies) {
       lines.push(
@@ -852,11 +864,10 @@ function buildEvolutionContext(portalName: string, config?: JinnConfig): string 
       );
     }
   } else {
-    lines.push(`You learn and evolve over time. When you discover new information about the user, their projects, or their preferences:`);
-    lines.push(`- Update \`~/.jinn/knowledge/user-profile.md\` with business/identity info`);
-    lines.push(`- Update \`~/.jinn/knowledge/preferences.md\` with style/communication preferences`);
-    lines.push(`- Update \`~/.jinn/knowledge/projects.md\` with project details`);
-    lines.push(`- If the user gives you persistent feedback (e.g. "always do X", "never do Y"), update \`~/.jinn/CLAUDE.md\``);
+    lines.push(`You learn and evolve over time. Memory is two-layered — keep the layers separate:`);
+    lines.push(`- Short durable facts, preferences, and decisions (1-3 lines each) → \`~/.ryoko/MEMORY.md\` (read every session; keep it lean)`);
+    lines.push(`- Long-form context (research results, project background, org info) → \`~/.ryoko/knowledge/<topic>.md\` (fetched on demand)`);
+    lines.push(`- Personality / tone feedback → \`~/.ryoko/SOUL.md\`; name or self-image changes → \`~/.ryoko/IDENTITY.md\``);
     lines.push(`\nDo this silently — don't announce every file update. Just evolve.`);
     if (canvasHintApplies) {
       lines.push(

--- a/packages/jimmy/src/sessions/context.ts
+++ b/packages/jimmy/src/sessions/context.ts
@@ -129,13 +129,15 @@ export function buildContext(opts: {
     });
   }
 
-  // ── STANDARD: Self-evolution ────────────────────────────────
+  // ── Self-evolution (ESSENTIAL while onboarding is pending, so the
+  //    BOOTSTRAP pointer can't be trimmed away on a large workspace) ──
   if (!opts.employee) {
+    const onboardingPending = fs.existsSync(path.join(JINN_HOME, "BOOTSTRAP.md"));
     sections.push({
-      tier: Tier.STANDARD,
+      tier: onboardingPending ? Tier.ESSENTIAL : Tier.STANDARD,
       marker: "## Self-evolution",
       content: buildEvolutionContext(portalName, opts.config),
-      summary: `## Self-evolution\nRecord short durable facts in \`~/.ryoko/MEMORY.md\` and long-form context in \`~/.ryoko/knowledge/<topic>.md\` when you learn new info about the user or their projects.`,
+      summary: `## Self-evolution\nRecord short durable facts in \`${JINN_HOME}/MEMORY.md\` and long-form context in \`${JINN_HOME}/knowledge/<topic>.md\` when you learn new info about the user or their projects.`,
     });
   }
 
@@ -207,7 +209,7 @@ export function buildContext(opts: {
       tier: Tier.STANDARD,
       marker: "## Scheduled cron",
       content: cronCtx,
-      summary: "## Scheduled cron jobs\nCron definitions are in `~/.ryoko/cron/jobs.json`. Read directly when needed.",
+      summary: `## Scheduled cron jobs\nCron definitions are in \`${CRON_JOBS}\`. Read directly when needed.`,
     });
   }
 
@@ -218,7 +220,7 @@ export function buildContext(opts: {
       tier: Tier.OPTIONAL,
       marker: "## Knowledge base",
       content: knowledgeCtx,
-      summary: "## Knowledge base\nKnowledge files are in `~/.ryoko/knowledge/` and `~/.ryoko/docs/`. Read them directly when needed.",
+      summary: `## Knowledge base\nKnowledge files are in \`${JINN_HOME}/knowledge/\` and \`${DOCS_DIR}/\`. Read them directly when needed.`,
     });
   }
 
@@ -614,7 +616,7 @@ function buildCronContext(): string | null {
       lines.push(`- **${job.name}**: \`${job.schedule}\`${job.employee ? ` → ${job.employee}` : ""}`);
     }
     if (disabledCount > 0) {
-      lines.push(`\n_${disabledCount} disabled jobs not shown. See \`~/.ryoko/cron/jobs.json\` for the full list._`);
+      lines.push(`\n_${disabledCount} disabled jobs not shown. See \`${CRON_JOBS}\` for the full list._`);
     }
     return lines.join("\n");
   } catch {
@@ -659,7 +661,7 @@ function buildKnowledgeContext(): string | null {
 
   const lines: string[] = [
     `## Knowledge base`,
-    `Knowledge files are in \`~/.ryoko/knowledge/\` and \`~/.ryoko/docs/\`. Read them directly when needed.`,
+    `Knowledge files are in \`${JINN_HOME}/knowledge/\` and \`${DOCS_DIR}/\`. Read them directly when needed.`,
     ``,
   ];
 
@@ -770,7 +772,7 @@ function buildConnectorContext(connectors: string[], _gatewayUrl: string, portal
   lines.push("- When you are directly addressed (mentioned / asked), ALWAYS give a non-empty public reply. Use react-only for pure acknowledgments or social confirmations — never as the answer to a substantive question.");
 
   lines.push("\n- **List all connectors**: `ryoko api GET /api/connectors`");
-  lines.push(`- Channel IDs and connector config can be found in \`~/.ryoko/config.yaml\``);
+  lines.push(`- Channel IDs and connector config can be found in \`${JINN_HOME}/config.yaml\``);
   return lines.join("\n");
 }
 
@@ -835,7 +837,10 @@ export function buildEvolutionContext(portalName: string, config?: JinnConfig): 
       .readFileSync(path.join(JINN_HOME, "knowledge", "user-profile.md"), "utf-8")
       .trim();
   } catch {}
-  const isNew = bootstrapPending || (!hasMemoryFile && legacyProfileContent.length < 50);
+  // A filled legacy profile means an already-onboarded veteran workspace even
+  // when setup has just placed BOOTSTRAP.md (the pre-persona upgrade path) —
+  // don't push those users back into onboarding.
+  const isNew = (bootstrapPending || !hasMemoryFile) && legacyProfileContent.length < 50;
 
   // Conversational discovery hint: a Slack workspace is wired up but the
   // user hasn't enabled the Agents View canvas. Surface it in steady-state
@@ -852,10 +857,10 @@ export function buildEvolutionContext(portalName: string, config?: JinnConfig): 
   if (isNew) {
     lines.push(`**ONBOARDING MODE**: This is a new or not-yet-onboarded ${portalName} installation.`);
     if (bootstrapPending) {
-      lines.push(`Before answering the user's request, read \`~/.ryoko/BOOTSTRAP.md\` and follow it to completion — it walks you through the onboarding skill (filling IDENTITY.md / SOUL.md / MEMORY.md) and is deleted when done.`);
+      lines.push(`Before answering the user's request, read \`${JINN_HOME}/BOOTSTRAP.md\` and follow it to completion — it walks you through the onboarding skill (filling IDENTITY.md / SOUL.md / MEMORY.md) and is deleted when done.`);
     } else {
       lines.push(`Before answering the user's request, introduce yourself briefly and ask who they are, what ${portalName} should help with, their communication preferences, and any active projects.`);
-      lines.push(`Write short durable facts, preferences, and decisions to \`~/.ryoko/MEMORY.md\`; put long-form context in \`~/.ryoko/knowledge/<topic>.md\`.`);
+      lines.push(`Write short durable facts, preferences, and decisions to \`${JINN_HOME}/MEMORY.md\`; put long-form context in \`${JINN_HOME}/knowledge/<topic>.md\`.`);
     }
     lines.push(`Then proceed to help with their original request.`);
     if (canvasHintApplies) {
@@ -865,9 +870,9 @@ export function buildEvolutionContext(portalName: string, config?: JinnConfig): 
     }
   } else {
     lines.push(`You learn and evolve over time. Memory is two-layered — keep the layers separate:`);
-    lines.push(`- Short durable facts, preferences, and decisions (1-3 lines each) → \`~/.ryoko/MEMORY.md\` (read every session; keep it lean)`);
-    lines.push(`- Long-form context (research results, project background, org info) → \`~/.ryoko/knowledge/<topic>.md\` (fetched on demand)`);
-    lines.push(`- Personality / tone feedback → \`~/.ryoko/SOUL.md\`; name or self-image changes → \`~/.ryoko/IDENTITY.md\``);
+    lines.push(`- Short durable facts, preferences, and decisions (1-3 lines each) → \`${JINN_HOME}/MEMORY.md\` (read every session; keep it lean)`);
+    lines.push(`- Long-form context (research results, project background, org info) → \`${JINN_HOME}/knowledge/<topic>.md\` (fetched on demand)`);
+    lines.push(`- Personality / tone feedback → \`${JINN_HOME}/SOUL.md\`; name or self-image changes → \`${JINN_HOME}/IDENTITY.md\``);
     lines.push(`\nDo this silently — don't announce every file update. Just evolve.`);
     if (canvasHintApplies) {
       lines.push(

--- a/packages/jimmy/src/shared/paths.ts
+++ b/packages/jimmy/src/shared/paths.ts
@@ -68,7 +68,15 @@ export const STT_MODELS_DIR = path.join(JINN_HOME, "models", "whisper");
 export const PID_FILE = path.join(JINN_HOME, "gateway.pid");
 export const CLAUDE_SKILLS_DIR = path.join(JINN_HOME, ".claude", "skills");
 export const AGENTS_SKILLS_DIR = path.join(JINN_HOME, ".agents", "skills");
-export const TEMPLATE_DIR = path.join(__dirname, "..", "..", "..", "template");
+/** Resolves for both layouts: dist/src/shared/ (built package) and
+ *  src/shared/ (vitest / ts-node running from source). */
+export const TEMPLATE_DIR = (() => {
+  const candidates = [
+    path.join(__dirname, "..", "..", "..", "template"),
+    path.join(__dirname, "..", "..", "template"),
+  ];
+  return candidates.find((c) => fs.existsSync(c)) ?? candidates[0];
+})();
 export const FILES_DIR = path.join(JINN_HOME, "files");
 export const MIGRATIONS_DIR = path.join(JINN_HOME, "migrations");
 export const TEMPLATE_MIGRATIONS_DIR = path.join(TEMPLATE_DIR, "migrations");

--- a/packages/jimmy/template/BOOTSTRAP.md
+++ b/packages/jimmy/template/BOOTSTRAP.md
@@ -21,7 +21,7 @@
 
 旧バージョンからのアップグレードの場合のみ:
 
-1. `~/.ryoko/knowledge/` 配下のファイルを ls で確認
+1. `./knowledge/` 配下のファイルを ls で確認（作業ディレクトリは常に自分のホーム）
 2. `user-profile.md` `preferences.md` `projects.md` 等が存在すれば Read
 3. 内容を要約してユーザーに「これらを引き継ぎますか？」と確認
 4. 承認されたら、短い事実は `MEMORY.md` に転記、長文は `knowledge/` に残す
@@ -30,7 +30,7 @@
 
 ### 1. onboarding スキルを起動
 
-`~/.ryoko/skills/onboarding/SKILL.md` を読み、書かれた手順を最後まで実行してください。
+`./skills/onboarding/SKILL.md` を読み、書かれた手順を最後まで実行してください。
 このスキルが IDENTITY.md / SOUL.md / MEMORY.md / TOOLS.md を対話で埋めます。
 
 ステップ 0 で既知の情報がある場合、onboarding 内のヒアリング質問はその部分をスキップして残りだけ聞いてください。
@@ -46,7 +46,9 @@
 ### 3. このファイルを削除
 
 ```bash
-rm ~/.ryoko/BOOTSTRAP.md
+rm ./BOOTSTRAP.md
 ```
+
+（作業ディレクトリは常に自分のホーム。`RYOKO_INSTANCE` で別名インスタンスとして動いている場合もこの相対パスなら正しいファイルを消せる）
 
 削除後、ユーザーに「セットアップ完了。これから {{portalName}} として動きます」と短く宣言してください。

--- a/packages/jimmy/template/config.default.yaml
+++ b/packages/jimmy/template/config.default.yaml
@@ -82,10 +82,10 @@ mcp:
   #     env:
   #       API_KEY: ${MY_API_KEY}
 
-# セッション上限（従業員ごとにYAMLで上書き可）
-sessions:
-  maxDurationMinutes: 30
-  maxCostUsd: 10.00
+# セッション上限（予約済みキー: 現行ランタイムはまだ参照しない。有効化しても効かない点に注意）
+# sessions:
+#   maxDurationMinutes: 30
+#   maxCostUsd: 10.00
 
 # Cron設定
 cron:

--- a/packages/web/src/app/chat/page.tsx
+++ b/packages/web/src/app/chat/page.tsx
@@ -22,7 +22,7 @@ import { consumeUrlSessionSelection } from '@/components/chat/url-session-select
 function getOnboardingPrompt(portalName: string, userMessage: string) {
   return `This is your first time being activated. The user just set up ${portalName} and opened the web dashboard for the first time.
 
-Read your CLAUDE.md instructions and the onboarding skill at ~/.jinn/skills/onboarding/SKILL.md, then follow the onboarding flow:
+Read your CLAUDE.md instructions and the onboarding skill at ./skills/onboarding/SKILL.md (relative to your home directory, which is your working directory), then follow the onboarding flow:
 - Greet the user warmly and introduce yourself as ${portalName}
 - Briefly explain what you can do (manage cron jobs, hire AI employees, connect to Slack, etc.)
 - Ask the user what they'd like to set up first


### PR DESCRIPTION
## 概要

新規ユーザーの初回体験を損なっていた不具合3件をまとめて修正。Playbook（テンプレ有料提供）計画のトラック A ①〜③に対応。

## 修正内容

### 1. config テンプレートが使われていなかった
`setup.ts` が `template/config.yaml` を探すのに対し実ファイルは `config.default.yaml` のため、常にインライン定数へ無言フォールバックしていた。結果、ドキュメント上デフォルト有効の `mcp.fetch` などが新規セットアップで無効になっていた。

- 新設 `src/cli/initial-config.ts` に生成ロジックを分離（`buildInitialConfig`）
- テンプレート欠損時は warn を出して最小構成へフォールバック
- `TEMPLATE_DIR` を dist / src 両レイアウトで解決できるよう堅牢化

### 2. skills.json の形式不整合で `ryoko skills list` が TypeError
テンプレートと find-and-install スキルは `{"installed": {...}}` オブジェクト形式、CLI 実装は配列を期待しており、素の setup 直後に `manifest.map is not a function` でクラッシュしていた。

- 正典をオブジェクト形式に統一（読み取りは旧配列形式も許容）

### 3. コード注入プロンプトが AGENTS.md のメモリ設計と矛盾
`context.ts` の Self-evolution セクションが upstream 由来の user-profile.md 3ファイル方式・旧 `~/.jinn` パスを指示しており、テンプレート AGENTS.md の MEMORY.md 2層方式と矛盾する指示が毎セッション同時注入されていた。

- 2層方式（MEMORY.md + knowledge/&lt;topic&gt;.md + SOUL/IDENTITY）に整合
- オンボーディング判定を BOOTSTRAP.md の存在基準に変更（旧 user-profile 判定はレガシー救済として残置）
- `~/.jinn` 表記をプロンプト文字列から一掃

## テスト

- [x] 新規テスト14本（skills-manifest 6 / initial-config 4 / evolution-context 4）
- [x] 既存含む全テスト 796/796 passed
- [x] `npm run build` クリーン

## 残タスク（別PR）

- docs/ テンプレートの陳腐化（実在しないスキル列挙・jinn-cli 表記）
- Web UI オンボーディングの名前置換正規表現が日本語テンプレートに不適合