### PR TITLE
fix: 同梱 docs の陳腐化解消と Web オンボーディングの日本語対応

### DIFF
--- a/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
+++ b/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
@@ -91,6 +91,9 @@ describe("skills.json manifest", () => {
       JSON.stringify({
         installed: {
           evil: { source: "owner/repo@x; echo PWNED > /tmp/pwned.txt", installedAt: "t" },
+          dot: { source: "./repo", installedAt: "t" },
+          dotdot: { source: "../repo", installedAt: "t" },
+          hidden: { source: ".hidden/repo", installedAt: "t" },
           fine: { source: "owner/repo@skill", installedAt: "t" },
           repo: { source: "owner/repo", installedAt: "t" },
         },
@@ -98,6 +101,9 @@ describe("skills.json manifest", () => {
     );
     const byName = Object.fromEntries(readManifest().map((e) => [e.name, e.source]));
     expect(byName.evil).toBe("");
+    expect(byName.dot).toBe("");
+    expect(byName.dotdot).toBe("");
+    expect(byName.hidden).toBe("");
     expect(byName.fine).toBe("owner/repo@skill");
     expect(byName.repo).toBe("owner/repo");
   });

--- a/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
+++ b/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
@@ -22,6 +22,8 @@ import {
   writeManifest,
   upsertManifest,
   removeFromManifest,
+  isValidSource,
+  sanitizeFindQuery,
   SKILLS_JSON,
 } from "../skills.js";
 
@@ -147,6 +149,17 @@ describe("skills.json manifest", () => {
     const written = lastWrittenJson();
     expect(written.installed.a.version).toBe("1.2.3");
     expect(written.installed.b.source).toBe("own/rep@b");
+  });
+
+  it("validates CLI-provided sources and sanitizes find queries (win32 shell:true path)", () => {
+    expect(isValidSource("owner/repo@skill")).toBe(true);
+    expect(isValidSource("owner/repo")).toBe(true);
+    expect(isValidSource("owner/repo@x; echo PWNED")).toBe(false);
+    expect(isValidSource("a & calc")).toBe(false);
+    expect(isValidSource("../repo")).toBe(false);
+    expect(sanitizeFindQuery("ios swift xcode")).toBe("ios swift xcode");
+    expect(sanitizeFindQuery("react & del /q *")).toBe("react del /q");
+    expect(sanitizeFindQuery('foo" | calc')).toBe("foo calc");
   });
 
   it("removeFromManifest keeps unrelated entries and top-level fields", () => {

--- a/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
+++ b/packages/jimmy/src/cli/__tests__/skills-manifest.test.ts
@@ -160,6 +160,8 @@ describe("skills.json manifest", () => {
     expect(sanitizeFindQuery("ios swift xcode")).toBe("ios swift xcode");
     expect(sanitizeFindQuery("react & del /q *")).toBe("react del /q");
     expect(sanitizeFindQuery('foo" | calc')).toBe("foo calc");
+    expect(sanitizeFindQuery("動画生成 スライド")).toBe("動画生成 スライド");
+    expect(sanitizeFindQuery("動画 & del")).toBe("動画 del");
   });
 
   it("removeFromManifest keeps unrelated entries and top-level fields", () => {

--- a/packages/jimmy/src/cli/skills.ts
+++ b/packages/jimmy/src/cli/skills.ts
@@ -50,7 +50,9 @@ export function isValidSource(pkg: string): boolean {
 /** Free-text search terms may still cross the win32 shell:true path — strip
  *  anything cmd.exe could reinterpret. Harmless for search relevance. */
 export function sanitizeFindQuery(query: string): string {
-  return query.replace(/[^\w .@/-]+/g, " ").replace(/\s+/g, " ").trim();
+  // \p{L}\p{N} keeps every script (Japanese queries included) while still
+  // stripping shell metacharacters for the win32 shell:true path.
+  return query.replace(/[^\p{L}\p{N}_ .@/-]+/gu, " ").replace(/\s+/g, " ").trim();
 }
 
 interface RawManifest {

--- a/packages/jimmy/src/cli/skills.ts
+++ b/packages/jimmy/src/cli/skills.ts
@@ -29,8 +29,15 @@ export interface SkillManifestEntry {
 
 /** skills.json is written freely by the agent (see find-and-install), so
  *  `source` is untrusted input that later reaches `npx skills add`. Only
- *  accept the "owner/repo" / "owner/repo@skill" shapes. */
-const SOURCE_RE = /^[\w.-]+\/[\w.-]+(@[\w.-]+)?$/;
+ *  accept the "owner/repo" / "owner/repo@skill" shapes — each segment must
+ *  start alphanumeric, so `./x`, `../x`, and `.hidden/x` (local-path forms
+ *  the skills CLI would resolve) are rejected. */
+const SOURCE_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*(@[\w.-]+)?$/;
+
+/** POSIX spawns npx directly (argv is never shell-parsed — that is the
+ *  injection boundary for agent-written sources). Windows needs a shell to
+ *  resolve npx.cmd; safe there because every source is SOURCE_RE-validated. */
+const NPX_SPAWN_OPTS = process.platform === "win32" ? { shell: true as const } : {};
 
 function sanitizeSource(v: unknown): string {
   return typeof v === "string" && SOURCE_RE.test(v) ? v : "";
@@ -197,7 +204,7 @@ export function skillsFind(query?: string): void {
   if (query) args.push(query);
   const result = spawnSync("npx", args, {
     stdio: "inherit",
-    // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
+    ...NPX_SPAWN_OPTS,
   });
   process.exitCode = result.status ?? 1;
 }
@@ -211,7 +218,7 @@ export function skillsAdd(pkg: string): void {
   // Run npx skills add
   const result = spawnSync("npx", ["skills", "add", pkg, "-g", "-y"], {
     stdio: "inherit",
-    // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
+    ...NPX_SPAWN_OPTS,
   });
 
   if (result.status !== 0) {
@@ -311,7 +318,7 @@ export function skillsUpdate(): void {
     const before = snapshotDirs();
     const result = spawnSync("npx", ["skills", "add", entry.source, "-g", "-y"], {
       stdio: "pipe",
-      // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
+      ...NPX_SPAWN_OPTS,
     });
 
     if (result.status !== 0) {
@@ -358,7 +365,7 @@ export function skillsRestore(): void {
     const before = snapshotDirs();
     const result = spawnSync("npx", ["skills", "add", entry.source, "-g", "-y"], {
       stdio: "pipe",
-      // no shell: argv must never be re-parsed — source strings come from the agent-written skills.json
+      ...NPX_SPAWN_OPTS,
     });
 
     if (result.status !== 0) {

--- a/packages/jimmy/src/cli/skills.ts
+++ b/packages/jimmy/src/cli/skills.ts
@@ -43,6 +43,16 @@ function sanitizeSource(v: unknown): string {
   return typeof v === "string" && SOURCE_RE.test(v) ? v : "";
 }
 
+export function isValidSource(pkg: string): boolean {
+  return SOURCE_RE.test(pkg);
+}
+
+/** Free-text search terms may still cross the win32 shell:true path — strip
+ *  anything cmd.exe could reinterpret. Harmless for search relevance. */
+export function sanitizeFindQuery(query: string): string {
+  return query.replace(/[^\w .@/-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
 interface RawManifest {
   installed: Record<string, Record<string, unknown>>;
   [key: string]: unknown;
@@ -201,7 +211,8 @@ function copyDirRecursive(src: string, dest: string): void {
 
 export function skillsFind(query?: string): void {
   const args = ["skills", "find"];
-  if (query) args.push(query);
+  const cleaned = query ? sanitizeFindQuery(query) : "";
+  if (cleaned) args.push(cleaned);
   const result = spawnSync("npx", args, {
     stdio: "inherit",
     ...NPX_SPAWN_OPTS,
@@ -210,6 +221,11 @@ export function skillsFind(query?: string): void {
 }
 
 export function skillsAdd(pkg: string): void {
+  if (!isValidSource(pkg)) {
+    console.error(`${RED}source は owner/repo または owner/repo@skill 形式で指定してください: ${pkg}${RESET}`);
+    process.exitCode = 1;
+    return;
+  }
   console.log(`\nスキルをインストール中: ${pkg}\n`);
 
   // Snapshot before

--- a/packages/jimmy/src/gateway/__tests__/onboarding-personalize.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-personalize.test.ts
@@ -1,15 +1,12 @@
 import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { personalizeInstructionMd, personalizeIdentityMd } from "../onboarding-personalize.js";
-
-// Resolved relative to this test file — TEMPLATE_DIR from shared/paths.js
-// assumes the dist layout and misresolves when vitest runs from src/.
-const TEMPLATE_DIR = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..", "..", "..", "template",
-);
+import { TEMPLATE_DIR } from "../../shared/paths.js";
+import {
+  personalizeInstructionMd,
+  personalizeIdentityMd,
+  resolveEffectiveName,
+} from "../onboarding-personalize.js";
 
 function renderedTemplate(filename: string): string {
   const raw = fs.readFileSync(path.join(TEMPLATE_DIR, filename), "utf-8");
@@ -41,14 +38,51 @@ describe("Web onboarding name personalization", () => {
     expect(md).toContain("You are **Momo**");
   });
 
+  it("survives a name containing an em dash across repeated renames", () => {
+    const once = personalizeInstructionMd(renderedTemplate("CLAUDE.md"), "Ryo — ko");
+    expect(once).toContain("# Ryo — ko — 運用指示書");
+    const twice = personalizeInstructionMd(once, "Neo");
+    expect(twice).toContain("# Neo — 運用指示書");
+    expect(twice).not.toContain("Ryo — ko — 運用指示書");
+  });
+
   it("syncs the IDENTITY.md Name section", () => {
     const md = personalizeIdentityMd(renderedTemplate("IDENTITY.md"), "Momo");
     expect(md).toContain("# IDENTITY — Momo");
     expect(md).toMatch(/## Name\nMomo/);
   });
 
+  it("handles an agent-reformatted IDENTITY.md with a blank line under ## Name", () => {
+    const md = personalizeIdentityMd("# IDENTITY — Momo\n\n## Name\n\nMomo\n\n## Vibe\nゆるい\n", "Neo");
+    expect(md).toContain("# IDENTITY — Neo");
+    expect(md).toMatch(/## Name\n\nNeo/);
+    expect(md).toContain("## Vibe\nゆるい");
+  });
+
+  it("does not eat the next heading when the Name section is empty", () => {
+    const md = personalizeIdentityMd("## Name\n## Vibe\nゆるい\n", "Neo");
+    expect(md).toContain("## Vibe\nゆるい");
+  });
+
   it("does not mangle unrelated bold text or headings", () => {
     const md = personalizeInstructionMd("# 別の見出し\n**強調** はそのまま。", "Momo");
     expect(md).toBe("# 別の見出し\n**強調** はそのまま。");
+  });
+});
+
+describe("resolveEffectiveName", () => {
+  it("prefers the requested name", () => {
+    expect(resolveEffectiveName("Momo", "Old")).toBe("Momo");
+  });
+
+  it("falls back to the configured name when the request omits it (regression: language-only update renamed back to Ryoko)", () => {
+    expect(resolveEffectiveName(undefined, "Momo")).toBe("Momo");
+    expect(resolveEffectiveName("", "Momo")).toBe("Momo");
+    expect(resolveEffectiveName("   ", "Momo")).toBe("Momo");
+  });
+
+  it("defaults to Ryoko only when nothing is configured", () => {
+    expect(resolveEffectiveName(undefined, undefined)).toBe("Ryoko");
+    expect(resolveEffectiveName("", "")).toBe("Ryoko");
   });
 });

--- a/packages/jimmy/src/gateway/__tests__/onboarding-personalize.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-personalize.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { personalizeInstructionMd, personalizeIdentityMd } from "../onboarding-personalize.js";
+
+// Resolved relative to this test file — TEMPLATE_DIR from shared/paths.js
+// assumes the dist layout and misresolves when vitest runs from src/.
+const TEMPLATE_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "..", "..", "template",
+);
+
+function renderedTemplate(filename: string): string {
+  const raw = fs.readFileSync(path.join(TEMPLATE_DIR, filename), "utf-8");
+  return raw.replaceAll("{{portalName}}", "Ryoko").replaceAll("{{portalSlug}}", "ryoko");
+}
+
+describe("Web onboarding name personalization", () => {
+  it("renames the identity line of the shipped Japanese CLAUDE.md (regression: regex only knew the English upstream form)", () => {
+    const md = personalizeInstructionMd(renderedTemplate("CLAUDE.md"), "Momo");
+    expect(md).toContain("あなたは **Momo**");
+    expect(md).not.toContain("あなたは **Ryoko**");
+    expect(md).toContain("# Momo — 運用指示書");
+  });
+
+  it("renames the shipped Japanese AGENTS.md the same way", () => {
+    const md = personalizeInstructionMd(renderedTemplate("AGENTS.md"), "Momo");
+    expect(md).toContain("あなたは **Momo**");
+    expect(md).not.toContain("あなたは **Ryoko**");
+  });
+
+  it("still handles the upstream English forms", () => {
+    const en = [
+      "You are Jinn, the COO of the user's AI organization.",
+      "",
+      "Intro: You are **Jinn** — a personal AI assistant.",
+    ].join("\n");
+    const md = personalizeInstructionMd(en, "Momo");
+    expect(md).toContain("You are Momo, the COO of the user's AI organization.");
+    expect(md).toContain("You are **Momo**");
+  });
+
+  it("syncs the IDENTITY.md Name section", () => {
+    const md = personalizeIdentityMd(renderedTemplate("IDENTITY.md"), "Momo");
+    expect(md).toContain("# IDENTITY — Momo");
+    expect(md).toMatch(/## Name\nMomo/);
+  });
+
+  it("does not mangle unrelated bold text or headings", () => {
+    const md = personalizeInstructionMd("# 別の見出し\n**強調** はそのまま。", "Momo");
+    expect(md).toBe("# 別の見出し\n**強調** はそのまま。");
+  });
+});

--- a/packages/jimmy/src/gateway/__tests__/portal-config.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/portal-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import yaml from "js-yaml";
+import { CONFIG_TEMPLATE_PATH } from "../../cli/initial-config.js";
+import { patchPortalSection } from "../portal-config.js";
+
+const countCommentLines = (s: string) =>
+  s.split("\n").filter((l) => l.trim().startsWith("#")).length;
+
+describe("patchPortalSection", () => {
+  it("updates the portal block in the shipped template WITHOUT touching its comments (regression: yaml.dump stripped all 50+ guidance comments)", () => {
+    const raw = fs.readFileSync(CONFIG_TEMPLATE_PATH, "utf-8");
+    const patched = patchPortalSection(raw, {
+      portalName: "Momo",
+      language: "Japanese",
+      onboarded: true,
+    });
+
+    expect(countCommentLines(patched)).toBe(countCommentLines(raw));
+
+    const parsed = yaml.load(patched) as any;
+    expect(parsed.portal).toEqual({ portalName: "Momo", language: "Japanese", onboarded: true });
+    // Everything outside portal is untouched
+    expect(parsed.engines?.claude?.model).toBe("claude-opus-5");
+    expect(parsed.mcp?.fetch?.enabled).toBe(true);
+    expect(parsed.logging?.level).toBe("info");
+  });
+
+  it("replaces the inline `portal: {}` form", () => {
+    const raw = "gateway:\n  port: 7777\nportal: {}\nlogging:\n  level: info\n";
+    const parsed = yaml.load(patchPortalSection(raw, { portalName: "Momo" })) as any;
+    expect(parsed.portal).toEqual({ portalName: "Momo" });
+    expect(parsed.logging.level).toBe("info");
+  });
+
+  it("appends a portal block when none exists", () => {
+    const raw = "gateway:\n  port: 7777\n";
+    const parsed = yaml.load(patchPortalSection(raw, { onboarded: true })) as any;
+    expect(parsed.portal).toEqual({ onboarded: true });
+    expect(parsed.gateway.port).toBe(7777);
+  });
+
+  it("handles a portal block at end of file and quotes hostile values", () => {
+    const raw = "gateway:\n  port: 7777\n\nportal:\n  portalName: Old\n";
+    const patched = patchPortalSection(raw, { portalName: 'Ry"oko: yes' });
+    const parsed = yaml.load(patched) as any;
+    expect(parsed.portal.portalName).toBe('Ry"oko: yes');
+  });
+
+  it("drops undefined values instead of serializing them", () => {
+    const raw = "portal: {}\n";
+    const parsed = yaml.load(
+      patchPortalSection(raw, { onboarded: true, portalName: undefined }),
+    ) as any;
+    expect(parsed.portal).toEqual({ onboarded: true });
+  });
+});

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -84,7 +84,8 @@ import { getDiskSpaceStatus } from "../shared/storage-health.js";
 import { ptySnapshotStore } from "../engines/pty-snapshot.js";
 import { collectClaudeUsage } from "../shared/claude-usage.js";
 import { PairingAttemptLimiter, pairingAttemptKey } from "./pairing-rate-limit.js";
-import { personalizeInstructionMd, personalizeIdentityMd } from "./onboarding-personalize.js";
+import { personalizeInstructionMd, personalizeIdentityMd, resolveEffectiveName } from "./onboarding-personalize.js";
+import { patchPortalSection, writeFileAtomic } from "./portal-config.js";
 
 /** Max bytes accepted on /api/internal/hook (loopback-only relay payloads are tiny). */
 const HOOK_BODY_MAX_BYTES = 64 * 1024;
@@ -2048,46 +2049,53 @@ Handle this as a priority request from a colleague.`;
       const body = _parsed.body as any;
       const { portalName, operatorName, language } = body;
 
-      // Read current config and merge portal settings
+      // Read current config and merge portal settings. Empty strings are
+      // treated as "not provided" — deleting the key would silently revert
+      // the portal to its defaults.
       const config = context.getConfig();
-      const updated = {
-        ...config,
-        portal: {
-          ...config.portal,
-          onboarded: true,
-          ...(portalName !== undefined && { portalName: portalName || undefined }),
-          ...(operatorName !== undefined && { operatorName: operatorName || undefined }),
-          ...(language !== undefined && { language: language || undefined }),
-        },
+      const provided = (v: unknown): v is string => typeof v === "string" && v.trim() !== "";
+      const portalPatch: Record<string, unknown> = {
+        ...config.portal,
+        onboarded: true,
+        ...(provided(portalName) && { portalName }),
+        ...(provided(operatorName) && { operatorName }),
+        ...(provided(language) && { language }),
       };
+      const updated = { ...config, portal: portalPatch };
 
-      // Write updated config
-      const yamlStr = yaml.dump(updated, { lineWidth: -1 });
-      fs.writeFileSync(CONFIG_PATH, yamlStr);
+      // Patch only the portal block — a whole-file yaml.dump would strip
+      // every comment the shipped config template carries.
+      const rawConfig = fs.existsSync(CONFIG_PATH) ? fs.readFileSync(CONFIG_PATH, "utf-8") : "";
+      writeFileAtomic(CONFIG_PATH, patchPortalSection(rawConfig, portalPatch));
       logger.info(`Onboarding: portal name="${portalName}", operator="${operatorName}", language="${language}"`);
 
-      const effectiveName = portalName || "Ryoko";
+      const effectiveName = resolveEffectiveName(portalName, config.portal?.portalName);
       const languageSection = language && language !== "English"
         ? `\n\n## Language\nAlways respond in ${language}. All communication with the user must be in ${language}.`
         : "";
 
-      // Update CLAUDE.md / AGENTS.md with the personalized name and language
+      // Update CLAUDE.md / AGENTS.md: language section always; the name only
+      // when this request actually carries one (a language-only update must
+      // not rename a customized assistant back to the default).
       for (const filename of ["CLAUDE.md", "AGENTS.md"]) {
         const mdPath = path.join(JINN_HOME, filename);
         if (!fs.existsSync(mdPath)) continue;
-        let md = personalizeInstructionMd(fs.readFileSync(mdPath, "utf-8"), effectiveName);
+        let md = fs.readFileSync(mdPath, "utf-8");
+        if (provided(portalName)) {
+          md = personalizeInstructionMd(md, effectiveName);
+        }
         // Remove existing language section if present, then add new one if needed
         md = md.replace(/\n\n## Language\nAlways respond in .+\. All communication with the user must be in .+\./m, "");
         if (languageSection) {
           md = md.trimEnd() + languageSection + "\n";
         }
-        fs.writeFileSync(mdPath, md);
+        writeFileAtomic(mdPath, md);
       }
 
       // Keep the persona file's Name section in sync
       const identityMdPath = path.join(JINN_HOME, "IDENTITY.md");
-      if (portalName && fs.existsSync(identityMdPath)) {
-        fs.writeFileSync(
+      if (provided(portalName) && fs.existsSync(identityMdPath)) {
+        writeFileAtomic(
           identityMdPath,
           personalizeIdentityMd(fs.readFileSync(identityMdPath, "utf-8"), effectiveName),
         );

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -84,6 +84,7 @@ import { getDiskSpaceStatus } from "../shared/storage-health.js";
 import { ptySnapshotStore } from "../engines/pty-snapshot.js";
 import { collectClaudeUsage } from "../shared/claude-usage.js";
 import { PairingAttemptLimiter, pairingAttemptKey } from "./pairing-rate-limit.js";
+import { personalizeInstructionMd, personalizeIdentityMd } from "./onboarding-personalize.js";
 
 /** Max bytes accepted on /api/internal/hook (loopback-only relay payloads are tiny). */
 const HOOK_BODY_MAX_BYTES = 64 * 1024;
@@ -2070,38 +2071,26 @@ Handle this as a priority request from a colleague.`;
         ? `\n\n## Language\nAlways respond in ${language}. All communication with the user must be in ${language}.`
         : "";
 
-      // Update CLAUDE.md with personalized COO name and language
-      const claudeMdPath = path.join(JINN_HOME, "CLAUDE.md");
-      if (fs.existsSync(claudeMdPath)) {
-        let claudeMd = fs.readFileSync(claudeMdPath, "utf-8");
-        // Replace the identity line in CLAUDE.md
-        claudeMd = claudeMd.replace(
-          /^You are \w+, the COO of the user's AI organization\.$/m,
-          `You are ${effectiveName}, the COO of the user's AI organization.`,
-        );
+      // Update CLAUDE.md / AGENTS.md with the personalized name and language
+      for (const filename of ["CLAUDE.md", "AGENTS.md"]) {
+        const mdPath = path.join(JINN_HOME, filename);
+        if (!fs.existsSync(mdPath)) continue;
+        let md = personalizeInstructionMd(fs.readFileSync(mdPath, "utf-8"), effectiveName);
         // Remove existing language section if present, then add new one if needed
-        claudeMd = claudeMd.replace(/\n\n## Language\nAlways respond in .+\. All communication with the user must be in .+\./m, "");
+        md = md.replace(/\n\n## Language\nAlways respond in .+\. All communication with the user must be in .+\./m, "");
         if (languageSection) {
-          claudeMd = claudeMd.trimEnd() + languageSection + "\n";
+          md = md.trimEnd() + languageSection + "\n";
         }
-        fs.writeFileSync(claudeMdPath, claudeMd);
+        fs.writeFileSync(mdPath, md);
       }
 
-      // Update AGENTS.md with personalized name and language
-      const agentsMdPath = path.join(JINN_HOME, "AGENTS.md");
-      if (fs.existsSync(agentsMdPath)) {
-        let agentsMd = fs.readFileSync(agentsMdPath, "utf-8");
-        // Replace the bold identity line (e.g. "You are **Jinn**")
-        agentsMd = agentsMd.replace(
-          /You are \*\*\w+\*\*/,
-          `You are **${effectiveName}**`,
+      // Keep the persona file's Name section in sync
+      const identityMdPath = path.join(JINN_HOME, "IDENTITY.md");
+      if (portalName && fs.existsSync(identityMdPath)) {
+        fs.writeFileSync(
+          identityMdPath,
+          personalizeIdentityMd(fs.readFileSync(identityMdPath, "utf-8"), effectiveName),
         );
-        // Remove existing language section if present, then add new one if needed
-        agentsMd = agentsMd.replace(/\n\n## Language\nAlways respond in .+\. All communication with the user must be in .+\./m, "");
-        if (languageSection) {
-          agentsMd = agentsMd.trimEnd() + languageSection + "\n";
-        }
-        fs.writeFileSync(agentsMdPath, agentsMd);
       }
 
       context.emit("config:updated", { portal: updated.portal });

--- a/packages/jimmy/src/gateway/onboarding-personalize.ts
+++ b/packages/jimmy/src/gateway/onboarding-personalize.ts
@@ -1,0 +1,30 @@
+/**
+ * Name personalization for the instruction / persona Markdown files.
+ * Must match BOTH the Japanese templates ("# X — 運用指示書", "あなたは **X**")
+ * and the upstream English forms ("You are **X**", "You are X, the COO ...") —
+ * the Web onboarding previously only knew the English forms, so renames from
+ * the UI never reached the Japanese files.
+ */
+
+export function personalizeInstructionMd(md: string, name: string): string {
+  let out = md.replace(
+    /^(# )[^\n—]+( — 運用指示書)$/m,
+    (_m, p1: string, p2: string) => p1 + name + p2,
+  );
+  out = out.replace(
+    /^(あなたは \*\*)[^*]+(\*\*)/m,
+    (_m, p1: string, p2: string) => p1 + name + p2,
+  );
+  out = out.replace(/You are \*\*[^*]+\*\*/, () => `You are **${name}**`);
+  out = out.replace(
+    /^You are \w+, the COO of the user's AI organization\.$/m,
+    () => `You are ${name}, the COO of the user's AI organization.`,
+  );
+  return out;
+}
+
+export function personalizeIdentityMd(md: string, name: string): string {
+  return md
+    .replace(/^(# IDENTITY — ).+$/m, (_m, p1: string) => p1 + name)
+    .replace(/^(## Name\n).+$/m, (_m, p1: string) => p1 + name);
+}

--- a/packages/jimmy/src/gateway/onboarding-personalize.ts
+++ b/packages/jimmy/src/gateway/onboarding-personalize.ts
@@ -6,9 +6,18 @@
  * the UI never reached the Japanese files.
  */
 
+/** Pick the name the workspace should carry after an onboarding POST:
+ *  the explicitly requested one, else the name already configured, else the
+ *  default. Falling back straight to the default would let a language-only
+ *  update silently rename a customized assistant back to "Ryoko". */
+export function resolveEffectiveName(requested: unknown, current: unknown): string {
+  const pick = (v: unknown) => (typeof v === "string" && v.trim() ? v : undefined);
+  return pick(requested) ?? pick(current) ?? "Ryoko";
+}
+
 export function personalizeInstructionMd(md: string, name: string): string {
   let out = md.replace(
-    /^(# )[^\n—]+( — 運用指示書)$/m,
+    /^(# ).+( — 運用指示書)$/m,
     (_m, p1: string, p2: string) => p1 + name + p2,
   );
   out = out.replace(
@@ -26,5 +35,8 @@ export function personalizeInstructionMd(md: string, name: string): string {
 export function personalizeIdentityMd(md: string, name: string): string {
   return md
     .replace(/^(# IDENTITY — ).+$/m, (_m, p1: string) => p1 + name)
-    .replace(/^(## Name\n).+$/m, (_m, p1: string) => p1 + name);
+    // \n+ tolerates a blank line the onboarding agent may have inserted
+    // between the heading and the value; (?!#) refuses to eat the next
+    // heading when the section is empty.
+    .replace(/^(## Name\n+)(?!#)(.+)$/m, (_m, p1: string) => p1 + name);
 }

--- a/packages/jimmy/src/gateway/portal-config.ts
+++ b/packages/jimmy/src/gateway/portal-config.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import yaml from "js-yaml";
+
+/**
+ * Replace ONLY the top-level `portal:` block in raw config.yaml text, leaving
+ * every other line byte-identical. A whole-file `yaml.dump` round-trip strips
+ * all comments — and the shipped config template is mostly guidance comments,
+ * so onboarding must never rewrite the file wholesale.
+ */
+export function patchPortalSection(raw: string, portal: Record<string, unknown>): string {
+  const defined = Object.fromEntries(
+    Object.entries(portal).filter(([, v]) => v !== undefined),
+  );
+  const rendered =
+    Object.keys(defined).length === 0
+      ? ["portal: {}"]
+      : [
+          "portal:",
+          ...yaml
+            .dump(defined, { lineWidth: -1 })
+            .split("\n")
+            .filter((l) => l !== "")
+            .map((l) => "  " + l),
+        ];
+
+  const lines = raw.split("\n");
+  const start = lines.findIndex((l) => /^portal:\s*(\{.*\})?\s*(#.*)?$/.test(l));
+  if (start === -1) {
+    const sep = raw === "" || raw.endsWith("\n") ? "" : "\n";
+    return raw + sep + rendered.join("\n") + "\n";
+  }
+
+  // The block ends at the next line that starts in column 0 (key or comment
+  // introducing the next section). Blank/indented lines belong to the block.
+  let end = start + 1;
+  while (end < lines.length && !/^\S/.test(lines[end])) end++;
+
+  // Keep exactly one blank line before the next section (if one follows).
+  const tail = lines.slice(end);
+  const spacer = tail.length > 0 && tail[0] !== "" ? [""] : [];
+  return [...lines.slice(0, start), ...rendered, ...spacer, ...tail].join("\n");
+}
+
+/** Crash-safe replacement for a config/instruction file the gateway watches. */
+export function writeFileAtomic(filePath: string, data: string): void {
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, filePath);
+}

--- a/packages/jimmy/src/gateway/portal-config.ts
+++ b/packages/jimmy/src/gateway/portal-config.ts
@@ -6,6 +6,10 @@ import yaml from "js-yaml";
  * every other line byte-identical. A whole-file `yaml.dump` round-trip strips
  * all comments — and the shipped config template is mostly guidance comments,
  * so onboarding must never rewrite the file wholesale.
+ *
+ * Known limitation: comments INSIDE the portal block itself are regenerated
+ * away. The shipped template keeps that block comment-free, so nothing is
+ * lost in practice; keep it that way when editing the template.
  */
 export function patchPortalSection(raw: string, portal: Record<string, unknown>): string {
   const defined = Object.fromEntries(

--- a/packages/jimmy/template/docs/architecture.md
+++ b/packages/jimmy/template/docs/architecture.md
@@ -54,13 +54,13 @@ Modular adapters that implement a standard interface. Each connector translates 
 Uses `node-cron` to run scheduled AI jobs. Watches `cron/jobs.json` for hot-reload. See `cron.md`.
 
 ### File Watcher
-Uses `chokidar` to watch `~/.jinn/` for changes and trigger appropriate reloads:
+Uses `chokidar` to watch `~/.ryoko/` for changes and trigger appropriate reloads:
 - `config.yaml` changes → reload gateway configuration
 - `cron/jobs.json` changes → reschedule cron jobs
 - `org/` changes → rebuild employee registry
 
 ### SQLite Session Registry
-Stores session metadata (id, engine, employee, connector source, timestamps) in `jinn.db`.
+Stores session metadata (id, engine, employee, connector source, timestamps) in `sessions/registry.db`.
 
 ## Data Flow
 

--- a/packages/jimmy/template/docs/cron.md
+++ b/packages/jimmy/template/docs/cron.md
@@ -1,6 +1,6 @@
 # Cron
 
-{{portalName}} supports scheduled AI jobs defined in `~/.jinn/cron/jobs.json`.
+{{portalName}} supports scheduled AI jobs defined in `~/.ryoko/cron/jobs.json`.
 
 ## Job Schema
 
@@ -59,7 +59,7 @@ No restart required. Engines can edit `jobs.json` directly to create or modify s
 
 ## Run Logs
 
-Each job execution is logged to `~/.jinn/cron/runs/<jobId>.jsonl`. Each line is a JSON object:
+Each job execution is logged to `~/.ryoko/cron/runs/<jobId>.jsonl`. Each line is a JSON object:
 
 ```json
 {
@@ -138,7 +138,7 @@ Direct employee-to-user delivery is only acceptable for simple, no-review-needed
     "timezone": "America/New_York",
     "engine": "claude",
     "employee": "{{portalSlug}}",
-    "prompt": "Review all skills in ~/.jinn/skills/ and suggest improvements or removals for unused skills."
+    "prompt": "Review all skills in ~/.ryoko/skills/ and suggest improvements or removals for unused skills."
   }
 ]
 ```

--- a/packages/jimmy/template/docs/cron.md
+++ b/packages/jimmy/template/docs/cron.md
@@ -76,6 +76,8 @@ Each job execution is logged to `~/.ryoko/cron/runs/<jobId>.jsonl`. Each line is
 
 When a cron job produces analytical, reporting, or decision-informing output, it should **always target {{portalSlug}}** (the COO), not the employee directly. {{portalName}} then delegates to the employee via a child session, reviews the output, filters noise, and delivers the final result.
 
+> Note: `"employee": "{{portalSlug}}"` here refers to the COO portal session itself — it is NOT an `org/` employee (org.md: `org/` starts empty and {{portalName}} is not defined there). The runner resolves an unknown employee name to a portal session, which is exactly the intended routing.
+
 **Correct** — cron → {{portalSlug}} → employee (via child session) → {{portalSlug}} reviews → delivery:
 ```json
 {

--- a/packages/jimmy/template/docs/mcp.md
+++ b/packages/jimmy/template/docs/mcp.md
@@ -6,7 +6,7 @@
 
 1. MCP servers are defined in `config.yaml` under the `mcp:` section
 2. When a session starts, {{portalName}} resolves which MCP servers the employee needs
-3. A temporary MCP config JSON file is written to `~/.jinn/tmp/mcp/`
+3. A temporary MCP config JSON file is written to `~/.ryoko/tmp/mcp/`
 4. The file is passed to Claude Code via `--mcp-config <path>`
 5. The file is cleaned up after the session completes
 

--- a/packages/jimmy/template/docs/org.md
+++ b/packages/jimmy/template/docs/org.md
@@ -4,7 +4,7 @@
 
 ## Employee Personas
 
-Employee files live at `~/.jinn/org/<department>/<name>.yaml`.
+Employee files live at `~/.ryoko/org/<department>/<name>.yaml`.
 
 ```yaml
 name: alice
@@ -33,10 +33,10 @@ persona: |
 
 ## Departments
 
-Each department is a directory under `~/.jinn/org/` containing:
+Each department is a directory under `~/.ryoko/org/` containing:
 
 ```
-~/.jinn/org/engineering/
+~/.ryoko/org/engineering/
   department.yaml     # Department metadata
   board.json          # Shared task board
   alice.yaml          # Employee persona
@@ -90,16 +90,22 @@ Task fields: `id`, `title`, `assignee`, `status` (open, in-progress, done, block
 
 ## Default Organization
 
-{{portalName}} ships with a single executive employee:
+`org/` starts empty. {{portalName}} itself is the executive (COO) and is not
+defined as an org employee — employees are the workers {{portalName}} delegates to.
+
+The onboarding skill proposes a starter scaffold matched to the user's profile
+(e.g. an `engineering/` department with a `dev-assistant` employee for a solo
+developer), and the management skill handles hiring from there. An employee
+file looks like:
 
 ```yaml
-name: {{portalSlug}}
-displayName: {{portalName}}
-department: executive
-rank: executive
+name: dev-assistant
+displayName: Dev Assistant
+department: engineering
+rank: employee
 engine: claude
-model: opus
+model: claude-opus-5
 persona: |
-  You are {{portalName}}, the executive AI assistant and gateway administrator.
-  You manage the organization, delegate tasks, and handle direct requests.
+  You are a careful software engineer. You implement tasks assigned by
+  {{portalName}}, report progress on the board, and escalate blockers.
 ```

--- a/packages/jimmy/template/docs/overview.md
+++ b/packages/jimmy/template/docs/overview.md
@@ -1,6 +1,6 @@
 # {{portalName}} Overview
 
-{{portalName}} is a lightweight AI gateway daemon that wraps professional AI CLI tools as "engines." It is published as `jinn-cli`.
+{{portalName}} is a lightweight AI gateway daemon that wraps professional AI CLI tools as "engines." It is published as `openryoko`.
 
 ## Core Principle
 
@@ -22,9 +22,9 @@ Traditional approaches build custom tool-calling loops, manage context windows, 
 ## Directory Structure
 
 ```
-~/.jinn/
+~/.ryoko/
   config.yaml          # Gateway configuration
-  jinn.db             # SQLite session registry
+  sessions/registry.db             # SQLite session registry
   docs/                # These reference docs
   skills/              # Skill directories with SKILL.md files
   cron/

--- a/packages/jimmy/template/docs/overview.md
+++ b/packages/jimmy/template/docs/overview.md
@@ -24,7 +24,8 @@ Traditional approaches build custom tool-calling loops, manage context windows, 
 ```
 ~/.ryoko/
   config.yaml          # Gateway configuration
-  sessions/registry.db             # SQLite session registry
+  sessions/
+    registry.db        # SQLite session registry
   docs/                # These reference docs
   skills/              # Skill directories with SKILL.md files
   cron/

--- a/packages/jimmy/template/docs/self-modification.md
+++ b/packages/jimmy/template/docs/self-modification.md
@@ -1,6 +1,6 @@
 # Self-Modification
 
-{{portalName}}'s engines operate within `~/.jinn/` and can modify any file in that directory. This enables {{portalName}} to update its own configuration, create skills, manage cron jobs, and restructure the organization at runtime.
+{{portalName}}'s engines operate within `~/.ryoko/` and can modify any file in that directory. This enables {{portalName}} to update its own configuration, create skills, manage cron jobs, and restructure the organization at runtime.
 
 ## What {{portalName}} Can Edit
 
@@ -25,7 +25,7 @@ Changes take effect immediately. No restart required.
 
 ## Safety Guidelines
 
-Engines have full file access within `~/.jinn/`. To avoid breaking the gateway:
+Engines have full file access within `~/.ryoko/`. To avoid breaking the gateway:
 
 ### Do
 
@@ -38,28 +38,28 @@ Engines have full file access within `~/.jinn/`. To avoid breaking the gateway:
 ### Do Not
 
 - Break `config.yaml` structure — invalid YAML will prevent config reload
-- Corrupt `jinn.db` — the SQLite database is managed by the gateway process
+- Corrupt `sessions/registry.db` — the SQLite database is managed by the gateway process
 - Write invalid JSON to `jobs.json` — this will cancel all cron jobs with nothing to replace them
 - Delete the `docs/` directory — these reference docs are needed for self-awareness
-- Modify files outside `~/.jinn/` unless explicitly instructed by the user
+- Modify files outside `~/.ryoko/` unless explicitly instructed by the user
 
 ## Example: Creating a Cron Job at Runtime
 
 An engine can create a new cron job by reading `cron/jobs.json`, appending a new entry, and writing it back:
 
 ```
-1. Read ~/.jinn/cron/jobs.json
+1. Read ~/.ryoko/cron/jobs.json
 2. Parse the JSON array
 3. Append new job object with unique id, schedule, prompt, etc.
 4. Validate the full array
-5. Write back to ~/.jinn/cron/jobs.json
+5. Write back to ~/.ryoko/cron/jobs.json
 6. The file watcher automatically reschedules all jobs
 ```
 
 ## Example: Adding a New Employee
 
 ```
-1. Create ~/.jinn/org/<department>/<name>.yaml with required fields
+1. Create ~/.ryoko/org/<department>/<name>.yaml with required fields
 2. The file watcher detects the new file and rebuilds the employee registry
 3. The new employee is immediately available for @mention routing
 ```

--- a/packages/jimmy/template/docs/skills.md
+++ b/packages/jimmy/template/docs/skills.md
@@ -4,7 +4,7 @@ Skills are markdown instruction sets that engines read and follow. There is no r
 
 ## How Skills Work
 
-Each skill is a directory in `~/.jinn/skills/` containing at minimum a `SKILL.md` file. When an engine starts a session, it has access to the skills directory and can read any skill's instructions.
+Each skill is a directory in `~/.ryoko/skills/` containing at minimum a `SKILL.md` file. When an engine starts a session, it has access to the skills directory and can read any skill's instructions.
 
 The `SKILL.md` file contains:
 - **Trigger description**: When this skill should be activated
@@ -14,7 +14,7 @@ The `SKILL.md` file contains:
 ## Creating a Skill
 
 ```
-~/.jinn/skills/
+~/.ryoko/skills/
   my-skill/
     SKILL.md          # Required: instructions
     data.json         # Optional: supporting data
@@ -41,13 +41,16 @@ When the user says "deploy" or asks about deployment status.
 
 ## Pre-packaged Skills
 
-{{portalName}} ships with several default skills:
+{{portalName}} ships with these default skills (see `~/.ryoko/skills/`):
 
-- **self**: Instructions for {{portalName}} to understand and modify its own configuration
-- **slack**: Slack-specific behavior and formatting guidelines
-- **cron**: How to create and manage scheduled jobs
-- **org**: Working with the organization structure and employee personas
-- **skills**: Meta-skill for creating and managing other skills
+- **onboarding**: First-run setup — fills IDENTITY.md / SOUL.md / MEMORY.md interactively
+- **management**: Hiring, firing, promotions, delegation, and board reviews for the org
+- **cron-manager**: Create, edit, enable/disable, and troubleshoot cron jobs
+- **skill-creator**: Write a SKILL.md playbook to create a new skill
+- **find-and-install**: Discover skills via `npx skills find` and install them
+- **self-heal**: Diagnose and repair {{portalName}}'s own configuration and runtime
+- **migrate**: Apply pending version migrations
+- **sync** / **new** / **status**: Slash-command playbooks (`/sync`, `/new`, `/status`)
 
 ## Key Points
 

--- a/packages/jimmy/template/skills/cron-manager/SKILL.md
+++ b/packages/jimmy/template/skills/cron-manager/SKILL.md
@@ -11,7 +11,7 @@ This skill activates when the user wants to create, edit, delete, enable, disabl
 
 ## Data File
 
-All cron jobs are stored in `~/.jinn/cron/jobs.json` as a JSON array of job objects. If the file does not exist, create it with an empty array `[]`.
+All cron jobs are stored in `~/.ryoko/cron/jobs.json` as a JSON array of job objects. If the file does not exist, create it with an empty array `[]`.
 
 ## CronJob Schema
 
@@ -51,7 +51,7 @@ Field details:
 
 ### Creating a Job
 
-1. Read the current `~/.jinn/cron/jobs.json` (or initialize as `[]` if missing).
+1. Read the current `~/.ryoko/cron/jobs.json` (or initialize as `[]` if missing).
 2. Ask the user for the required fields: name, schedule, engine, model, and prompt.
 3. Ask about the timezone. Default to `UTC` if not specified.
 4. Ask about the employee persona to use. This is optional.
@@ -60,12 +60,12 @@ Field details:
 7. Generate a UUID for the `id` field.
 8. Set `enabled` to `true` by default.
 9. Append the new job object to the array.
-10. Write the updated array back to `~/.jinn/cron/jobs.json`.
+10. Write the updated array back to `~/.ryoko/cron/jobs.json`.
 11. Confirm the creation and summarize the schedule in plain English.
 
 ### Editing a Job
 
-1. Read `~/.jinn/cron/jobs.json`.
+1. Read `~/.ryoko/cron/jobs.json`.
 2. Find the job by name or id.
 3. Show the current values to the user.
 4. Apply the requested changes.
@@ -74,7 +74,7 @@ Field details:
 
 ### Deleting a Job
 
-1. Read `~/.jinn/cron/jobs.json`.
+1. Read `~/.ryoko/cron/jobs.json`.
 2. Find the job by name or id.
 3. Confirm deletion with the user (show job details).
 4. Remove the job from the array.
@@ -83,7 +83,7 @@ Field details:
 
 ### Enabling / Disabling a Job
 
-1. Read `~/.jinn/cron/jobs.json`.
+1. Read `~/.ryoko/cron/jobs.json`.
 2. Find the job by name or id.
 3. Set `enabled` to `true` (enable) or `false` (disable).
 4. Write the updated array back.
@@ -91,7 +91,7 @@ Field details:
 
 ### Listing Jobs
 
-1. Read `~/.jinn/cron/jobs.json`.
+1. Read `~/.ryoko/cron/jobs.json`.
 2. Display jobs in a readable format, grouped by enabled/disabled.
 3. Include name, schedule (with plain-English interpretation), timezone, engine, and delivery info.
 

--- a/packages/jimmy/template/skills/cron-manager/SKILL.md
+++ b/packages/jimmy/template/skills/cron-manager/SKILL.md
@@ -11,7 +11,7 @@ This skill activates when the user wants to create, edit, delete, enable, disabl
 
 ## Data File
 
-All cron jobs are stored in `~/.ryoko/cron/jobs.json` as a JSON array of job objects. If the file does not exist, create it with an empty array `[]`.
+All cron jobs are stored in `cron/jobs.json` (relative to the {{portalName}} home directory, which is always your working directory) as a JSON array of job objects. If the file does not exist, create it with an empty array `[]`.
 
 ## CronJob Schema
 
@@ -51,7 +51,7 @@ Field details:
 
 ### Creating a Job
 
-1. Read the current `~/.ryoko/cron/jobs.json` (or initialize as `[]` if missing).
+1. Read the current `cron/jobs.json` (or initialize as `[]` if missing).
 2. Ask the user for the required fields: name, schedule, engine, model, and prompt.
 3. Ask about the timezone. Default to `UTC` if not specified.
 4. Ask about the employee persona to use. This is optional.
@@ -60,12 +60,12 @@ Field details:
 7. Generate a UUID for the `id` field.
 8. Set `enabled` to `true` by default.
 9. Append the new job object to the array.
-10. Write the updated array back to `~/.ryoko/cron/jobs.json`.
+10. Write the updated array back to `cron/jobs.json`.
 11. Confirm the creation and summarize the schedule in plain English.
 
 ### Editing a Job
 
-1. Read `~/.ryoko/cron/jobs.json`.
+1. Read `cron/jobs.json`.
 2. Find the job by name or id.
 3. Show the current values to the user.
 4. Apply the requested changes.
@@ -74,7 +74,7 @@ Field details:
 
 ### Deleting a Job
 
-1. Read `~/.ryoko/cron/jobs.json`.
+1. Read `cron/jobs.json`.
 2. Find the job by name or id.
 3. Confirm deletion with the user (show job details).
 4. Remove the job from the array.
@@ -83,7 +83,7 @@ Field details:
 
 ### Enabling / Disabling a Job
 
-1. Read `~/.ryoko/cron/jobs.json`.
+1. Read `cron/jobs.json`.
 2. Find the job by name or id.
 3. Set `enabled` to `true` (enable) or `false` (disable).
 4. Write the updated array back.
@@ -91,7 +91,7 @@ Field details:
 
 ### Listing Jobs
 
-1. Read `~/.ryoko/cron/jobs.json`.
+1. Read `cron/jobs.json`.
 2. Display jobs in a readable format, grouped by enabled/disabled.
 3. Include name, schedule (with plain-English interpretation), timezone, engine, and delivery info.
 

--- a/packages/jimmy/template/skills/management/SKILL.md
+++ b/packages/jimmy/template/skills/management/SKILL.md
@@ -11,7 +11,7 @@ This skill activates when the user wants to manage their organization: hiring or
 
 ## Organization Structure
 
-The organization lives under the `org/` directory in the {{portalName}} home folder (`~/.ryoko/org/`). Each department is a subdirectory containing employee persona YAML files and a task board.
+The organization lives under `org/` in the {{portalName}} home directory — which is always your working directory, so relative paths in this skill resolve correctly on any instance. Each department is a subdirectory containing employee persona YAML files and a task board.
 
 ```
 org/

--- a/packages/jimmy/template/skills/management/SKILL.md
+++ b/packages/jimmy/template/skills/management/SKILL.md
@@ -11,7 +11,7 @@ This skill activates when the user wants to manage their organization: hiring or
 
 ## Organization Structure
 
-The organization lives under the `org/` directory in the {{portalName}} home folder (`~/.jinn/org/`). Each department is a subdirectory containing employee persona YAML files and a task board.
+The organization lives under the `org/` directory in the {{portalName}} home folder (`~/.ryoko/org/`). Each department is a subdirectory containing employee persona YAML files and a task board.
 
 ```
 org/

--- a/packages/jimmy/template/skills/self-heal/SKILL.md
+++ b/packages/jimmy/template/skills/self-heal/SKILL.md
@@ -15,7 +15,7 @@ Work through these checks in order. Stop and fix issues as you find them.
 
 ### 1. Check Gateway Logs
 
-Read `~/.jinn/logs/gateway.log` and look for:
+Read the newest log file under `~/.ryoko/logs/` and look for:
 - Error messages or stack traces
 - Repeated failures or crash loops
 - Connection refused or timeout errors
@@ -26,7 +26,7 @@ Summarize any problems found to the user.
 
 ### 2. Validate Configuration
 
-Read `~/.jinn/config.yaml` and verify:
+Read `~/.ryoko/config.yaml` and verify:
 - The file is valid YAML (no syntax errors)
 - The `port` field is a valid number (typically 3777)
 - Required fields are present: `port`, `engine`, `model`
@@ -44,13 +44,13 @@ If the engine command is not found, inform the user that the engine is not insta
 ### 4. Check Session Database
 
 Look at the session registry for stuck sessions:
-- Read `~/.jinn/sessions.db` or the session storage
+- Read `~/.ryoko/sessions/registry.db` (the SQLite session registry)
 - Look for sessions with status `running` that have not been updated recently (more than 30 minutes old)
 - These may be stuck and need to be reset
 
 ### 5. Check Disk and Temp Files
 
-- Check if `~/.jinn/tmp/` contains stale files that should be cleaned up
+- Check if `~/.ryoko/tmp/` contains stale files that should be cleaned up
 - Large or numerous temp files can cause issues
 
 ## Common Fixes
@@ -68,7 +68,7 @@ jinn stop && jinn start
 
 If temp files are stale or causing issues:
 
-Delete all contents of `~/.jinn/tmp/` but keep the directory itself.
+Delete all contents of `~/.ryoko/tmp/` but keep the directory itself.
 
 ### Fix Malformed JSON
 
@@ -104,7 +104,7 @@ If the gateway cannot bind to its configured port:
 
 ## Reference
 
-For understanding {{portalName}}'s architecture and component relationships, refer to the documentation in `~/.jinn/docs/` if available.
+For understanding {{portalName}}'s architecture and component relationships, refer to the documentation in `~/.ryoko/docs/` if available.
 
 ## Error Handling
 

--- a/packages/jimmy/template/skills/self-heal/SKILL.md
+++ b/packages/jimmy/template/skills/self-heal/SKILL.md
@@ -11,11 +11,11 @@ This skill activates when {{portalName}} is experiencing issues, errors, or unex
 
 ## Diagnostic Steps
 
-Work through these checks in order. Stop and fix issues as you find them.
+Work through these checks in order. Stop and fix issues as you find them. All relative paths below are relative to the {{portalName}} home directory, which is always your working directory.
 
 ### 1. Check Gateway Logs
 
-Read the newest log file under `~/.ryoko/logs/` and look for:
+Read the newest log file under `logs/` and look for:
 - Error messages or stack traces
 - Repeated failures or crash loops
 - Connection refused or timeout errors
@@ -26,7 +26,7 @@ Summarize any problems found to the user.
 
 ### 2. Validate Configuration
 
-Read `~/.ryoko/config.yaml` and verify:
+Read `config.yaml` and verify:
 - The file is valid YAML (no syntax errors)
 - The `port` field is a valid number (typically 3777)
 - Required fields are present: `port`, `engine`, `model`
@@ -44,13 +44,13 @@ If the engine command is not found, inform the user that the engine is not insta
 ### 4. Check Session Database
 
 Look at the session registry for stuck sessions:
-- Read `~/.ryoko/sessions/registry.db` (the SQLite session registry)
+- Read `sessions/registry.db` (the SQLite session registry)
 - Look for sessions with status `running` that have not been updated recently (more than 30 minutes old)
 - These may be stuck and need to be reset
 
 ### 5. Check Disk and Temp Files
 
-- Check if `~/.ryoko/tmp/` contains stale files that should be cleaned up
+- Check if `tmp/` contains stale files that should be cleaned up
 - Large or numerous temp files can cause issues
 
 ## Common Fixes
@@ -68,7 +68,7 @@ jinn stop && jinn start
 
 If temp files are stale or causing issues:
 
-Delete all contents of `~/.ryoko/tmp/` but keep the directory itself.
+Delete all contents of `tmp/` but keep the directory itself.
 
 ### Fix Malformed JSON
 
@@ -104,7 +104,7 @@ If the gateway cannot bind to its configured port:
 
 ## Reference
 
-For understanding {{portalName}}'s architecture and component relationships, refer to the documentation in `~/.ryoko/docs/` if available.
+For understanding {{portalName}}'s architecture and component relationships, refer to the documentation in `docs/` if available.
 
 ## Error Handling
 

--- a/packages/jimmy/template/skills/skill-creator/SKILL.md
+++ b/packages/jimmy/template/skills/skill-creator/SKILL.md
@@ -11,25 +11,25 @@ This skill activates when the user wants to create a new custom skill for {{port
 
 ## Output Location
 
-All skills are stored at `~/.ryoko/skills/<skill-name>/SKILL.md`. Each skill lives in its own directory named with kebab-case.
+All skills are stored at `skills/<skill-name>/SKILL.md`. Each skill lives in its own directory named with kebab-case.
 
 ## Behavior by Engine
 
 ### Claude Code (claude engine)
 
-Claude Code has native skill creation capabilities. Defer to the engine's built-in skill/memory system when available. The engine knows how to create well-structured instruction files. Simply ensure the output file lands at the correct path: `~/.ryoko/skills/<skill-name>/SKILL.md`.
+Claude Code has native skill creation capabilities. Defer to the engine's built-in skill/memory system when available. The engine knows how to create well-structured instruction files. Simply ensure the output file lands at the correct path: `skills/<skill-name>/SKILL.md`.
 
 ### Codex (codex engine)
 
-Create the SKILL.md file manually following the conventions below. Write the file directly to `~/.ryoko/skills/<skill-name>/SKILL.md`.
+Create the SKILL.md file manually following the conventions below. Write the file directly to `skills/<skill-name>/SKILL.md`.
 
 ## Steps
 
 1. Ask the user what the skill should do. Get a clear description of the capability.
 2. Ask for a name (kebab-case). Suggest one if the user does not provide it.
-3. Create the directory `~/.ryoko/skills/<skill-name>/` if it does not exist.
+3. Create the directory `skills/<skill-name>/` if it does not exist.
 4. Generate the SKILL.md content following the conventions below.
-5. Write the file to `~/.ryoko/skills/<skill-name>/SKILL.md`.
+5. Write the file to `skills/<skill-name>/SKILL.md`.
 6. Confirm the skill was created and summarize what it does.
 
 ## Conventions for Writing Good SKILL.md Files
@@ -47,12 +47,12 @@ Bad: "This skill does reporting stuff."
 
 Provide numbered steps that an AI engine can follow without ambiguity. Each step should be a concrete action, not a vague directive.
 
-Good: "1. Read the file at `~/.ryoko/data/repos.json`. 2. For each repository, fetch the latest commits from the past 7 days."
+Good: "1. Read the file at `data/repos.json`. 2. For each repository, fetch the latest commits from the past 7 days."
 Bad: "1. Get the data. 2. Process it."
 
 ### 3. Data File References
 
-Specify exact file paths for any data the skill reads or writes. Use `~/.ryoko/` as the base directory. Define the expected schema for any JSON or YAML files.
+Specify exact file paths for any data the skill reads or writes, relative to the {{portalName}} home directory (always the working directory). Define the expected schema for any JSON or YAML files.
 
 ### 4. Error Handling Guidance
 
@@ -84,7 +84,7 @@ This skill activates when <specific trigger description>.
 
 ## Data Files
 
-- `~/.ryoko/<path>` — <description of the file and its format>
+- `<path>` — <description of the file and its format>
 
 ## Steps
 
@@ -103,7 +103,7 @@ This skill activates when <specific trigger description>.
 
 ## Auto-Sync
 
-The gateway automatically creates symlinks in `~/.ryoko/.claude/skills/` and `~/.ryoko/.agents/skills/` pointing to each skill directory. This happens on startup and whenever the `skills/` directory changes. You do not need to manage symlinks manually.
+The gateway automatically creates symlinks in `.claude/skills/` and `.agents/skills/` pointing to each skill directory. This happens on startup and whenever the `skills/` directory changes. You do not need to manage symlinks manually.
 
 ## Error Handling
 

--- a/packages/jimmy/template/skills/skill-creator/SKILL.md
+++ b/packages/jimmy/template/skills/skill-creator/SKILL.md
@@ -11,25 +11,25 @@ This skill activates when the user wants to create a new custom skill for {{port
 
 ## Output Location
 
-All skills are stored at `~/.jinn/skills/<skill-name>/SKILL.md`. Each skill lives in its own directory named with kebab-case.
+All skills are stored at `~/.ryoko/skills/<skill-name>/SKILL.md`. Each skill lives in its own directory named with kebab-case.
 
 ## Behavior by Engine
 
 ### Claude Code (claude engine)
 
-Claude Code has native skill creation capabilities. Defer to the engine's built-in skill/memory system when available. The engine knows how to create well-structured instruction files. Simply ensure the output file lands at the correct path: `~/.jinn/skills/<skill-name>/SKILL.md`.
+Claude Code has native skill creation capabilities. Defer to the engine's built-in skill/memory system when available. The engine knows how to create well-structured instruction files. Simply ensure the output file lands at the correct path: `~/.ryoko/skills/<skill-name>/SKILL.md`.
 
 ### Codex (codex engine)
 
-Create the SKILL.md file manually following the conventions below. Write the file directly to `~/.jinn/skills/<skill-name>/SKILL.md`.
+Create the SKILL.md file manually following the conventions below. Write the file directly to `~/.ryoko/skills/<skill-name>/SKILL.md`.
 
 ## Steps
 
 1. Ask the user what the skill should do. Get a clear description of the capability.
 2. Ask for a name (kebab-case). Suggest one if the user does not provide it.
-3. Create the directory `~/.jinn/skills/<skill-name>/` if it does not exist.
+3. Create the directory `~/.ryoko/skills/<skill-name>/` if it does not exist.
 4. Generate the SKILL.md content following the conventions below.
-5. Write the file to `~/.jinn/skills/<skill-name>/SKILL.md`.
+5. Write the file to `~/.ryoko/skills/<skill-name>/SKILL.md`.
 6. Confirm the skill was created and summarize what it does.
 
 ## Conventions for Writing Good SKILL.md Files
@@ -47,12 +47,12 @@ Bad: "This skill does reporting stuff."
 
 Provide numbered steps that an AI engine can follow without ambiguity. Each step should be a concrete action, not a vague directive.
 
-Good: "1. Read the file at `~/.jinn/data/repos.json`. 2. For each repository, fetch the latest commits from the past 7 days."
+Good: "1. Read the file at `~/.ryoko/data/repos.json`. 2. For each repository, fetch the latest commits from the past 7 days."
 Bad: "1. Get the data. 2. Process it."
 
 ### 3. Data File References
 
-Specify exact file paths for any data the skill reads or writes. Use `~/.jinn/` as the base directory. Define the expected schema for any JSON or YAML files.
+Specify exact file paths for any data the skill reads or writes. Use `~/.ryoko/` as the base directory. Define the expected schema for any JSON or YAML files.
 
 ### 4. Error Handling Guidance
 
@@ -84,7 +84,7 @@ This skill activates when <specific trigger description>.
 
 ## Data Files
 
-- `~/.jinn/<path>` — <description of the file and its format>
+- `~/.ryoko/<path>` — <description of the file and its format>
 
 ## Steps
 
@@ -103,7 +103,7 @@ This skill activates when <specific trigger description>.
 
 ## Auto-Sync
 
-The gateway automatically creates symlinks in `~/.jinn/.claude/skills/` and `~/.jinn/.agents/skills/` pointing to each skill directory. This happens on startup and whenever the `skills/` directory changes. You do not need to manage symlinks manually.
+The gateway automatically creates symlinks in `~/.ryoko/.claude/skills/` and `~/.ryoko/.agents/skills/` pointing to each skill directory. This happens on startup and whenever the `skills/` directory changes. You do not need to manage symlinks manually.
 
 ## Error Handling
 


### PR DESCRIPTION
## 概要

Playbook 計画トラック A ④。新規ユーザーがエージェント経由で参照する同梱ドキュメントの陳腐化と、Web UI オンボーディングの名前置換が日本語テンプレートに効かない問題を修正。

## 修正内容

### template/docs（8ファイル）
- `jinn-cli` → `openryoko`、`~/.jinn` → `~/.ryoko`、`jinn.db` → `sessions/registry.db` の旧表記を一掃
- skills.md: 実在しない5スキル（self / slack / cron / org / skills）の列挙を、実際に同梱される10スキル（onboarding / management / cron-manager / skill-creator / find-and-install / self-heal / migrate / sync / new / status）に差し替え
- org.md: 「デフォルトで executive 従業員1名を同梱」という虚偽記述を「org/ は空で開始し onboarding がスキャフォールドを提案する」実態に修正

### Web オンボーディング（POST /api/onboarding）
名前置換の正規表現が英語版 upstream（`You are X, the COO ...`）専用で、日本語テンプレート（`あなたは **X** —` / `# X — 運用指示書`）には一切マッチしなかった。UI から名前を変えても CLAUDE.md / AGENTS.md が追従しない状態を修正。

- 置換ロジックを `gateway/onboarding-personalize.ts` に分離（日英両形式対応）
- IDENTITY.md の `## Name` セクションも同期するようにした

## テスト

- [x] 新規テスト5本（実テンプレートを読み込んで置換を検証）
- [x] 全テスト 787/787 passed
- [x] `npm run build` クリーン

## 関連

#51（トラック A ①〜③）と独立。両方 merge 後に openryoko-release フローでリリース予定。