### PR TITLE
feat(workflows): 上流JinnのWorkflow基盤を移植（PR#1: backend core）

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -40,7 +40,8 @@
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",
     "uuid": "^11.1.1",
-    "ws": "^8.21.3"
+    "ws": "^8.21.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/packages/jimmy/src/cron/validation.ts
+++ b/packages/jimmy/src/cron/validation.ts
@@ -1,0 +1,41 @@
+import cron from 'node-cron';
+
+export type CronScheduleField = 'schedule' | 'timezone' | 'until';
+
+export interface CronScheduleValidationError {
+  field: CronScheduleField;
+  message: string;
+}
+
+export interface CronScheduleInput {
+  schedule: unknown;
+  timezone?: unknown;
+  until?: unknown;
+}
+
+/** Validate with the same cron parser used by the scheduler plus the platform's
+ * IANA timezone implementation. This is safe to call before any persistence. */
+export function validateCronSchedule(input: CronScheduleInput): CronScheduleValidationError[] {
+  const errors: CronScheduleValidationError[] = [];
+  if (typeof input.schedule !== 'string' || !input.schedule.trim() || !cron.validate(input.schedule.trim())) {
+    errors.push({ field: 'schedule', message: 'schedule must be a valid cron expression' });
+  }
+  if (input.timezone !== undefined) {
+    if (typeof input.timezone !== 'string' || !input.timezone.trim()) {
+      errors.push({ field: 'timezone', message: 'timezone must be a non-empty IANA timezone' });
+    } else {
+      try {
+        new Intl.DateTimeFormat('en-US', { timeZone: input.timezone.trim() }).format(0);
+      } catch {
+        errors.push({ field: 'timezone', message: `timezone "${input.timezone}" is not a valid IANA timezone` });
+      }
+    }
+  }
+  if (input.until !== undefined) {
+    const timestamp = typeof input.until === 'string' && input.until.trim() ? Date.parse(input.until) : Number.NaN;
+    if (!Number.isFinite(timestamp)) {
+      errors.push({ field: 'until', message: 'until must be a finite ISO-8601 timestamp' });
+    }
+  }
+  return errors;
+}

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -80,6 +80,9 @@ import {
   shouldRequireGatewayAuth,
   verifyGatewayAuth,
 } from "./auth.js";
+import { handleWorkflowApi } from "./workflow-api.js";
+import type { WorkflowService } from "../workflows/service.js";
+import { shouldRequireGatewayAuth as workflowAuthRequired, verifyGatewayAuth as workflowVerifyAuth } from "./auth.js";
 import { getDiskSpaceStatus } from "../shared/storage-health.js";
 import { ptySnapshotStore } from "../engines/pty-snapshot.js";
 import { collectClaudeUsage } from "../shared/claude-usage.js";
@@ -132,6 +135,8 @@ export interface ApiContext {
   hookSecret?: string;
   authToken?: string;
   authHome?: string;
+  /** Present only when config.workflows.enabled — carries the Workflow engine. */
+  workflowService?: WorkflowService;
 }
 
 export function resumePendingWebQueueItems(context: ApiContext): void {
@@ -476,6 +481,16 @@ export async function handleApiRequest(
   const method = req.method || "GET";
 
   try {
+    // /api/workflows/** — the Workflow engine (upstream port). Routed before the
+    // flat routes below; handleWorkflowApi returns false for everything else.
+    if (context.workflowService && pathname.startsWith("/api/workflows")) {
+      const authenticated = !workflowAuthRequired(context.getConfig())
+        || Boolean(context.authToken && context.authHome
+          && workflowVerifyAuth(req.headers, context.authToken, context.authHome));
+      if (await handleWorkflowApi(req, res, { method, pathname, url },
+        { service: context.workflowService, authenticated })) return;
+    }
+
     // POST /api/internal/hook — receive Claude Code turn hooks from hook-relay.mjs
     // (interactive PTY engine). Loopback-only + shared-secret authenticated.
     if (method === "POST" && pathname === "/api/internal/hook") {

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -1703,6 +1703,7 @@ Handle this as a priority request from a colleague.`;
         "mcp",
         "sessions",
         "cron",
+        "workflows",
         "notifications",
         "portal",
         "context",

--- a/packages/jimmy/src/gateway/compress.ts
+++ b/packages/jimmy/src/gateway/compress.ts
@@ -1,0 +1,45 @@
+import zlib from "node:zlib";
+import type { Transform } from "node:stream";
+
+export type Encoding = "br" | "gzip";
+
+/** Responses smaller than this aren't worth the compression overhead. */
+export const MIN_COMPRESS_BYTES = 1024;
+
+const COMPRESSIBLE_EXT = new Set([
+  ".js",
+  ".css",
+  ".html",
+  ".json",
+  ".svg",
+  ".map",
+  ".txt",
+  ".webmanifest",
+]);
+
+/** Pick the best encoding the client accepts, preferring brotli. */
+export function pickEncoding(acceptEncoding: string | undefined): Encoding | null {
+  if (!acceptEncoding) return null;
+  const ae = acceptEncoding.toLowerCase();
+  if (ae.includes("br")) return "br";
+  if (ae.includes("gzip")) return "gzip";
+  return null;
+}
+
+export function isCompressibleExt(ext: string): boolean {
+  return COMPRESSIBLE_EXT.has(ext.toLowerCase());
+}
+
+// Quality tuned for on-the-fly compression: meaningful ratio without burning CPU.
+const BROTLI_OPTS = { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 5 } };
+const GZIP_OPTS = { level: 6 };
+
+/** Streaming compressor for piping files. */
+export function compressStream(enc: Encoding): Transform {
+  return enc === "br" ? zlib.createBrotliCompress(BROTLI_OPTS) : zlib.createGzip(GZIP_OPTS);
+}
+
+/** One-shot compressor for in-memory bodies (e.g. JSON). */
+export function compressBuffer(enc: Encoding, buf: Buffer): Buffer {
+  return enc === "br" ? zlib.brotliCompressSync(buf, BROTLI_OPTS) : zlib.gzipSync(buf, GZIP_OPTS);
+}

--- a/packages/jimmy/src/gateway/http-helpers.ts
+++ b/packages/jimmy/src/gateway/http-helpers.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared HTTP request-body helpers used by gateway/api.ts and the per-domain
+ * router modules. Error responses written here are tiny
+ * (well under the compression threshold), so plain uncompressed JSON writes
+ * are behaviour-identical to route-helpers.ts's compressing json() helper.
+ */
+import type { IncomingMessage as HttpRequest, ServerResponse } from "node:http";
+
+/** Signals that a request body exceeded the per-handler size cap. */
+export class BodyTooLargeError extends Error {
+  constructor() {
+    super("Request body exceeds maximum allowed size");
+    this.name = "BodyTooLargeError";
+  }
+}
+
+export interface ReadBodyOpts {
+  /** Hard cap on bytes accepted from the stream; rejects with BodyTooLargeError when exceeded. */
+  maxBytes?: number;
+}
+
+export interface ReadJsonBodyOpts extends ReadBodyOpts {
+  /** Treat an empty/whitespace-only body as `{ ok: true, body: null }` instead of a 400. */
+  allowEmpty?: boolean;
+  /** Route-specific fixed body for JSON syntax/duplicate-key rejection. */
+  invalidJsonResponse?: unknown;
+  invalidJsonStatus?: number;
+  /** Reject ambiguous duplicate top-level object members. */
+  rejectDuplicateTopLevelKeys?: boolean;
+  /** Route-specific fixed body for an exceeded maxBytes limit. */
+  tooLargeResponse?: unknown;
+}
+
+function hasDuplicateTopLevelObjectKeys(raw: string): boolean {
+  const seen = new Set<string>();
+  let depth = 0;
+  let stringStart = -1;
+  let expectingTopLevelKey = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i];
+    if (stringStart >= 0) {
+      if (char === "\\") {
+        i++;
+        continue;
+      }
+      if (char !== '"') continue;
+      if (depth === 1 && expectingTopLevelKey) {
+        const key = JSON.parse(raw.slice(stringStart, i + 1)) as string;
+        if (seen.has(key)) return true;
+        seen.add(key);
+        expectingTopLevelKey = false;
+      }
+      stringStart = -1;
+      continue;
+    }
+    if (char === '"') {
+      stringStart = i;
+    } else if (char === "{" || char === "[") {
+      depth++;
+      if (depth === 1 && char === "{") expectingTopLevelKey = true;
+    } else if (char === "}" || char === "]") {
+      depth--;
+    } else if (char === "," && depth === 1) {
+      expectingTopLevelKey = true;
+    }
+  }
+  return false;
+}
+
+export function readBody(req: HttpRequest, opts: ReadBodyOpts = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    const max = opts.maxBytes;
+    const onData = (chunk: Buffer) => {
+      total += chunk.length;
+      if (max !== undefined && total > max) {
+        // Over the cap: reject WITHOUT touching the socket. Destroying here tore
+        // down the connection before the caller's 413 could reach the wire, so
+        // real HTTP clients saw a bare "fetch failed" instead of the structured
+        // error (Codex GRS-015 finding 2). Instead, stop BUFFERING but keep
+        // DISCARDING inbound chunks so the exchange completes and the response is
+        // deliverable; a hard ceiling (8× the cap) still cuts off a sender that
+        // never stops (local-machine threat model — compatibility first, with a
+        // bounded worst case).
+        req.off("data", onData);
+        chunks.length = 0;
+        req.on("data", (later: Buffer) => {
+          total += later.length;
+          if (total > max * 8) req.destroy();
+        });
+        reject(new BodyTooLargeError());
+        return;
+      }
+      chunks.push(chunk);
+    };
+    req.on("data", onData);
+    req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    req.on("error", reject);
+  });
+}
+
+export function readBodyRaw(req: HttpRequest): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function errorJson(res: ServerResponse, data: unknown, status: number): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+export async function readJsonBody(
+  req: HttpRequest,
+  res: ServerResponse,
+  opts: ReadJsonBodyOpts = {},
+): Promise<{ ok: true; body: unknown } | { ok: false }> {
+  let raw: string;
+  try {
+    raw = await readBody(req, opts);
+  } catch (err) {
+    if (err instanceof BodyTooLargeError) {
+      // The 413 is written while the client may still be uploading (readBody now
+      // drains instead of destroying — the response must actually reach the wire).
+      // Connection: close tells the client not to reuse the exchange.
+      res.writeHead(413, { "Content-Type": "application/json", Connection: "close" });
+      res.end(JSON.stringify(opts.tooLargeResponse ?? { error: "Payload too large" }));
+      return { ok: false };
+    }
+    throw err;
+  }
+  if (opts.allowEmpty && !raw.trim()) return { ok: true, body: null };
+  try {
+    const body: unknown = JSON.parse(raw);
+    if (opts.rejectDuplicateTopLevelKeys && hasDuplicateTopLevelObjectKeys(raw)) {
+      errorJson(res, opts.invalidJsonResponse ?? { error: "Invalid JSON in request body" }, opts.invalidJsonStatus ?? 400);
+      return { ok: false };
+    }
+    return { ok: true, body };
+  } catch {
+    errorJson(res, opts.invalidJsonResponse ?? { error: "Invalid JSON in request body" }, opts.invalidJsonStatus ?? 400);
+    return { ok: false };
+  }
+}

--- a/packages/jimmy/src/gateway/media-type.ts
+++ b/packages/jimmy/src/gateway/media-type.ts
@@ -1,0 +1,87 @@
+/** Conservative bound for request Content-Type parsing. Node applies its own
+ * header limit on the wire; this also keeps direct handler callers bounded. */
+const MEDIA_TYPE_MAX_CHARS = 1024;
+
+function isTokenChar(char: string | undefined): boolean {
+  return char !== undefined && /^[A-Za-z0-9!#$%&'*+.^_`|~-]$/.test(char);
+}
+
+function skipSpaces(value: string, start: number): number {
+  let index = start;
+  while (value[index] === " ") index++;
+  return index;
+}
+
+function readToken(value: string, start: number): { token: string; next: number } | undefined {
+  let next = start;
+  while (isTokenChar(value[next])) next++;
+  if (next === start) return undefined;
+  return { token: value.slice(start, next), next };
+}
+
+/** Strict Content-Type predicate for JSON request bodies.
+ *
+ * Accepts application/json and application/*+json with RFC token or non-empty
+ * quoted-string parameters. Parameter names are case-insensitively unique.
+ * Controls, malformed quoting, empty values, and comma-joined media types are
+ * rejected instead of guessed at. */
+export function isJsonMediaType(value: string | string[] | undefined): boolean {
+  if (typeof value !== "string" || value.length === 0 || value.length > MEDIA_TYPE_MAX_CHARS) return false;
+  if (/[\u0000-\u001f\u007f]/.test(value)) return false;
+
+  let index = skipSpaces(value, 0);
+  const type = readToken(value, index);
+  if (!type || type.token.toLowerCase() !== "application" || value[type.next] !== "/") return false;
+  index = type.next + 1;
+
+  const subtype = readToken(value, index);
+  if (!subtype) return false;
+  const normalizedSubtype = subtype.token.toLowerCase();
+  if (normalizedSubtype !== "json" && !(normalizedSubtype.length > 5 && !normalizedSubtype.startsWith("+") && normalizedSubtype.endsWith("+json"))) {
+    return false;
+  }
+  index = skipSpaces(value, subtype.next);
+
+  const parameterNames = new Set<string>();
+  while (index < value.length) {
+    if (value[index] !== ";") return false;
+    index = skipSpaces(value, index + 1);
+
+    const name = readToken(value, index);
+    if (!name) return false;
+    const normalizedName = name.token.toLowerCase();
+    if (parameterNames.has(normalizedName)) return false;
+    parameterNames.add(normalizedName);
+
+    index = skipSpaces(value, name.next);
+    if (value[index] !== "=") return false;
+    index = skipSpaces(value, index + 1);
+
+    if (value[index] === '"') {
+      index++;
+      let decodedChars = 0;
+      let closed = false;
+      while (index < value.length) {
+        const char = value[index];
+        if (char === '"') {
+          index++;
+          closed = true;
+          break;
+        }
+        if (char === "\\") {
+          index++;
+          if (index >= value.length) return false;
+        }
+        decodedChars++;
+        index++;
+      }
+      if (!closed || decodedChars === 0) return false;
+    } else {
+      const parameterValue = readToken(value, index);
+      if (!parameterValue) return false;
+      index = parameterValue.next;
+    }
+    index = skipSpaces(value, index);
+  }
+  return true;
+}

--- a/packages/jimmy/src/gateway/route-helpers.ts
+++ b/packages/jimmy/src/gateway/route-helpers.ts
@@ -1,0 +1,113 @@
+import type { ServerResponse } from "node:http";
+import { pickEncoding, compressBuffer, MIN_COMPRESS_BYTES } from "./compress.js";
+
+/**
+ * Response and route-matching helpers shared by api.ts and the per-domain
+ * router modules (`<domain>-api.ts`, plus `files.ts`, which predates the naming).
+ *
+ * They live below api.ts rather than in it because a domain module importing
+ * `json` from api.ts would be a real runtime import cycle — api.ts imports the
+ * domain module to dispatch to it.
+ *
+ * The contract every domain module follows:
+ *
+ *  1. One exported `handle<Domain>Api(req, res, route, context): Promise<boolean>`.
+ *     `true` means the request was consumed; `false` falls through to api.ts.
+ *  2. It receives the already-parsed `ParsedRoute` and never re-parses `req.url`
+ *     — one parse means one set of rejection rules for hostile targets.
+ *  3. Sends go through `json`/`notFound`/`badRequest`/`serverError` from here. A
+ *     module that rolls its own `send` drops the gzip/br negotiation; one whose
+ *     envelope is its own may adapt `json`, never write past it.
+ *  4. Unexpected errors throw to api.ts's outer try/catch. A module keeps a
+ *     boundary of its own only if it logs the cause and answers in a shape its
+ *     clients already depend on — workflow-api's `{ code, message }` is the one.
+ *     Catches for an *expected* failure (a corrupt file on disk) stay put.
+ *  5. Operator-only authority stays in `operatorOnlyControlPlaneRoute` wherever a
+ *     route reaches it. Workflow, talk and heartbeat dispatch ahead of that table;
+ *     files dispatches after it but the table lists no `/api/files` route. So all
+ *     four gate themselves, and each one is a place a guard can go missing.
+ *  6. The delegation call sits exactly where the route block used to sit in the
+ *     dispatch chain, in the same order.
+ */
+
+/** The request line api.ts has already parsed, handed down to a domain module. */
+export interface ParsedRoute {
+  method: string;
+  pathname: string;
+  url: URL;
+}
+
+/** Per-request Accept-Encoding, stashed by handleApiRequest so json() can compress. */
+export type ResWithEncoding = ServerResponse & { __acceptEncoding?: string };
+
+export function json(res: ServerResponse, data: unknown, status = 200): void {
+  const body = Buffer.from(JSON.stringify(data));
+  const enc =
+    body.length >= MIN_COMPRESS_BYTES
+      ? pickEncoding((res as ResWithEncoding).__acceptEncoding)
+      : null;
+  if (enc) {
+    res.writeHead(status, {
+      "Content-Type": "application/json",
+      "Content-Encoding": enc,
+      Vary: "Accept-Encoding",
+    });
+    res.end(compressBuffer(enc, body));
+    return;
+  }
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(body);
+}
+
+export function notFound(res: ServerResponse): void {
+  json(res, { error: "Not found" }, 404);
+}
+
+export function badRequest(res: ServerResponse, message: string): void {
+  json(res, { error: message }, 400);
+}
+
+export function serverError(res: ServerResponse, message: string): void {
+  json(res, { error: message }, 500);
+}
+
+/**
+ * One `:param` segment decoded, or null when it must not be treated as a value:
+ * an encoded separator, undecodable input, a traversal segment, or an embedded
+ * separator or NUL. Rejecting here is what keeps a param from ever naming a
+ * path outside the directory a handler joins it into.
+ */
+function decodeRouteParam(raw: string): string | null {
+  if (/%2f|%5c/i.test(raw)) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+  if (!decoded || decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\") || decoded.includes("\0")) {
+    return null;
+  }
+  return decoded;
+}
+
+export function matchRoute(
+  pattern: string,
+  pathname: string,
+): Record<string, string> | null {
+  const patternParts = pattern.split("/");
+  const pathParts = pathname.split("/");
+  if (patternParts.length !== pathParts.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i++) {
+    if (patternParts[i].startsWith(":")) {
+      const decoded = decodeRouteParam(pathParts[i]);
+      if (decoded === null) return null;
+      params[patternParts[i].slice(1)] = decoded;
+    } else if (patternParts[i] !== pathParts[i]) {
+      return null;
+    }
+  }
+  return params;
+}

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -25,6 +25,12 @@ import { writeGatewayInfo } from "./gateway-info.js";
 import { cleanupSessionSettings, seedTrust } from "../shared/claude-settings.js";
 import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, CLAUDE_SETTINGS_DIR, JINN_HOME } from "../shared/paths.js";
 import { handleApiRequest, resumePendingWebQueueItems, type ApiContext } from "./api.js";
+import { openWorkflowDatabase } from "../workflows/repository-migrations.js";
+import { WorkflowRepository } from "../workflows/repository.js";
+import { WorkflowService } from "../workflows/service.js";
+import { WorkflowSessionExecutor } from "../workflows/session-executor.js";
+import { getMessages } from "../sessions/registry.js";
+import { getModelRegistry } from "../shared/models.js";
 import { ensureFilesDir } from "./files.js";
 import { ensureOwnerOnlyDirectory } from "../shared/owner-only.js";
 import {
@@ -906,6 +912,32 @@ export async function startGateway(
   // status:"running" with no live turn (see status-reconciler.ts).
   const stopStatusReconciler = startStatusReconciler({ engines, emit });
 
+  // --- Workflow engine (upstream port). Opt-in via config.workflows.enabled;
+  // absent flag = no workflow DB, no trigger arming, no /api/workflows routes.
+  let workflowService: WorkflowService | undefined;
+  if (currentConfig.workflows?.enabled) {
+    const workflowRepository = new WorkflowRepository(openWorkflowDatabase());
+    workflowService = new WorkflowService({
+      repository: workflowRepository,
+      executor: new WorkflowSessionExecutor(sessionManager, (id) => {
+        const session = getSession(id);
+        if (!session) return null;
+        const finalText = [...getMessages(id)].reverse().find((message) => message.role === "assistant")?.content;
+        return { session, ...(finalText ? { finalText } : {}) };
+      }),
+      employees: () => employeeRegistry,
+      models: () => getModelRegistry(currentConfig),
+      engineFallback: { chainFor: (engine) => (currentConfig.engines as unknown as Record<string, { fallback?: string[] } | undefined>)[engine]?.fallback ?? [] },
+      sessionSpend: (sessionIds) => sessionIds.reduce((sum, id) => sum + (getSession(id)?.totalCost ?? 0), 0),
+      readTranscript: (id) => getMessages(id).map(({ id: messageId, role, content, timestamp }) => ({ id: messageId, role, content, timestamp })),
+      onChange: ({ workflowId, runId }) => emit("workflow:changed", { entity: "workflow-run", workflowId, runId }),
+      onDefinitionChange: ({ workflowId, revision }) => emit("workflow:changed", { entity: "workflow-definition", id: workflowId, revision }),
+    });
+    sessionManager.setEmployeeProvider((id) => employeeRegistry.get(id));
+    sessionManager.redispatchPendingWorkflowAttempts();
+    logger.info("Workflow engine enabled (config.workflows.enabled)");
+  }
+
   // API context
   const apiContext: ApiContext = {
     config: currentConfig,
@@ -922,6 +954,7 @@ export async function startGateway(
     hookSecret: useInteractiveClaude ? hookSecret : undefined,
     authToken,
     authHome: JINN_HOME,
+    workflowService,
   };
 
   // NOTE: replaying pending web queue items is deferred until AFTER the server is
@@ -1303,6 +1336,9 @@ export async function startGateway(
       claudeEngine.killAll();
     }
     codexEngine.killAll();
+
+    // Stop workflow triggers/runner before cron
+    try { workflowService?.dispose(); } catch { /* best effort */ }
 
     // Stop cron scheduler
     stopScheduler();

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -922,28 +922,11 @@ export async function startGateway(
 
   // --- Workflow engine (upstream port). Opt-in via config.workflows.enabled;
   // absent flag = no workflow DB, no trigger arming, no /api/workflows routes.
+  // Constructed AFTER the server is listening (see below): the WorkflowService
+  // constructor arms schedule triggers and a wake timer that can run recovery
+  // immediately, and a recovered attempt may spawn an interactive PTY turn
+  // whose Stop hook needs the gateway listening and gateway.json written.
   let workflowService: WorkflowService | undefined;
-  if (currentConfig.workflows?.enabled) {
-    const workflowRepository = new WorkflowRepository(openWorkflowDatabase());
-    workflowService = new WorkflowService({
-      repository: workflowRepository,
-      executor: new WorkflowSessionExecutor(sessionManager, (id) => {
-        const session = getSession(id);
-        if (!session) return null;
-        const finalText = [...getMessages(id)].reverse().find((message) => message.role === "assistant")?.content;
-        return { session, ...(finalText ? { finalText } : {}) };
-      }),
-      employees: () => employeeRegistry,
-      models: () => getModelRegistry(currentConfig),
-      engineFallback: { chainFor: (engine) => (currentConfig.engines as unknown as Record<string, { fallback?: string[] } | undefined>)[engine]?.fallback ?? [] },
-      sessionSpend: (sessionIds) => sessionIds.reduce((sum, id) => sum + (getSession(id)?.totalCost ?? 0), 0),
-      readTranscript: (id) => getMessages(id).map(({ id: messageId, role, content, timestamp }) => ({ id: messageId, role, content, timestamp })),
-      onChange: ({ workflowId, runId }) => emit("workflow:changed", { entity: "workflow-run", workflowId, runId }),
-      onDefinitionChange: ({ workflowId, revision }) => emit("workflow:changed", { entity: "workflow-definition", id: workflowId, revision }),
-    });
-    sessionManager.setEmployeeProvider((id) => employeeRegistry.get(id));
-    logger.info("Workflow engine enabled (config.workflows.enabled)");
-  }
 
   // API context
   const apiContext: ApiContext = {
@@ -961,7 +944,6 @@ export async function startGateway(
     hookSecret: useInteractiveClaude ? hookSecret : undefined,
     authToken,
     authHome: JINN_HOME,
-    workflowService,
   };
 
 
@@ -1291,12 +1273,33 @@ export async function startGateway(
   // recovery turn spawns — so hook-relay.mjs can deliver its Stop hook.
   resumePendingWebQueueItems(apiContext);
 
-  // Workflow redispatch/recovery can spawn engine turns — including interactive
-  // PTY turns whose Stop hook needs the gateway to be listening and
-  // gateway.json to exist (same reason resumePendingWebQueueItems above is
-  // deferred). Employee provider is already wired; recover() must see the
+  // Workflow engine start, deferred to gateway readiness: constructing the
+  // service arms schedule triggers and its wake timer, and both recovery paths
+  // below can spawn engine turns — including interactive PTY turns whose Stop
+  // hook needs the gateway listening and gateway.json written (same reason
+  // resumePendingWebQueueItems above is deferred). The employee provider must
+  // be wired before the first dispatch, and recover() must see the
   // redispatched sessions, so the order inside this block matters.
-  if (workflowService) {
+  if (currentConfig.workflows?.enabled) {
+    sessionManager.setEmployeeProvider((id) => employeeRegistry.get(id));
+    workflowService = new WorkflowService({
+      repository: new WorkflowRepository(openWorkflowDatabase()),
+      executor: new WorkflowSessionExecutor(sessionManager, (id) => {
+        const session = getSession(id);
+        if (!session) return null;
+        const finalText = [...getMessages(id)].reverse().find((message) => message.role === "assistant")?.content;
+        return { session, ...(finalText ? { finalText } : {}) };
+      }),
+      employees: () => employeeRegistry,
+      models: () => getModelRegistry(currentConfig),
+      engineFallback: { chainFor: (engine) => (currentConfig.engines as unknown as Record<string, { fallback?: string[] } | undefined>)[engine]?.fallback ?? [] },
+      sessionSpend: (sessionIds) => sessionIds.reduce((sum, id) => sum + (getSession(id)?.totalCost ?? 0), 0),
+      readTranscript: (id) => getMessages(id).map(({ id: messageId, role, content, timestamp }) => ({ id: messageId, role, content, timestamp })),
+      onChange: ({ workflowId, runId }) => emit("workflow:changed", { entity: "workflow-run", workflowId, runId }),
+      onDefinitionChange: ({ workflowId, revision }) => emit("workflow:changed", { entity: "workflow-definition", id: workflowId, revision }),
+    });
+    apiContext.workflowService = workflowService;
+    logger.info("Workflow engine enabled (config.workflows.enabled)");
     sessionManager.redispatchPendingWorkflowAttempts();
     try {
       await workflowService.recover(new Date().toISOString());

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -10,7 +10,7 @@ import type { JinnConfig, Connector, Employee } from "../shared/types.js";
 import { loadConfig } from "../shared/config.js";
 import { invalidateModelRegistry } from "../shared/models.js";
 import { configureLogger, logger } from "../shared/logger.js";
-import { initDb, scheduleFtsBackfill, recoverStaleSessions, recoverStaleQueueItems, getInterruptedSessions, listSessions, updateSession, getSession } from "../sessions/registry.js";
+import { initDb, scheduleFtsBackfill, recoverStaleSessions, recoverStaleWorkflowAttemptSessions, recoverStaleQueueItems, getInterruptedSessions, interruptSessionAttempt, listSessions, updateSession, getSession } from "../sessions/registry.js";
 import { SessionManager, type RouteOptions } from "../sessions/manager.js";
 import { ClaudeEngine } from "../engines/claude.js";
 import { CodexEngine } from "../engines/codex.js";
@@ -198,6 +198,14 @@ export async function startGateway(
   const recovered = recoverStaleSessions();
   if (recovered > 0) {
     logger.info(`Recovered ${recovered} stale session(s) — marked as "interrupted" for resume`);
+  }
+  // Workflow attempt sessions get their own sweep: it stamps the durable
+  // `gateway-restart` receipt the runtime needs to REPLACE the attempt instead
+  // of spending its retry budget. recoverStaleSessions() above deliberately
+  // skips workflow_kind rows so this sweep still finds them running.
+  const recoveredWorkflowAttempts = recoverStaleWorkflowAttemptSessions();
+  if (recoveredWorkflowAttempts > 0) {
+    logger.info(`Recovered ${recoveredWorkflowAttempts} stale workflow attempt(s) — stamped gateway-restart receipts`);
   }
 
   // Log resumable sessions so operators know what can be picked up
@@ -934,7 +942,6 @@ export async function startGateway(
       onDefinitionChange: ({ workflowId, revision }) => emit("workflow:changed", { entity: "workflow-definition", id: workflowId, revision }),
     });
     sessionManager.setEmployeeProvider((id) => employeeRegistry.get(id));
-    sessionManager.redispatchPendingWorkflowAttempts();
     logger.info("Workflow engine enabled (config.workflows.enabled)");
   }
 
@@ -956,6 +963,19 @@ export async function startGateway(
     authHome: JINN_HOME,
     workflowService,
   };
+
+  if (workflowService) {
+    // Replay internal dispatches a restart left pending, then let the runtime
+    // recover its own runs (dispatching attempts, receipts whose completion
+    // event was lost, due waits). Order matters: the employee provider is
+    // already wired above, and recover() must see the redispatched sessions.
+    sessionManager.redispatchPendingWorkflowAttempts();
+    try {
+      await workflowService.recover(new Date().toISOString());
+    } catch (error) {
+      logger.error(`Workflow recovery failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
 
   // NOTE: replaying pending web queue items is deferred until AFTER the server is
   // listening and gateway.json (port + hook secret) has been written — otherwise an
@@ -1148,9 +1168,22 @@ export async function startGateway(
     onConfigReload: () => {
       try {
         const previous = currentConfig;
+        const previousWorkflowsEnabled = Boolean(currentConfig.workflows?.enabled);
         currentConfig = loadConfig();
         invalidateModelRegistry(); // rebuild the model/capability registry from the reloaded config
         apiContext.config = currentConfig;
+        // Workflow engine is boot-time wiring. Disable takes effect immediately
+        // (dispose stops schedule triggers and the runner; routes disappear with
+        // the context entry); enable requires a restart.
+        const workflowsEnabled = Boolean(currentConfig.workflows?.enabled);
+        if (previousWorkflowsEnabled && !workflowsEnabled && workflowService) {
+          try { workflowService.dispose(); } catch { /* best effort */ }
+          workflowService = undefined;
+          apiContext.workflowService = undefined;
+          logger.info("Workflow engine disabled via config reload");
+        } else if (!previousWorkflowsEnabled && workflowsEnabled && !workflowService) {
+          logger.warn("config.workflows.enabled was turned on — restart the gateway to start the Workflow engine");
+        }
         // Propagate the fresh config into SessionManager so new sessions
         // pick up edits to engines.default / portal.* / engine bin paths
         // even when the connectors block didn't change.
@@ -1315,6 +1348,13 @@ export async function startGateway(
     // This preserves their engine_session_id so they can be resumed on next startup.
     const runningSessions = listSessions({ status: "running" });
     for (const session of runningSessions) {
+      if (session.workflowProvenance?.kind === "phase") {
+        // A workflow attempt needs the durable interrupted receipt (outcome +
+        // terminal version), or the next boot's recovery cannot replace it.
+        interruptSessionAttempt(session.id, "Interrupted: gateway shutting down gracefully", new Date().toISOString());
+        logger.info(`Marked workflow attempt session ${session.id} as interrupted for replacement`);
+        continue;
+      }
       updateSession(session.id, {
         status: "interrupted",
         lastActivity: new Date().toISOString(),

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -10,7 +10,7 @@ import type { JinnConfig, Connector, Employee } from "../shared/types.js";
 import { loadConfig } from "../shared/config.js";
 import { invalidateModelRegistry } from "../shared/models.js";
 import { configureLogger, logger } from "../shared/logger.js";
-import { initDb, scheduleFtsBackfill, recoverStaleSessions, recoverStaleWorkflowAttemptSessions, recoverStaleQueueItems, getInterruptedSessions, interruptSessionAttempt, listSessions, updateSession, getSession } from "../sessions/registry.js";
+import { initDb, scheduleFtsBackfill, recoverStaleSessions, recoverStaleWorkflowAttemptSessions, recoverStaleQueueItems, getInterruptedSessions, listSessions, updateSession, getSession } from "../sessions/registry.js";
 import { SessionManager, type RouteOptions } from "../sessions/manager.js";
 import { ClaudeEngine } from "../engines/claude.js";
 import { CodexEngine } from "../engines/codex.js";
@@ -964,18 +964,7 @@ export async function startGateway(
     workflowService,
   };
 
-  if (workflowService) {
-    // Replay internal dispatches a restart left pending, then let the runtime
-    // recover its own runs (dispatching attempts, receipts whose completion
-    // event was lost, due waits). Order matters: the employee provider is
-    // already wired above, and recover() must see the redispatched sessions.
-    sessionManager.redispatchPendingWorkflowAttempts();
-    try {
-      await workflowService.recover(new Date().toISOString());
-    } catch (error) {
-      logger.error(`Workflow recovery failed: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
+
 
   // NOTE: replaying pending web queue items is deferred until AFTER the server is
   // listening and gateway.json (port + hook secret) has been written — otherwise an
@@ -1302,6 +1291,20 @@ export async function startGateway(
   // recovery turn spawns — so hook-relay.mjs can deliver its Stop hook.
   resumePendingWebQueueItems(apiContext);
 
+  // Workflow redispatch/recovery can spawn engine turns — including interactive
+  // PTY turns whose Stop hook needs the gateway to be listening and
+  // gateway.json to exist (same reason resumePendingWebQueueItems above is
+  // deferred). Employee provider is already wired; recover() must see the
+  // redispatched sessions, so the order inside this block matters.
+  if (workflowService) {
+    sessionManager.redispatchPendingWorkflowAttempts();
+    try {
+      await workflowService.recover(new Date().toISOString());
+    } catch (error) {
+      logger.error(`Workflow recovery failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   // Notify connected WebSocket clients about interrupted sessions available for resume
   if (resumable.length > 0) {
     // Small delay to let WebSocket clients connect after server starts
@@ -1346,15 +1349,19 @@ export async function startGateway(
 
     // Mark all running sessions as "interrupted" before killing engine processes.
     // This preserves their engine_session_id so they can be resumed on next startup.
+    // Workflow attempts get the SAME sweep the next boot would run: it cancels
+    // their internal queue rows and stamps the durable `gateway-restart`
+    // receipt in one transaction. A plain interrupt receipt would classify as
+    // `attempt-stop` on the next boot (workflowAttemptInterruptionCause's
+    // fallback) — an operator stop, which is not retryable — and a graceful
+    // shutdown would fail the runs it merely paused.
+    const stoppedWorkflowAttempts = recoverStaleWorkflowAttemptSessions();
+    if (stoppedWorkflowAttempts > 0) {
+      logger.info(`Marked ${stoppedWorkflowAttempts} workflow attempt(s) with gateway-restart receipts for replacement on next boot`);
+    }
     const runningSessions = listSessions({ status: "running" });
     for (const session of runningSessions) {
-      if (session.workflowProvenance?.kind === "phase") {
-        // A workflow attempt needs the durable interrupted receipt (outcome +
-        // terminal version), or the next boot's recovery cannot replace it.
-        interruptSessionAttempt(session.id, "Interrupted: gateway shutting down gracefully", new Date().toISOString());
-        logger.info(`Marked workflow attempt session ${session.id} as interrupted for replacement`);
-        continue;
-      }
+      if (session.workflowProvenance?.kind === "phase") continue; // handled by the sweep above
       updateSession(session.id, {
         status: "interrupted",
         lastActivity: new Date().toISOString(),

--- a/packages/jimmy/src/gateway/workflow-api.ts
+++ b/packages/jimmy/src/gateway/workflow-api.ts
@@ -134,6 +134,23 @@ function fullRunDetail(detail: WorkflowRunDetail, spendUsd: number): WorkflowRun
   return { ...detail, attempts: withoutAttemptInput(detail), spendUsd };
 }
 
+/** Fork adaptation (see the PUT handler below): the node kinds that need the
+ *  unported Todo subsystem, reported by name so the author knows what to drop. */
+function unsupportedTodoCapability(definition: Record<string, unknown>): string | undefined {
+  const nodes = Array.isArray(definition.nodes) ? definition.nodes : [];
+  for (const node of nodes) {
+    if (typeof node !== "object" || node === null) continue;
+    const { type, config } = node as { type?: unknown; config?: { kind?: unknown; mode?: unknown } };
+    if (type === "trigger" && config?.kind === "todo-status") {
+      return "todo-status triggers need the Todo (work-items) subsystem, which this build does not include.";
+    }
+    if (type === "wait" && config?.mode === "todo-comment") {
+      return "todo-comment waits need the Todo (work-items) subsystem, which this build does not include.";
+    }
+  }
+  return undefined;
+}
+
 async function definitions(req: IncomingMessage, res: ServerResponse, url: URL, parts: string[], options: WorkflowApiOptions): Promise<boolean> {
   const { service } = options; const method = req.method ?? "GET";
   if (parts.length === 2 && method === "GET") { send(res, 200, service.listDefinitions(definitionQuery(url))); return true; }
@@ -146,6 +163,12 @@ async function definitions(req: IncomingMessage, res: ServerResponse, url: URL, 
   if (parts.length === 3 && method === "PUT") {
     const parsed = await body(req, res); if (parsed === undefined) return true;
     const value = record(parsed, ["definition", "expectedRevision"]); const definition = plainObject(value.definition, "Workflow definition is invalid.");
+    // Fork adaptation: OpenRyoko has not ported the Todo (work-items) subsystem,
+    // so a todo-status trigger would never fire and a todo-comment wait could
+    // never resume. Refuse to SAVE them rather than let a definition look armed
+    // while silently dead. Remove this guard when work-items lands.
+    const unsupported = unsupportedTodoCapability(definition);
+    if (unsupported) { send(res, 422, { code: "unsupported-capability", message: unsupported }); return true; }
     send(res, 200, service.saveDefinition({ ...definition, id } as never, value.expectedRevision as number)); return true;
   }
   if (parts.length === 4 && parts[3] === "duplicate" && method === "POST") {

--- a/packages/jimmy/src/gateway/workflow-api.ts
+++ b/packages/jimmy/src/gateway/workflow-api.ts
@@ -1,0 +1,300 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { WorkflowRepositoryError, WorkflowServiceError, type WorkflowService } from "../workflows/service.js";
+import { CALLER_SESSION_HEADER } from "../mcp/identity.js";
+import { logger } from "../shared/logger.js";
+import { getSession } from "../sessions/registry.js";
+import type { DefinitionListQuery, RunListQuery } from "../workflows/repository.js";
+import type { WorkflowAttemptWire, WorkflowRunDetail, WorkflowRunDetailWire, WorkflowRunLeanWire } from "../workflows/wire.js";
+import { WorkflowOutputError } from "../workflows/output.js";
+import { readJsonBody } from "./http-helpers.js";
+import { isJsonMediaType } from "./media-type.js";
+import { json, type ParsedRoute } from "./route-helpers.js";
+
+export interface WorkflowApiOptions {
+  service: WorkflowService;
+  authenticated: boolean;
+}
+
+// Only the argument order is local: `{ code, message }` envelopes rule out badRequest/serverError.
+const send = (res: ServerResponse, status: number, body: unknown): void => json(res, body, status);
+
+function errorStatus(error: WorkflowRepositoryError): number {
+  if (error.code === "not-found") return 404;
+  if (error.code === "id-conflict" || error.code === "revision-conflict" || error.code === "idempotency-conflict") return 409;
+  if (error.code === "corrupt-record") return 500;
+  return 422;
+}
+
+function failure(res: ServerResponse, error: unknown): void {
+  if (error instanceof WorkflowServiceError) {
+    const status = error.code === "forbidden" ? 403 : error.code === "conflict" ? 409 : 422;
+    send(res, status, { code: error.code, message: error.message,
+      ...(error.issues ? { issues: error.issues } : {}) });
+    return;
+  }
+  if (error instanceof WorkflowRepositoryError) {
+    send(res, errorStatus(error), { code: error.code, message: error.message,
+      ...(error.issues ? { issues: error.issues } : {}) });
+    return;
+  }
+  // The 500 says nothing, so this is the only record the cause ever gets.
+  logger.error(`Workflow API unexpected error: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  send(res, 500, { code: "internal-error", message: "Workflow operation failed." });
+}
+
+function approvalActor(req: IncomingMessage): string {
+  const caller = req.headers[CALLER_SESSION_HEADER];
+  if (typeof caller !== "string" || !caller) return "operator";
+  return getSession(caller)?.employee ?? `session:${caller}`;
+}
+
+function segments(pathname: string): string[] | null {
+  try {
+    return pathname.split("/").filter(Boolean).map((part) => decodeURIComponent(part));
+  } catch {
+    return null;
+  }
+}
+
+function record(value: unknown, keys: readonly string[], message = "Workflow request is invalid."): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).some((key) => !keys.includes(key))) {
+    throw new WorkflowRepositoryError("bad-input", message);
+  }
+  return value as Record<string, unknown>;
+}
+
+function plainObject(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new WorkflowRepositoryError("bad-input", message);
+  return value as Record<string, unknown>;
+}
+
+async function body(req: IncomingMessage, res: ServerResponse, maxBytes = 256 * 1024): Promise<unknown | undefined> {
+  if (!isJsonMediaType(req.headers["content-type"])) {
+    send(res, 422, { code: "bad-input", message: "Workflow requests require JSON content." });
+    return undefined;
+  }
+  const invalid = { code: "bad-input", message: "Request body must be canonical JSON." };
+  const parsed = await readJsonBody(req, res, { maxBytes, rejectDuplicateTopLevelKeys: true,
+    invalidJsonResponse: invalid, invalidJsonStatus: 422,
+    tooLargeResponse: { code: "payload-too-large", message: "Request body is too large." } });
+  return parsed.ok ? parsed.body : undefined;
+}
+
+function definitionQuery(url: URL): DefinitionListQuery {
+  const query: DefinitionListQuery = {};
+  const allowed = new Set(["cursor", "limit", "enabled", "retired"]);
+  for (const key of url.searchParams.keys()) if (!allowed.has(key)) throw new WorkflowRepositoryError("bad-input", "Workflow definition query is invalid.");
+  if (url.searchParams.has("cursor")) query.cursor = url.searchParams.get("cursor")!;
+  if (url.searchParams.has("limit")) query.limit = Number(url.searchParams.get("limit"));
+  for (const key of ["enabled", "retired"] as const) if (url.searchParams.has(key)) {
+    const value = url.searchParams.get(key); if (value !== "true" && value !== "false") throw new WorkflowRepositoryError("bad-input", "Workflow definition query is invalid.");
+    query[key] = value === "true";
+  }
+  return query;
+}
+
+function runQuery(url: URL): RunListQuery {
+  const query: Record<string, unknown> = {};
+  const allowed = new Set(["cursor", "limit", "status", "triggerKind", "startedFrom", "startedTo", "text"]);
+  for (const [key, value] of url.searchParams) {
+    if (!allowed.has(key)) throw new WorkflowRepositoryError("bad-input", "Workflow run query is invalid.");
+    query[key] = key === "limit" ? Number(value) : value;
+  }
+  return query as RunListQuery;
+}
+
+function runDetailIsFull(url: URL): boolean {
+  const allowed = new Set(["view"]);
+  for (const key of url.searchParams.keys()) if (!allowed.has(key)) throw new WorkflowRepositoryError("bad-input", "Workflow run query is invalid.");
+  const view = url.searchParams.get("view");
+  if (view !== null && view !== "full") throw new WorkflowRepositoryError("bad-input", 'Workflow run view must be "full".');
+  return view === "full";
+}
+
+/** An attempt's `input` always repeats the input already on its own node run:
+ *  both are `inputFor(run, nodeId)` read in the same transaction at dispatch, a
+ *  retry copies the first attempt's value, and the graph is acyclic so a node
+ *  activates once. The node run keeps it — that is the only copy for a node type
+ *  that owns no attempts — and the wire carries it once. */
+function withoutAttemptInput(detail: WorkflowRunDetail): WorkflowAttemptWire[] {
+  return detail.attempts.map(({ input, ...attempt }) => attempt);
+}
+
+/** Run detail is lean by default so that polling a run costs a status page, not
+ *  the whole definition snapshot plus every interpolated prompt. The definition
+ *  is still reachable through GET /api/workflows/:id, and prompts through the
+ *  attempt transcript route. */
+function leanRunDetail(detail: WorkflowRunDetail, spendUsd: number): WorkflowRunLeanWire {
+  const { definition, attempts, ...run } = detail;
+  return { ...run, attempts: withoutAttemptInput(detail).map(({ promptText, ...attempt }) => attempt), spendUsd };
+}
+
+function fullRunDetail(detail: WorkflowRunDetail, spendUsd: number): WorkflowRunDetailWire {
+  return { ...detail, attempts: withoutAttemptInput(detail), spendUsd };
+}
+
+async function definitions(req: IncomingMessage, res: ServerResponse, url: URL, parts: string[], options: WorkflowApiOptions): Promise<boolean> {
+  const { service } = options; const method = req.method ?? "GET";
+  if (parts.length === 2 && method === "GET") { send(res, 200, service.listDefinitions(definitionQuery(url))); return true; }
+  if (parts.length === 2 && method === "POST") {
+    const value = body(req, res); const parsed = await value; if (parsed === undefined) return true;
+    send(res, 201, service.createDefinition(record(parsed, ["id", "title", "description"]) as never)); return true;
+  }
+  const id = parts[2]; if (!id) return false;
+  if (parts.length === 3 && method === "GET") { const value = service.getDefinition(id); if (!value) throw new WorkflowRepositoryError("not-found", `Workflow definition ${id} was not found.`); send(res, 200, value); return true; }
+  if (parts.length === 3 && method === "PUT") {
+    const parsed = await body(req, res); if (parsed === undefined) return true;
+    const value = record(parsed, ["definition", "expectedRevision"]); const definition = plainObject(value.definition, "Workflow definition is invalid.");
+    send(res, 200, service.saveDefinition({ ...definition, id } as never, value.expectedRevision as number)); return true;
+  }
+  if (parts.length === 4 && parts[3] === "duplicate" && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true; const value = record(parsed, ["id", "title"]);
+    send(res, 201, service.duplicateDefinition(id, value as never)); return true;
+  }
+  if (parts.length === 4 && ["retire", "unretire", "enable", "disable"].includes(parts[3]!) && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true; const value = record(parsed, ["expectedRevision"]); const retiring = parts[3] === "retire" || parts[3] === "unretire";
+    const saved = retiring ? service.setRetired({ id, retired: parts[3] === "retire", expectedRevision: value.expectedRevision as number })
+      : service.setEnabled({ id, enabled: parts[3] === "enable", expectedRevision: value.expectedRevision as number });
+    send(res, 200, saved); return true;
+  }
+  return false;
+}
+
+async function runs(req: IncomingMessage, res: ServerResponse, url: URL, parts: string[], service: WorkflowService): Promise<boolean> {
+  const method = req.method ?? "GET"; const workflowId = parts[2]; if (!workflowId || parts[3] !== "runs") return false;
+  if (parts.length === 4 && method === "GET") { send(res, 200, service.listRuns(workflowId, runQuery(url))); return true; }
+  if (parts.length === 4 && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true; const value = record(parsed, ["input", "idempotencyKey", "todoId"]);
+    const caller = callerSessionId(req);
+    send(res, 201, await service.startManual({ workflowId, input: value.input as never,
+      ...(value.idempotencyKey === undefined ? {} : { idempotencyKey: value.idempotencyKey as string }),
+      ...(value.todoId === undefined ? {} : { todoId: value.todoId as string }),
+      ...(caller === undefined ? {} : { callerSessionId: caller }) })); return true;
+  }
+  const runId = parts[4]; if (!runId) return false;
+  if (parts.length === 5 && method === "GET") {
+    const full = runDetailIsFull(url); const value = service.getRun(workflowId, runId);
+    if (!value) throw new WorkflowRepositoryError("not-found", `Workflow run ${runId} was not found.`);
+    const spendUsd = service.getRunSpend(workflowId, runId);
+    send(res, 200, full ? fullRunDetail(value, spendUsd) : leanRunDetail(value, spendUsd)); return true;
+  }
+  if (parts.length === 6 && parts[5] === "cancel" && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true; const value = record(parsed, ["reason"]);
+    send(res, 200, await service.cancelRun({ workflowId, runId, reason: value.reason === undefined ? "" : value.reason as string })); return true;
+  }
+  if (parts.length === 6 && parts[5] === "rerun" && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true; const value = record(parsed, ["definition", "idempotencyKey"]);
+    send(res, 201, await service.rerun({ workflowId, runId, definition: value.definition as never, idempotencyKey: value.idempotencyKey as string })); return true;
+  }
+  if (parts.length === 8 && parts[5] === "nodes" && parts[7] === "approval" && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true;
+    const value = record(parsed, ["decision", "reason", "choice", "expectedRevision"]);
+    send(res, 200, await service.decideApproval({ workflowId, runId, nodeId: parts[6]!,
+      decision: value.decision as never, expectedRevision: value.expectedRevision as number, decidedBy: approvalActor(req),
+      ...(value.reason === undefined ? {} : { reason: value.reason as string }),
+      ...(value.choice === undefined ? {} : { choice: value.choice as string }) })); return true;
+  }
+  if (parts.length === 8 && parts[5] === "nodes" && parts[7] === "retry" && method === "POST") {
+    const parsed = await body(req, res); if (parsed === undefined) return true;
+    const value = record(parsed, ["idempotencyKey"]);
+    send(res, 200, await service.retryNode({ workflowId, runId, nodeId: parts[6]!,
+      idempotencyKey: value.idempotencyKey as string })); return true;
+  }
+  if (parts.length === 10 && parts[5] === "nodes" && parts[7] === "attempts" && parts[9] === "transcript" && method === "GET") {
+    send(res, 200, service.getAttemptTranscript({ workflowId, runId, nodeId: parts[6]!, attempt: Number(parts[8]) })); return true;
+  }
+  return false;
+}
+
+async function event(req: IncomingMessage, res: ServerResponse, parts: string[], service: WorkflowService): Promise<boolean> {
+  if (parts.length !== 4 || parts[2] !== "events" || req.method !== "POST") return false;
+  const parsed = await body(req, res, 65 * 1024); if (parsed === undefined) return true;
+  const value = record(parsed, ["fireId", "payload"], "Workflow event request is invalid.");
+  send(res, 202, await service.fireEvent({ eventName: parts[3]!, fireId: value.fireId as string, payload: value.payload as never }));
+  return true;
+}
+
+function callerSessionId(req: IncomingMessage): string | undefined {
+  const value = req.headers[CALLER_SESSION_HEADER];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function attemptFailure(res: ServerResponse, error: unknown): void {
+  if (error instanceof WorkflowOutputError) {
+    send(res, 422, { code: error.code, message: error.message });
+    return;
+  }
+  if (error instanceof WorkflowRepositoryError) {
+    if (error.code === "not-found") {
+      send(res, 409, {
+        code: "not-a-workflow-attempt",
+        message: "The caller is not a running Workflow attempt.",
+      });
+      return;
+    }
+    if (error.code === "already-submitted") {
+      send(res, 409, { code: error.code, message: error.message });
+      return;
+    }
+  }
+  failure(res, error);
+}
+
+async function attempts(req: IncomingMessage, res: ServerResponse, parts: string[], service: WorkflowService): Promise<boolean> {
+  if (parts.length !== 4 || parts[2] !== "attempts" || req.method !== "POST"
+    || !["submit", "extend"].includes(parts[3]!)) return false;
+  const sessionId = callerSessionId(req);
+  if (!sessionId) {
+    send(res, 409, {
+      code: "not-a-workflow-attempt",
+      message: "The caller is not a running Workflow attempt.",
+    });
+    return true;
+  }
+  const parsed = await body(req, res);
+  if (parsed === undefined) return true;
+  try {
+    if (parts[3] === "submit") {
+      const value = record(parsed, ["outcome", "fields", "summary"]);
+      if (value.outcome !== undefined && value.outcome !== "success" && value.outcome !== "failure") {
+        throw new WorkflowRepositoryError("bad-input", "Workflow attempt outcome must be success or failure.");
+      }
+      if (value.summary !== undefined && typeof value.summary !== "string") {
+        throw new WorkflowRepositoryError("bad-input", "Workflow attempt summary must be a string.");
+      }
+      await service.submitAttemptOutput({
+        sessionId,
+        ...(value.outcome === undefined ? {} : { outcome: value.outcome }),
+        ...(value.fields === undefined ? {} : { fields: value.fields }),
+        ...(value.summary === undefined ? {} : { summary: value.summary }),
+      });
+    } else {
+      const value = record(parsed, ["reason"]);
+      if (value.reason !== undefined && typeof value.reason !== "string") {
+        throw new WorkflowRepositoryError("bad-input", "Workflow attempt extension reason must be a string.");
+      }
+      await service.extendAttemptDeadline({
+        sessionId,
+        ...(value.reason === undefined ? {} : { reason: value.reason }),
+      });
+    }
+    send(res, 200, { ok: true });
+  } catch (error) {
+    attemptFailure(res, error);
+  }
+  return true;
+}
+
+export async function handleWorkflowApi(req: IncomingMessage, res: ServerResponse, route: ParsedRoute, options: WorkflowApiOptions): Promise<boolean> {
+  const { url } = route; const parts = segments(route.pathname);
+  if (!parts || parts[0] !== "api" || parts[1] !== "workflows") return false;
+  const writing = ["POST", "PUT", "PATCH", "DELETE"].includes(route.method);
+  if (writing && !options.authenticated) { send(res, 401, { code: "unauthorized", message: "Workflow authentication required." }); return true; }
+  try {
+    if (await attempts(req, res, parts, options.service)) return true;
+    if (await event(req, res, parts, options.service)) return true;
+    if (await runs(req, res, url, parts, options.service)) return true;
+    return await definitions(req, res, url, parts, options);
+  } catch (error) { failure(res, error); return true; }
+}

--- a/packages/jimmy/src/mcp/identity.ts
+++ b/packages/jimmy/src/mcp/identity.ts
@@ -1,0 +1,3 @@
+/** Header a session-scoped MCP caller stamps its own session id into, so a
+ *  gateway route can attribute the request (upstream-compatible name). */
+export const CALLER_SESSION_HEADER = "x-jinn-caller-session";

--- a/packages/jimmy/src/sessions/__tests__/workflow-attempt-registry.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/workflow-attempt-registry.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  claimWorkflowAttemptDispatch,
+  getOrCreateWorkflowAttemptSession,
+  getQueueItems,
+  getSession,
+  initDb,
+  markQueueItemRunning,
+  migrateSessionsSchema,
+  recoverStaleSessions,
+  recoverStaleWorkflowAttemptSessions,
+  settleWorkflowAttemptDispatch,
+  updateSession,
+  createSession,
+} from "../registry.js";
+import { workflowAttemptInterruptionCause } from "../workflow-interruptions.js";
+import type { Session, WorkflowSessionProvenance } from "../../shared/types.js";
+
+/* The paths a graceful shutdown and the next boot share: the workflow sweep
+ * must stamp a receipt the boot classifies as `gateway-restart` (retryable —
+ * the run gets REPLACED, not failed), cancel the internal queue rows in the
+ * same transaction, and never be undone by the generic session recovery. */
+
+let counter = 0;
+
+function provenance(runId: string): WorkflowSessionProvenance {
+  return {
+    kind: "phase", workflowId: "flow", workflowName: "flow", runId, triggerSource: "workflow",
+    phase: { nodeId: "work", name: "work", index: 1, round: 1, attempt: 1 },
+  };
+}
+
+function workflowSession(): Session {
+  counter += 1;
+  const runId = `run-${process.pid}-${counter}`;
+  const key = `workflow:flow:${runId}:work:1`;
+  return getOrCreateWorkflowAttemptSession({
+    engine: "claude", source: "workflow", sourceRef: key, connector: "workflow", sessionKey: key,
+    employee: "worker", prompt: "Do the work.", workflowProvenance: provenance(runId),
+  });
+}
+
+beforeEach(() => {
+  initDb();
+});
+
+describe("the shutdown/boot workflow sweep", () => {
+  it("stamps a receipt the boot classifies as gateway-restart and cancels the queue row", () => {
+    const session = workflowSession();
+    const claim = claimWorkflowAttemptDispatch(session.id, session.sessionKey, "Do the work.");
+    expect(claim).toBeTruthy();
+    expect(markQueueItemRunning(claim!)).toBe(true);
+    updateSession(session.id, { status: "running" });
+
+    expect(recoverStaleWorkflowAttemptSessions()).toBeGreaterThanOrEqual(1);
+
+    const swept = getSession(session.id)!;
+    expect(swept.status).toBe("interrupted");
+    expect(swept.attemptOutcome).toBe("interrupted");
+    expect(swept.attemptTerminalVersion).toBe(1);
+    expect(swept.attemptTurn).toBeGreaterThanOrEqual(1);
+    // The classification the workflow runtime reads on the next boot — this is
+    // what makes the attempt replaceable instead of a terminal operator stop.
+    expect(workflowAttemptInterruptionCause(swept.lastError, swept, swept.attemptTurn)).toBe("gateway-restart");
+    // The internal dispatch row died with the attempt: nothing pending survives.
+    expect(getQueueItems(session.sessionKey)).toHaveLength(0);
+  });
+
+  it("is not undone by the generic session recovery, which skips workflow rows", () => {
+    const session = workflowSession();
+    updateSession(session.id, { status: "running" });
+
+    recoverStaleSessions();
+    // Generic recovery left the workflow row alone (still running, no receipt)…
+    expect(getSession(session.id)!.status).toBe("running");
+    expect(getSession(session.id)!.attemptOutcome).toBeNull();
+    // …so the dedicated sweep still finds it and stamps the full receipt.
+    expect(recoverStaleWorkflowAttemptSessions()).toBeGreaterThanOrEqual(1);
+    expect(getSession(session.id)!.attemptOutcome).toBe("interrupted");
+  });
+});
+
+describe("the durable dispatch claim", () => {
+  it("clears the previous receipt in the claim transaction and closes the row on settle", () => {
+    const session = workflowSession();
+    const first = claimWorkflowAttemptDispatch(session.id, session.sessionKey, "Do the work.");
+    expect(first).toBeTruthy();
+    expect(markQueueItemRunning(first!)).toBe(true);
+    // The CAS admits exactly one runner per row.
+    expect(markQueueItemRunning(first!)).toBe(false);
+
+    const settled = settleWorkflowAttemptDispatch(session.id, "succeeded");
+    expect(settled?.attemptOutcome).toBe("succeeded");
+    expect(settled?.attemptTurn).toBe(1);
+    // Receipt and queue-row close are one transaction: no pending row survives
+    // a settle for a restart to re-execute.
+    expect(getQueueItems(session.sessionKey)).toHaveLength(0);
+
+    // A reminder claim opens the next generation durably: the succeeded receipt
+    // is cleared in the SAME transaction that creates the pending row.
+    const second = claimWorkflowAttemptDispatch(session.id, session.sessionKey, "One more thing.");
+    expect(second).toBeTruthy();
+    expect(second).not.toBe(first);
+    expect(getSession(session.id)!.attemptOutcome).toBeNull();
+    expect(getSession(session.id)!.attemptTerminalVersion).toBe(0);
+  });
+
+  it("keeps an interrupted receipt over a late settle", () => {
+    const session = workflowSession();
+    const claim = claimWorkflowAttemptDispatch(session.id, session.sessionKey, "Do the work.");
+    expect(claim).toBeTruthy();
+    updateSession(session.id, { status: "running" });
+    recoverStaleWorkflowAttemptSessions();
+
+    const settled = settleWorkflowAttemptDispatch(session.id, "succeeded");
+    expect(settled?.attemptOutcome).toBe("interrupted");
+  });
+});
+
+describe("sessions schema migration", () => {
+  it("tolerates re-running against a database that already has every column", () => {
+    const database = initDb();
+    // Both the sessions columns and queue_items.internal already exist here;
+    // a re-run (two processes racing the same migration) must not throw.
+    expect(() => migrateSessionsSchema(database)).not.toThrow();
+    expect(() => migrateSessionsSchema(database)).not.toThrow();
+  });
+});
+
+describe("non-workflow sessions", () => {
+  it("are untouched by the workflow sweep", () => {
+    const plain = createSession({ engine: "claude", source: "web", sourceRef: `web-${process.pid}-${counter += 1}` });
+    updateSession(plain.id, { status: "running" });
+    recoverStaleWorkflowAttemptSessions();
+    expect(getSession(plain.id)!.status).toBe("running");
+  });
+});

--- a/packages/jimmy/src/sessions/attempt-continuation.ts
+++ b/packages/jimmy/src/sessions/attempt-continuation.ts
@@ -1,0 +1,48 @@
+/**
+ * Carrying an engine session from one workflow attempt to the next.
+ *
+ * Every attempt gets its own session row — the workflow bookkeeping is keyed
+ * on that one-to-one mapping — and a fresh row resumes nothing, so a rework
+ * round re-derives all the context its predecessor already holds. Seeding the
+ * new row with the previous attempt's engine session id before its first turn
+ * makes the ordinary resume path fire instead.
+ *
+ * OpenRyoko adaptation: the fork's registry tracks a single `engineSessionId`
+ * per session (no per-engine ref map, no codex rollout store), so continuation
+ * is offered only when the engines match — and codex, whose threads upstream
+ * carries by copying rollout files this fork does not track, always dispatches
+ * cold rather than resuming a thread that may no longer resolve.
+ */
+
+import type { Session, WorkflowAttemptContinuation } from "../shared/types.js";
+import { logger } from "../shared/logger.js";
+import { getSession, updateSession } from "./registry.js";
+
+/**
+ * The engine thread `sessionId` still holds and a new session could pick up, or
+ * null. Null covers every reason a candidate is unusable: the session is gone,
+ * it ran on a different engine, it never recorded a thread, or the engine is
+ * codex (no rollout tracking in this fork — see the module note).
+ */
+export function resumableEngineSession(sessionId: string, engine: string): string | null {
+  const session = getSession(sessionId);
+  if (!session || session.engine !== engine) return null;
+  if (engine === "codex") return null;
+  return session.engineSessionId || null;
+}
+
+/**
+ * Seed a freshly created attempt session with the engine session it continues.
+ * A no-op once the session already carries an engine session id, so replaying
+ * a dispatch after a crash never rewinds a turn that has since run.
+ */
+export function continueWorkflowAttemptSession(
+  session: Session,
+  continueFrom: WorkflowAttemptContinuation | undefined,
+): Session {
+  if (!continueFrom || session.engineSessionId) return session;
+  const { engine, engineSessionId, sourceSessionId } = continueFrom;
+  if (engine !== session.engine || engine === "codex") return session;
+  logger.info(`Session ${session.id} continues ${engine} session ${engineSessionId} from session ${sourceSessionId}.`);
+  return updateSession(session.id, { engineSessionId }) ?? session;
+}

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -5,19 +5,33 @@ import type {
   Engine,
   IncomingMessage,
   JinnConfig,
+  SessionAttemptOutcome,
   Session,
   Target,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+  WorkflowAttemptInterruptionCause,
 } from "../shared/types.js";
 import {
+  cancelWorkflowAttemptDispatch,
+  claimWorkflowAttemptDispatch,
   createSession,
   deleteSession,
+  getOrCreateWorkflowAttemptSession,
   getSession,
   getSessionBySessionKey,
   getMessages,
   insertMessage,
+  interruptSessionAttempt,
+  listChildSessions,
+  listPendingWorkflowAttemptDispatches,
   updateSession,
   type UpdateSessionFields,
 } from "./registry.js";
+import { isInterruptibleEngine } from "../shared/types.js";
+import { continueWorkflowAttemptSession } from "./attempt-continuation.js";
+import { workflowAttemptInterruptionCause } from "./workflow-interruptions.js";
 import { recordTurnAccounting } from "./accounting.js";
 import { notifyParentSession, notifyRateLimited, notifyRateLimitResumed, notifyDiscordChannel } from "./callbacks.js";
 import { buildContext } from "./context.js";
@@ -35,6 +49,24 @@ import { loadJobs } from "../cron/jobs.js";
 import { setCronJobEnabled, triggerCronJob } from "../cron/scheduler.js";
 import { checkBudget } from "../gateway/budgets.js";
 import { resolveMcpServers, writeMcpConfigFile, cleanupMcpConfigFile } from "../mcp/resolver.js";
+
+const WORKFLOW_CAPABILITIES = { threading: false, messageEdits: false, reactions: false, attachments: false };
+/** Inert connector a workflow attempt turn runs under: nothing to deliver to,
+ *  nothing to react on — the runner reads the transcript, not a channel. */
+const WORKFLOW_CONNECTOR: Connector = {
+  name: "workflow",
+  async start() {},
+  async stop() {},
+  getCapabilities: () => WORKFLOW_CAPABILITIES,
+  getHealth: () => ({ status: "running", capabilities: WORKFLOW_CAPABILITIES }),
+  reconstructTarget: () => ({ channel: "workflow" }),
+  async sendMessage() { return undefined; },
+  async replyMessage() { return undefined; },
+  async addReaction() {},
+  async removeReaction() {},
+  async editMessage() {},
+  onMessage() {},
+};
 
 export interface RouteOptions {
   employee?: Employee;
@@ -145,6 +177,9 @@ export class SessionManager {
   private connectorNames: string[];
   private queue = new SessionQueue();
   private connectorProvider: () => Map<string, Connector> = () => new Map();
+  private employeeProvider: (id: string) => Employee | undefined = () => undefined;
+  private workflowAttemptCompletionListeners = new Set<WorkflowAttemptCompletionListener>();
+  private emittedWorkflowAttemptCompletions = new Set<string>();
 
   constructor(
     config: JinnConfig,
@@ -158,6 +193,182 @@ export class SessionManager {
 
   setConnectorProvider(provider: () => Map<string, Connector>): void {
     this.connectorProvider = provider;
+  }
+
+  /** Wire the employee roster in after boot (mirrors setConnectorProvider). */
+  setEmployeeProvider(provider: (id: string) => Employee | undefined): void {
+    this.employeeProvider = provider;
+  }
+
+  // --- Workflow attempt execution (upstream port, adapted) -------------------
+  //
+  // Upstream fences terminal writes with per-dispatch attempt tokens; this fork
+  // relies on the queue's per-sessionKey serialization plus the persisted
+  // dispatch claim, and stamps the terminal receipt in the dispatch task right
+  // after runSession — never inside it — so the conversational path stays
+  // untouched. A stop that raced the settle wins: the receipt is only written
+  // while attemptOutcome is still null.
+
+  subscribeWorkflowAttemptCompletion(listener: WorkflowAttemptCompletionListener): () => void {
+    this.workflowAttemptCompletionListeners.add(listener);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      this.workflowAttemptCompletionListeners.delete(listener);
+    };
+  }
+
+  async runWorkflowAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    const employee = this.employeeProvider(command.employeeId);
+    if (!employee) throw new Error(`Workflow employee "${command.employeeId}" is not available.`);
+    const key = `workflow:${command.owner.workflowId}:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+    const session = continueWorkflowAttemptSession(
+      getOrCreateWorkflowAttemptSession({
+        engine: command.engine,
+        source: "workflow",
+        sourceRef: key,
+        connector: "workflow",
+        sessionKey: key,
+        employee: command.employeeId,
+        model: command.model,
+        effortLevel: command.effort,
+        prompt: command.prompt,
+        workflowProvenance: {
+          kind: "phase",
+          workflowId: command.owner.workflowId,
+          workflowName: command.owner.workflowId,
+          runId: command.owner.runId,
+          triggerSource: "workflow",
+          phase: { nodeId: command.owner.nodeId, name: command.owner.nodeId, index: 1, round: 1, attempt: command.owner.attempt },
+        },
+      }),
+      command.continueFrom,
+    );
+    const claim = claimWorkflowAttemptDispatch(session.id, session.sessionKey, command.prompt);
+    if (claim) this.enqueueWorkflowAttempt(session, command.prompt, employee, claim);
+    return { sessionId: session.id };
+  }
+
+  private enqueueWorkflowAttempt(session: Session, prompt: string, employee: Employee, claim: string): void {
+    const msg: IncomingMessage = {
+      connector: "workflow", source: "workflow", sessionKey: session.sessionKey, replyContext: {},
+      channel: session.id, user: "workflow", userId: "workflow", text: prompt, attachments: [], raw: null,
+    };
+    // Emitted on the enqueue promise, never inside the task: a listener that
+    // answers the completion by dispatching again (the stop-nudge does) must
+    // find the queue row already settled, not still running this prompt.
+    setImmediate(() => {
+      let settled: Session | undefined;
+      void this.queue.enqueue(session.sessionKey, async () => {
+        try {
+          // A new dispatch opens a new attempt generation: clear the previous
+          // terminal receipt so the settle below (or a stop) owns this turn.
+          updateSession(session.id, { attemptOutcome: null, attemptTerminalVersion: 0 });
+          await this.runSession(session, msg, [], WORKFLOW_CONNECTOR, { channel: session.id }, employee);
+          settled = this.settleWorkflowAttemptTurn(session.id);
+        } catch (error) {
+          logger.error(`Workflow session ${session.id} dispatch failed: ${String(error)}`);
+          settled = this.settleWorkflowAttemptTurn(session.id);
+        }
+      }, claim).then(() => {
+        if (settled) this.emitWorkflowAttemptCompletion(settled);
+      });
+    });
+  }
+
+  /** Terminal receipt for the turn runSession just ran. A stop that already
+   *  stamped `interrupted` keeps its receipt; this only fills a null one. */
+  private settleWorkflowAttemptTurn(sessionId: string): Session | undefined {
+    const current = getSession(sessionId);
+    if (!current || current.workflowProvenance?.kind !== "phase") return current ?? undefined;
+    if (current.attemptOutcome) return current;
+    const outcome: SessionAttemptOutcome = current.status === "error" ? "failed"
+      : current.status === "interrupted" ? "interrupted" : "succeeded";
+    return updateSession(sessionId, {
+      attemptOutcome: outcome,
+      attemptTerminalVersion: 1,
+      attemptTurn: (current.attemptTurn ?? 0) + 1,
+    }) ?? current;
+  }
+
+  async remindWorkflowAttempt(sessionId: string, text: string): Promise<void> {
+    const session = getSession(sessionId);
+    if (!session || session.workflowProvenance?.kind !== "phase" || !session.employee) {
+      throw new Error(`Workflow attempt session "${sessionId}" is not available.`);
+    }
+    const employee = this.employeeProvider(session.employee);
+    if (!employee) throw new Error(`Workflow employee "${session.employee}" is not available.`);
+    const claim = claimWorkflowAttemptDispatch(session.id, session.sessionKey, text);
+    if (!claim) throw new Error(`Workflow attempt session "${sessionId}" is not idle.`);
+    this.enqueueWorkflowAttempt(session, text, employee, claim);
+  }
+
+  workflowAttemptState(sessionId: string): { idle: boolean; runningChildren: number } | null {
+    const session = getSession(sessionId);
+    if (!session || session.workflowProvenance?.kind !== "phase") return null;
+    const idle = session.status === "idle"
+      && !this.queue.isRunning(session.sessionKey)
+      && this.queue.getPendingCount(session.sessionKey) === 0;
+    const runningChildren = listChildSessions(sessionId).filter((child) => {
+      const transport = this.queue.getTransportState(child.sessionKey, child.status);
+      return child.status === "running" || transport === "running" || transport === "queued";
+    }).length;
+    return { idle, runningChildren };
+  }
+
+  async stopWorkflowAttempt(input: { sessionId: string; reason: string }): Promise<void> {
+    const session = getSession(input.sessionId);
+    if (!session || session.workflowProvenance?.kind !== "phase") return;
+    const stopped = interruptSessionAttempt(session.id, input.reason, new Date().toISOString());
+    if (!stopped) return;
+    cancelWorkflowAttemptDispatch(stopped.id);
+    this.queue.clearQueue(stopped.sessionKey);
+    const engine = this.engines.get(stopped.engine);
+    if (engine && isInterruptibleEngine(engine)) engine.kill(stopped.id, input.reason);
+    this.emitWorkflowAttemptCompletion(stopped, "attempt-stop");
+  }
+
+  /** Replay internal dispatches a restart left pending (call once at boot,
+   *  after the employee provider is wired). */
+  redispatchPendingWorkflowAttempts(): void {
+    for (const item of listPendingWorkflowAttemptDispatches()) {
+      const session = getSession(item.sessionId);
+      const employee = session?.employee ? this.employeeProvider(session.employee) : undefined;
+      if (!session || !employee) continue;
+      this.enqueueWorkflowAttempt(session, item.prompt, employee, item.id);
+    }
+  }
+
+  private emitWorkflowAttemptCompletion(session?: Session, interruptionCause?: WorkflowAttemptInterruptionCause): void {
+    const provenance = session?.workflowProvenance;
+    if (!session?.attemptOutcome || provenance?.kind !== "phase" || !provenance.phase) return;
+    const terminalVersion = session.attemptTerminalVersion ?? 0;
+    const turn = session.attemptTurn ?? 0;
+    const key = `${session.id}:${turn}`;
+    if (terminalVersion < 1 || turn < 1 || this.emittedWorkflowAttemptCompletions.has(key)) return;
+    const finalText = [...getMessages(session.id)].reverse().find((message) => message.role === "assistant")?.content;
+    const event: WorkflowAttemptCompletion = {
+      sessionId: session.id,
+      owner: {
+        workflowId: provenance.workflowId, runId: provenance.runId,
+        nodeId: provenance.phase.nodeId, attempt: provenance.phase.attempt,
+      },
+      turn,
+      terminalVersion: 1,
+      outcome: session.attemptOutcome,
+      completedAt: session.lastActivity,
+      ...(session.attemptOutcome === "interrupted" ? {
+        interruptionCause: interruptionCause ?? workflowAttemptInterruptionCause(session.lastError, session, turn),
+      } : {}),
+      ...(finalText ? { finalText } : {}),
+      ...(session.lastError ? { error: session.lastError } : {}),
+    };
+    this.emittedWorkflowAttemptCompletions.add(key);
+    for (const listener of this.workflowAttemptCompletionListeners) {
+      void Promise.resolve(listener(event)).catch((error) =>
+        logger.error(`Workflow attempt completion listener failed: ${String(error)}`));
+    }
   }
 
   /**

--- a/packages/jimmy/src/sessions/manager.ts
+++ b/packages/jimmy/src/sessions/manager.ts
@@ -26,6 +26,7 @@ import {
   interruptSessionAttempt,
   listChildSessions,
   listPendingWorkflowAttemptDispatches,
+  settleWorkflowAttemptDispatch,
   updateSession,
   type UpdateSessionFields,
 } from "./registry.js";
@@ -261,15 +262,18 @@ export class SessionManager {
     setImmediate(() => {
       let settled: Session | undefined;
       void this.queue.enqueue(session.sessionKey, async () => {
+        // The previous terminal receipt was already cleared inside the durable
+        // claim transaction (claimWorkflowAttemptDispatch), so this turn — or a
+        // stop that races it — owns the receipt from here on.
         try {
-          // A new dispatch opens a new attempt generation: clear the previous
-          // terminal receipt so the settle below (or a stop) owns this turn.
-          updateSession(session.id, { attemptOutcome: null, attemptTerminalVersion: 0 });
           await this.runSession(session, msg, [], WORKFLOW_CONNECTOR, { channel: session.id }, employee);
           settled = this.settleWorkflowAttemptTurn(session.id);
         } catch (error) {
+          // A turn whose plumbing threw is a FAILED attempt, never a success:
+          // deciding success from `status === "idle"` here would let an
+          // insertMessage/context failure masquerade as a completed turn.
           logger.error(`Workflow session ${session.id} dispatch failed: ${String(error)}`);
-          settled = this.settleWorkflowAttemptTurn(session.id);
+          settled = settleWorkflowAttemptDispatch(session.id, "failed", { error: String(error) });
         }
       }, claim).then(() => {
         if (settled) this.emitWorkflowAttemptCompletion(settled);
@@ -277,19 +281,18 @@ export class SessionManager {
     });
   }
 
-  /** Terminal receipt for the turn runSession just ran. A stop that already
-   *  stamped `interrupted` keeps its receipt; this only fills a null one. */
+  /** Terminal receipt for the turn runSession just ran, written atomically with
+   *  the queue-row close (see registry.settleWorkflowAttemptDispatch). A stop
+   *  that already stamped `interrupted` keeps its receipt. A turn that ended in
+   *  `waiting`/`running` (rate-limit park, still-active transport) settles
+   *  nothing — recovery or the next turn owns it. */
   private settleWorkflowAttemptTurn(sessionId: string): Session | undefined {
     const current = getSession(sessionId);
     if (!current || current.workflowProvenance?.kind !== "phase") return current ?? undefined;
-    if (current.attemptOutcome) return current;
-    const outcome: SessionAttemptOutcome = current.status === "error" ? "failed"
-      : current.status === "interrupted" ? "interrupted" : "succeeded";
-    return updateSession(sessionId, {
-      attemptOutcome: outcome,
-      attemptTerminalVersion: 1,
-      attemptTurn: (current.attemptTurn ?? 0) + 1,
-    }) ?? current;
+    const outcome: SessionAttemptOutcome | null = current.status === "error" ? "failed"
+      : current.status === "interrupted" ? "interrupted"
+      : current.status === "idle" ? "succeeded" : null;
+    return settleWorkflowAttemptDispatch(sessionId, outcome);
   }
 
   async remindWorkflowAttempt(sessionId: string, text: string): Promise<void> {
@@ -321,9 +324,12 @@ export class SessionManager {
     const session = getSession(input.sessionId);
     if (!session || session.workflowProvenance?.kind !== "phase") return;
     const stopped = interruptSessionAttempt(session.id, input.reason, new Date().toISOString());
+    // Cancel the pending dispatch even when the interrupt receipt found nothing
+    // to stamp — a session whose last turn already succeeded can still hold a
+    // pending reminder row, and a stop must not leave it to run later.
+    cancelWorkflowAttemptDispatch(session.id);
+    this.queue.clearQueue(session.sessionKey);
     if (!stopped) return;
-    cancelWorkflowAttemptDispatch(stopped.id);
-    this.queue.clearQueue(stopped.sessionKey);
     const engine = this.engines.get(stopped.engine);
     if (engine && isInterruptibleEngine(engine)) engine.kill(stopped.id, input.reason);
     this.emitWorkflowAttemptCompletion(stopped, "attempt-stop");

--- a/packages/jimmy/src/sessions/queue.ts
+++ b/packages/jimmy/src/sessions/queue.ts
@@ -1,4 +1,4 @@
-import { markQueueItemRunning, markQueueItemCompleted } from "./registry.js";
+import { getQueueItem, markQueueItemRunning, markQueueItemCompleted } from "./registry.js";
 
 export class SessionQueue {
   private queues = new Map<string, Promise<void>>();
@@ -75,7 +75,7 @@ export class SessionQueue {
   /**
    * Enqueue a task for a session. Tasks are serialized per session key.
    */
-  async enqueue(sessionKey: string, fn: () => Promise<void>, queueItemId?: string): Promise<void> {
+  async enqueue(sessionKey: string, fn: () => Promise<void>, queueItemId?: string, claimed = false): Promise<void> {
     this.pending.set(sessionKey, (this.pending.get(sessionKey) || 0) + 1);
     // Snapshot the cancellation generation at enqueue time. A later clearQueue()
     // bumps it and skips this task; tasks enqueued after that clearQueue capture the
@@ -84,17 +84,30 @@ export class SessionQueue {
     const prev = this.queues.get(sessionKey) || Promise.resolve();
     const runTask = async () => {
       this.running.add(sessionKey);
+      let queueItemStarted = false;
       try {
         // Wait while paused (500ms poll)
         while (this.paused.has(sessionKey)) {
           await new Promise(resolve => setTimeout(resolve, 500));
         }
-        if (queueItemId) markQueueItemRunning(queueItemId);
+        // pending→running is a CAS: only the winner runs the prompt, so two
+        // dispatchers holding the same durable row id can never both execute
+        // it. A `claimed` caller already holds the row as 'running' (a boot
+        // redispatch of a row recoverStaleQueueItems put back) and only
+        // verifies it is still theirs.
+        if (queueItemId) {
+          const item = getQueueItem(queueItemId);
+          if (!item || (claimed ? item.status !== "running" && !markQueueItemRunning(queueItemId)
+            : item.status !== "pending" || !markQueueItemRunning(queueItemId))) return;
+          queueItemStarted = true;
+        }
         if ((this.cancelGeneration.get(sessionKey) ?? 0) === taskGeneration) {
           await fn();
         }
-        if (queueItemId) markQueueItemCompleted(queueItemId);
       } finally {
+        // Mark the DB row done in finally so an errored/cancelled task can't
+        // leave the item stuck as 'running'.
+        if (queueItemId && queueItemStarted) markQueueItemCompleted(queueItemId);
         this.running.delete(sessionKey);
         this.decrementPending(sessionKey);
       }

--- a/packages/jimmy/src/sessions/registry.ts
+++ b/packages/jimmy/src/sessions/registry.ts
@@ -320,7 +320,13 @@ export function migrateSessionsSchema(database: Database.Database): void {
   for (const [name, type, defaultVal] of missingColumns) {
     if (!colNames.has(name)) {
       const defaultClause = defaultVal !== undefined ? ` DEFAULT ${defaultVal}` : '';
-      database.exec(`ALTER TABLE sessions ADD COLUMN ${name} ${type}${defaultClause}`);
+      try {
+        database.exec(`ALTER TABLE sessions ADD COLUMN ${name} ${type}${defaultClause}`);
+      } catch (error) {
+        // Two processes racing the same migration both observe "column missing";
+        // the loser's ALTER must not abort startup once the column exists.
+        if (!String(error).includes('duplicate column name')) throw error;
+      }
     }
   }
 
@@ -632,7 +638,7 @@ export function recoverStaleSessions(): number {
   const db = initDb();
   const now = new Date().toISOString();
   const result = db.prepare(
-    "UPDATE sessions SET status = 'interrupted', last_activity = ?, last_error = 'Interrupted: gateway restarted while session was running' WHERE status = 'running'",
+    "UPDATE sessions SET status = 'interrupted', last_activity = ?, last_error = 'Interrupted: gateway restarted while session was running' WHERE status = 'running' AND workflow_kind IS NULL",
   ).run(now);
   return result.changes;
 }
@@ -916,10 +922,18 @@ export function insertNotificationWithQueueItem(sessionId: string, sessionKey: s
   return tx();
 }
 
-export function markQueueItemRunning(itemId: string): void {
+/** pending→running の CAS。勝者のみ true — 敗者はそのプロンプトを実行してはならない。 */
+export function markQueueItemRunning(itemId: string): boolean {
   const db = initDb();
-  db.prepare("UPDATE queue_items SET status = 'running', started_at = ? WHERE id = ?")
-    .run(new Date().toISOString(), itemId);
+  return db.prepare("UPDATE queue_items SET status = 'running', started_at = ? WHERE id = ? AND status = 'pending'")
+    .run(new Date().toISOString(), itemId).changes === 1;
+}
+
+export function getQueueItem(itemId: string): QueueItem | undefined {
+  const db = initDb();
+  return db.prepare(
+    "SELECT id, session_id as sessionId, session_key as sessionKey, prompt, status, position, created_at as createdAt, started_at as startedAt, completed_at as completedAt FROM queue_items WHERE id = ?"
+  ).get(itemId) as QueueItem | undefined;
 }
 
 export function markQueueItemCompleted(itemId: string): void {
@@ -1092,7 +1106,12 @@ export function claimWorkflowAttemptDispatch(sessionId: string, sessionKey: stri
       throw new Error(`Workflow session ${sessionId} dispatch claim does not match its immutable command.`);
     }
     if (existing?.status === 'running') return null;
-    return existing?.id ?? enqueueQueueItem(sessionId, sessionKey, prompt, { internal: true });
+    const itemId = existing?.id ?? enqueueQueueItem(sessionId, sessionKey, prompt, { internal: true });
+    // 新しい dispatch generation の開始を claim と同じ transaction で durable に:
+    // 前ターンの terminal receipt をここでクリアするので、pending row が存在する間は
+    // 「outcome が刻まれていれば settle 済み」という不変式が成り立つ。
+    db.prepare("UPDATE sessions SET attempt_outcome = NULL, attempt_terminal_version = 0 WHERE id = ?").run(sessionId);
+    return itemId;
   }).immediate();
 }
 
@@ -1159,5 +1178,33 @@ export function recoverStaleWorkflowAttemptSessions(): number {
         AND attempt_outcome IS NULL
         AND attempt_terminal_version = 0
     `).run(now).changes;
+  }).immediate();
+}
+
+/** Terminal receipt for the turn a workflow dispatch just ran, written in the
+ *  same transaction that closes the internal queue row — so a crash can never
+ *  leave "receipt says succeeded, queue row still pending" for a restart to
+ *  re-execute. A stop that already stamped `interrupted` keeps its receipt
+ *  (only a null outcome is filled), but the queue row is closed either way. */
+export function settleWorkflowAttemptDispatch(
+  sessionId: string,
+  outcome: SessionAttemptOutcome | null,
+  opts: { error?: string } = {},
+): Session | undefined {
+  const database = initDb();
+  return database.transaction(() => {
+    const current = getSession(sessionId);
+    if (!current || current.workflowProvenance?.kind !== 'phase') return current ?? undefined;
+    database.prepare(
+      "UPDATE queue_items SET status = 'completed', completed_at = ? WHERE session_id = ? AND internal = 1 AND status IN ('pending', 'running')"
+    ).run(new Date().toISOString(), sessionId);
+    if (current.attemptOutcome) return current;
+    if (outcome === null) return current;
+    return updateSession(sessionId, {
+      attemptOutcome: outcome,
+      attemptTerminalVersion: 1,
+      attemptTurn: (current.attemptTurn ?? 0) + 1,
+      ...(opts.error !== undefined ? { status: 'error' as const, lastError: opts.error, lastActivity: new Date().toISOString() } : {}),
+    }) ?? current;
   }).immediate();
 }

--- a/packages/jimmy/src/sessions/registry.ts
+++ b/packages/jimmy/src/sessions/registry.ts
@@ -344,7 +344,11 @@ export function migrateSessionsSchema(database: Database.Database): void {
   // column added.
   const queueCols = database.prepare('PRAGMA table_info(queue_items)').all() as Array<{ name: string }>;
   if (queueCols.length > 0 && !queueCols.some((c) => c.name === 'internal')) {
-    database.exec('ALTER TABLE queue_items ADD COLUMN internal INTEGER NOT NULL DEFAULT 0');
+    try {
+      database.exec('ALTER TABLE queue_items ADD COLUMN internal INTEGER NOT NULL DEFAULT 0');
+    } catch (error) {
+      if (!String(error).includes('duplicate column name')) throw error;
+    }
   }
 }
 

--- a/packages/jimmy/src/sessions/registry.ts
+++ b/packages/jimmy/src/sessions/registry.ts
@@ -6,7 +6,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { SESSIONS_DB } from '../shared/paths.js';
 import { logger } from '../shared/logger.js';
 import { assertDiskSpaceForWrite } from '../shared/storage-health.js';
-import type { JsonObject, ReplyContext, Session } from '../shared/types.js';
+import type {
+  JsonObject,
+  ReplyContext,
+  Session,
+  SessionAttemptOutcome,
+  WorkflowAttemptInterruptionCause,
+  WorkflowSessionProvenance,
+} from '../shared/types.js';
 
 let db: Database.Database;
 let ftsAvailable = true;
@@ -200,8 +207,16 @@ function rowToSession(row: Record<string, unknown>): Session {
     model: (row.model as string) ?? null,
     title: (row.title as string) ?? null,
     parentSessionId: (row.parent_session_id as string) ?? null,
+    workflowProvenance: row.workflow_provenance
+      ? (parseJsonObject(row.workflow_provenance) as unknown as WorkflowSessionProvenance | null)
+      : null,
     effortLevel: (row.effort_level as string) ?? null,
     status: row.status as Session['status'],
+    attemptOutcome: (row.attempt_outcome as SessionAttemptOutcome) ?? null,
+    attemptTerminalVersion: (row.attempt_terminal_version as number) ?? 0,
+    attemptTurn: (row.attempt_turn as number) ?? 0,
+    attemptInterruptionCause: (row.attempt_interruption_cause as WorkflowAttemptInterruptionCause) ?? null,
+    attemptInterruptionTurn: (row.attempt_interruption_turn as number) ?? null,
     totalCost: (row.total_cost as number) ?? 0,
     totalTurns: (row.total_turns as number) ?? 0,
     lastContextTokens: (row.last_context_tokens as number) ?? null,
@@ -234,7 +249,8 @@ export function initDb(): Database.Database {
       position INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
       started_at TEXT,
-      completed_at TEXT
+      completed_at TEXT,
+      internal INTEGER NOT NULL DEFAULT 0
     );
     CREATE INDEX IF NOT EXISTS idx_queue_session
       ON queue_items (session_key, status, position);
@@ -287,6 +303,18 @@ export function migrateSessionsSchema(database: Database.Database): void {
     ['total_turns', 'INTEGER', '0'],
     ['effort_level', 'TEXT'],
     ['last_context_tokens', 'INTEGER'],
+    // Workflow attempt attribution + terminal receipts (upstream port)
+    ['workflow_provenance', 'TEXT'],
+    ['workflow_kind', 'TEXT'],
+    ['workflow_id', 'TEXT'],
+    ['workflow_run_id', 'TEXT'],
+    ['workflow_phase_node_id', 'TEXT'],
+    ['workflow_phase_attempt', 'INTEGER'],
+    ['attempt_outcome', 'TEXT'],
+    ['attempt_terminal_version', 'INTEGER', '0'],
+    ['attempt_turn', 'INTEGER', '0'],
+    ['attempt_interruption_cause', 'TEXT'],
+    ['attempt_interruption_turn', 'INTEGER'],
   ];
 
   for (const [name, type, defaultVal] of missingColumns) {
@@ -304,6 +332,14 @@ export function migrateSessionsSchema(database: Database.Database): void {
   if (refreshedNames.has('connector')) {
     database.exec(`UPDATE sessions SET connector = COALESCE(connector, source) WHERE connector IS NULL OR connector = ''`);
   }
+
+  // queue_items is created after this migration runs on a fresh database (its
+  // CREATE TABLE already carries `internal`); only an existing table needs the
+  // column added.
+  const queueCols = database.prepare('PRAGMA table_info(queue_items)').all() as Array<{ name: string }>;
+  if (queueCols.length > 0 && !queueCols.some((c) => c.name === 'internal')) {
+    database.exec('ALTER TABLE queue_items ADD COLUMN internal INTEGER NOT NULL DEFAULT 0');
+  }
 }
 
 export interface CreateSessionOpts {
@@ -320,6 +356,8 @@ export interface CreateSessionOpts {
   title?: string;
   parentSessionId?: string;
   effortLevel?: string;
+  /** Durable workflow/run/phase attribution (upstream port). */
+  workflowProvenance?: WorkflowSessionProvenance;
 }
 
 function getNextSessionNumber(): number {
@@ -348,12 +386,14 @@ export function createSession(opts: CreateSessionOpts & { prompt?: string; porta
   const replyContext = opts.replyContext ? JSON.stringify(opts.replyContext) : null;
   const transportMeta = opts.transportMeta ? JSON.stringify(opts.transportMeta) : null;
 
+  const workflow = opts.workflowProvenance ?? null;
   const stmt = db.prepare(`
     INSERT INTO sessions (
       id, engine, source, source_ref, connector, session_key, reply_context, message_id, transport_meta,
-      employee, model, title, parent_session_id, effort_level, status, created_at, last_activity
+      employee, model, title, parent_session_id, effort_level, status, created_at, last_activity,
+      workflow_provenance, workflow_kind, workflow_id, workflow_run_id, workflow_phase_node_id, workflow_phase_attempt
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'idle', ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'idle', ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   stmt.run(
     id,
@@ -372,6 +412,12 @@ export function createSession(opts: CreateSessionOpts & { prompt?: string; porta
     opts.effortLevel ?? null,
     now,
     now,
+    workflow ? JSON.stringify(workflow) : null,
+    workflow?.kind ?? null,
+    workflow?.workflowId ?? null,
+    workflow?.runId ?? null,
+    workflow?.phase?.nodeId ?? null,
+    workflow?.phase?.attempt ?? null,
   );
 
   return {
@@ -389,8 +435,14 @@ export function createSession(opts: CreateSessionOpts & { prompt?: string; porta
     model: opts.model ?? null,
     title,
     parentSessionId: opts.parentSessionId ?? null,
+    workflowProvenance: workflow,
     effortLevel: opts.effortLevel ?? null,
     status: 'idle',
+    attemptOutcome: null,
+    attemptTerminalVersion: 0,
+    attemptTurn: 0,
+    attemptInterruptionCause: null,
+    attemptInterruptionTurn: null,
     totalCost: 0,
     totalTurns: 0,
     lastContextTokens: null,
@@ -428,6 +480,11 @@ export interface UpdateSessionFields {
   lastError?: string | null;
   title?: string;
   lastContextTokens?: number | null;
+  attemptOutcome?: SessionAttemptOutcome | null;
+  attemptTerminalVersion?: number;
+  attemptTurn?: number;
+  attemptInterruptionCause?: WorkflowAttemptInterruptionCause | null;
+  attemptInterruptionTurn?: number | null;
 }
 
 export function updateSession(id: string, updates: UpdateSessionFields): Session | undefined {
@@ -442,6 +499,26 @@ export function updateSession(id: string, updates: UpdateSessionFields): Session
   if (updates.engineSessionId !== undefined) {
     sets.push('engine_session_id = ?');
     values.push(updates.engineSessionId);
+  }
+  if (updates.attemptOutcome !== undefined) {
+    sets.push('attempt_outcome = ?');
+    values.push(updates.attemptOutcome);
+  }
+  if (updates.attemptTerminalVersion !== undefined) {
+    sets.push('attempt_terminal_version = ?');
+    values.push(updates.attemptTerminalVersion);
+  }
+  if (updates.attemptTurn !== undefined) {
+    sets.push('attempt_turn = ?');
+    values.push(updates.attemptTurn);
+  }
+  if (updates.attemptInterruptionCause !== undefined) {
+    sets.push('attempt_interruption_cause = ?');
+    values.push(updates.attemptInterruptionCause);
+  }
+  if (updates.attemptInterruptionTurn !== undefined) {
+    sets.push('attempt_interruption_turn = ?');
+    values.push(updates.attemptInterruptionTurn);
   }
   if (updates.status !== undefined) {
     sets.push('status = ?');
@@ -812,15 +889,15 @@ export interface QueueItem {
   completedAt: string | null;
 }
 
-export function enqueueQueueItem(sessionId: string, sessionKey: string, prompt: string): string {
+export function enqueueQueueItem(sessionId: string, sessionKey: string, prompt: string, opts: { internal?: boolean } = {}): string {
   const db = initDb();
   const id = randomUUID();
   const position = (db.prepare(
     "SELECT COALESCE(MAX(position), 0) + 1 as pos FROM queue_items WHERE session_key = ? AND status = 'pending'"
   ).get(sessionKey) as { pos: number }).pos;
   db.prepare(
-    "INSERT INTO queue_items (id, session_id, session_key, prompt, status, position, created_at) VALUES (?, ?, ?, ?, 'pending', ?, ?)"
-  ).run(id, sessionId, sessionKey, prompt, position, new Date().toISOString());
+    "INSERT INTO queue_items (id, session_id, session_key, prompt, status, position, created_at, internal) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)"
+  ).run(id, sessionId, sessionKey, prompt, position, new Date().toISOString(), opts.internal ? 1 : 0);
   return id;
 }
 
@@ -938,4 +1015,149 @@ export function deleteFile(id: string): boolean {
   const db = initDb();
   const result = db.prepare('DELETE FROM files WHERE id = ?').run(id);
   return result.changes > 0;
+}
+
+// --- Workflow attempt sessions (upstream port, adapted to the jimmy schema) ---
+
+const QUEUE_ITEM_WIRE_SELECT =
+  "SELECT id, session_id as sessionId, session_key as sessionKey, prompt, status, position, created_at as createdAt, started_at as startedAt, completed_at as completedAt FROM queue_items";
+
+type WorkflowAttemptSessionOpts = CreateSessionOpts & { prompt?: string; workflowProvenance: WorkflowSessionProvenance };
+
+function assertWorkflowAttemptSession(session: Session, opts: WorkflowAttemptSessionOpts, key: string): void {
+  const expected = opts.workflowProvenance;
+  const actual = session.workflowProvenance;
+  const sameOwner = expected.kind === 'phase' && expected.phase && actual?.kind === 'phase' && actual.phase
+    && actual.workflowId === expected.workflowId && actual.runId === expected.runId
+    && actual.phase.nodeId === expected.phase.nodeId && actual.phase.attempt === expected.phase.attempt;
+  if (!sameOwner) throw new Error(`Workflow attempt session key collision for ${key}.`);
+  if (session.sessionKey !== key || session.sourceRef !== key) throw new Error(`Workflow attempt session key mismatch for ${key}.`);
+  const expectedConfig = [opts.engine, opts.employee ?? null, opts.model ?? null, opts.effortLevel ?? null];
+  if ([session.engine, session.employee, session.model, session.effortLevel].some((value, index) => value !== expectedConfig[index])) {
+    throw new Error(`Workflow attempt session configuration mismatch for ${key}.`);
+  }
+}
+
+/** One session row per workflow attempt, found again after a crash by its
+ *  provenance rather than created twice. */
+export function getOrCreateWorkflowAttemptSession(opts: WorkflowAttemptSessionOpts): Session {
+  const database = initDb();
+  const workflow = opts.workflowProvenance;
+  const phase = workflow.kind === 'phase' ? workflow.phase : undefined;
+  if (!phase) throw new Error('Workflow attempt sessions require phase provenance.');
+  const key = opts.sessionKey ?? opts.sourceRef;
+  const getOrCreate = database.transaction(() => {
+    const rows = database.prepare(
+      `SELECT * FROM sessions WHERE session_key = ? OR (workflow_kind = 'phase' AND workflow_id = ? AND workflow_run_id = ? AND workflow_phase_node_id = ? AND workflow_phase_attempt = ?)`
+    ).all(key, workflow.workflowId, workflow.runId, phase.nodeId, phase.attempt) as Record<string, unknown>[];
+    if (rows.length > 1) throw new Error(`Workflow attempt session key collision for ${key}.`);
+    const existing = rows[0] ? rowToSession(rows[0]) : undefined;
+    if (!existing) return createSession(opts);
+    assertWorkflowAttemptSession(existing, opts, key);
+    return existing;
+  });
+  return getOrCreate.immediate();
+}
+
+/** Terminal interruption receipt. Only a live, unsettled attempt row takes it,
+ *  so a stop that raced a completion never rewrites what already settled. */
+export function interruptSessionAttempt(id: string, reason: string, completedAt: string): Session | undefined {
+  const result = initDb().prepare(`UPDATE sessions SET status = 'interrupted', attempt_outcome = 'interrupted',
+    attempt_terminal_version = 1, attempt_turn = attempt_turn + 1, last_activity = ?, last_error = ?,
+    attempt_interruption_cause = NULL, attempt_interruption_turn = NULL
+    WHERE id = ? AND workflow_kind = 'phase' AND attempt_outcome IS NULL AND attempt_terminal_version = 0`)
+    .run(completedAt, reason, id);
+  return result.changes === 1 ? getSession(id) : undefined;
+}
+
+export function listChildSessions(parentSessionId: string): Session[] {
+  const rows = initDb().prepare('SELECT * FROM sessions WHERE parent_session_id = ?')
+    .all(parentSessionId) as Record<string, unknown>[];
+  return rows.map(rowToSession);
+}
+
+/** Claim the one internal dispatch slot of an idle workflow attempt session.
+ *  Returns the queue item id to run under, or null when the slot is taken. */
+export function claimWorkflowAttemptDispatch(sessionId: string, sessionKey: string, prompt: string): string | null {
+  const db = initDb();
+  return db.transaction(() => {
+    const session = db.prepare(`SELECT id FROM sessions WHERE id = ? AND session_key = ?
+      AND workflow_kind = 'phase' AND status = 'idle'
+      AND (attempt_outcome IS NULL OR attempt_outcome = 'succeeded')`).get(sessionId, sessionKey);
+    if (!session) return null;
+    const existing = db.prepare(
+      `${QUEUE_ITEM_WIRE_SELECT} WHERE session_id = ? AND internal = 1 AND status IN ('pending', 'running') ORDER BY created_at, position LIMIT 1`
+    ).get(sessionId) as (QueueItem & { sessionKey: string }) | undefined;
+    if (existing && (existing.sessionKey !== sessionKey || existing.prompt !== prompt)) {
+      throw new Error(`Workflow session ${sessionId} dispatch claim does not match its immutable command.`);
+    }
+    if (existing?.status === 'running') return null;
+    return existing?.id ?? enqueueQueueItem(sessionId, sessionKey, prompt, { internal: true });
+  }).immediate();
+}
+
+export function cancelWorkflowAttemptDispatch(sessionId: string): number {
+  return initDb().prepare(
+    `UPDATE queue_items SET status = 'cancelled' WHERE session_id = ? AND internal = 1 AND status IN ('pending', 'running')`
+  ).run(sessionId).changes;
+}
+
+/** Pending internal dispatches whose attempt session can still run them —
+ *  what a restarting gateway replays. */
+export function listPendingWorkflowAttemptDispatches(): QueueItem[] {
+  return initDb().prepare(`${QUEUE_ITEM_WIRE_SELECT} WHERE status = 'pending' AND internal = 1
+    AND EXISTS (SELECT 1 FROM sessions WHERE sessions.id = queue_items.session_id
+      AND sessions.workflow_kind = 'phase' AND sessions.status = 'idle'
+      AND (sessions.attempt_outcome IS NULL OR sessions.attempt_outcome = 'succeeded'))
+    ORDER BY created_at, position`).all() as QueueItem[];
+}
+
+/** Record the engine-native session id an attempt should resume from. The
+ *  fork tracks one engineSessionId per session, so the record only lands when
+ *  the engine matches the session's own. */
+export function recordEngineSessionId(sessionId: string, engine: string, nativeId: string): Session | undefined {
+  const session = getSession(sessionId);
+  if (!session) return undefined;
+  if (session.engine !== engine) return session;
+  return updateSession(sessionId, { engineSessionId: nativeId }) ?? session;
+}
+
+/** Settle workflow attempts whose engine process was lost with the old gateway.
+ *  The `gateway-restart` cause is what lets the runtime replace the attempt
+ *  rather than spend its retry budget (see workflows/restart-redispatch.ts). */
+export function recoverStaleWorkflowAttemptSessions(): number {
+  const database = initDb();
+  const now = new Date().toISOString();
+  return database.transaction(() => {
+    database.prepare(`
+      UPDATE queue_items
+      SET status = 'cancelled'
+      WHERE internal = 1
+        AND status IN ('pending', 'running')
+        AND EXISTS (
+          SELECT 1
+          FROM sessions
+          WHERE sessions.id = queue_items.session_id
+            AND sessions.status = 'running'
+            AND sessions.workflow_kind = 'phase'
+            AND sessions.attempt_outcome IS NULL
+            AND sessions.attempt_terminal_version = 0
+        )
+    `).run();
+    return database.prepare(`
+      UPDATE sessions
+      SET status = 'interrupted',
+        attempt_outcome = 'interrupted',
+        attempt_terminal_version = 1,
+        attempt_turn = MAX(attempt_turn, 1),
+        attempt_interruption_cause = 'gateway-restart',
+        attempt_interruption_turn = MAX(attempt_turn, 1),
+        last_activity = ?,
+        last_error = 'Interrupted: gateway restarted while workflow attempt was running'
+      WHERE status = 'running'
+        AND workflow_kind = 'phase'
+        AND attempt_outcome IS NULL
+        AND attempt_terminal_version = 0
+    `).run(now).changes;
+  }).immediate();
 }

--- a/packages/jimmy/src/sessions/stop-nudge.ts
+++ b/packages/jimmy/src/sessions/stop-nudge.ts
@@ -1,0 +1,63 @@
+/**
+ * A turn that ends on narration has decided nothing: nothing submitted, no
+ * terminal claim, no block reported. Both surfaces that own tracked work — the
+ * workflow attempt and the delegated child — answer it the same way, with a
+ * bounded, counted nudge sent at that turn's own end. Each nudge is itself a
+ * turn, so the count is what closes the loop; after MAX_STOP_NUDGES the caller
+ * falls back to whatever it did before.
+ *
+ * What counts as narration differs by surface, because the evidence differs. A
+ * workflow attempt owns a submit tool and a fenced output block, so a turn that
+ * used neither has objectively delivered nothing and the text only has to fail
+ * to claim otherwise. A delegated child has no such tool — its reply IS the
+ * deliverable — so there the classifier keeps the delegation contract's
+ * fail-safe bias and fires only on an explicit continuation assertion. Both
+ * surfaces share the suppressors, the wording, and the budget.
+ */
+
+/** Two, so a model that narrates twice still gets one more chance to submit
+ *  before the surface stops talking and lets its own timeout logic run. */
+export const MAX_STOP_NUDGES = 2;
+
+export const STOP_NUDGE_TEXT =
+  "A plain-text reply is not a terminal state. Your linked Todo is still open and this turn ended on narration "
+  + "rather than on a result. Continue the work now and finish the deliverable, then submit it the way this task "
+  + "requires. If you cannot finish it, say plainly that you are blocked and what is blocking you. Do not end "
+  + "another turn on a promise of future action.";
+
+const EXPLICIT_UNFINISHED_SIGNAL = /\b(?:i(?: am|['’]m) still working (?:on|through)|i(?: will|['’]ll) continue (?:working\b|(?:with\s+)?(?:this|the|my)\s+(?:task|work|implementation|fix|patch|change|migration|feature|deliverable|test run)|with (?:the )?remaining (?:work|implementation|checks|tests?))|(?:(?:the|this|my)\s+)?(?:task|work|implementation|fix|patch|change|migration|feature|deliverable)\s+(?:is|remains)\s+(?:incomplete|still in progress)|not (?:done|finished|complete))\b/i;
+const TERMINAL_SIGNAL = /\b(final report|completed|complete|done|finished|shipped|implemented|resolved|all tests pass(?:ed)?|(?:tests?|checks?) (?:now )?pass(?:ed)?|ready for review|ready to merge|(?:the )?(?:pr|patch) (?:is )?ready|commit (?:sha|hash)|hand(?:-| )?off)\b/i;
+const PARENT_WAIT_SIGNAL = /\?|\b(need (?:your|the parent's) input|please confirm|which (?:option|approach)|should i|would you|let me know|blocked (?:on|by)|waiting on|awaiting (?:approval|confirmation|input)|waiting for (?:approval|confirmation|input|you|the parent)|(?:need|missing|without|awaiting) (?:the )?(?:credentials?|access|permissions?|api key|token|secret))\b/i;
+
+/** Whether this final text claims the work reached a terminal state. */
+function hasTerminalSignal(text: string): boolean {
+  return TERMINAL_SIGNAL.test(text.replace(/\bnot\s+(?:done|finished|complete)\b/gi, " "));
+}
+
+/** Whether this final text is a progress note and nothing more. */
+export function isNonTerminalNarration(text: string): boolean {
+  // Incidental mentions of work, running services, remaining items, or next
+  // steps are not evidence that the task remains unfinished. Without a submit
+  // tool to fall back on, the nudge requires a first-person continuation
+  // assertion, a task-bound incomplete/still-in-progress assertion, or explicit
+  // negated completion. Mixed terminal + unfinished clauses are ambiguous, and
+  // ambiguity surfaces to the parent rather than authorizing a nudge.
+  if (!EXPLICIT_UNFINISHED_SIGNAL.test(text)) return false;
+  return !hasTerminalSignal(text) && !PARENT_WAIT_SIGNAL.test(text);
+}
+
+/**
+ * Whether this turn end earns a stop nudge, given how many it has already had.
+ *
+ * The caller has already established that the turn submitted nothing, so the
+ * text cannot be asked to prove the work is unfinished — ordinary progress talk
+ * ("I am reviewing the remaining files now") is the whole case this exists for.
+ * It only has to leave the two claims a nudge would contradict unmade: that the
+ * work is done, and that the turn is waiting on an answer. An empty final text
+ * asserts neither but narrates nothing either, so it stays with the ladder.
+ */
+export function planStopNudge(input: { finalText: string; stopNudgesSent: number }): boolean {
+  const text = input.finalText.trim();
+  if (input.stopNudgesSent >= MAX_STOP_NUDGES || text.length === 0) return false;
+  return !hasTerminalSignal(text) && !PARENT_WAIT_SIGNAL.test(text);
+}

--- a/packages/jimmy/src/sessions/workflow-interruptions.ts
+++ b/packages/jimmy/src/sessions/workflow-interruptions.ts
@@ -1,0 +1,28 @@
+import type { Session, WorkflowAttemptInterruptionCause } from "../shared/types.js";
+
+export const USER_MESSAGE_INTERRUPTION_REASON = "Interrupted: new message received";
+
+/** Prefer the turn-fenced boundary marker; retain error matching for legacy rows. */
+export function workflowAttemptInterruptionCause(
+  error: string | null | undefined,
+  session?: Pick<Session, "attemptInterruptionCause" | "attemptInterruptionTurn">,
+  turn?: number,
+): WorkflowAttemptInterruptionCause {
+  if (
+    session?.attemptInterruptionCause
+    && session.attemptInterruptionTurn === turn
+  ) {
+    return session.attemptInterruptionCause;
+  }
+  return error === USER_MESSAGE_INTERRUPTION_REASON
+    ? "user-message"
+    : "attempt-stop";
+}
+
+export function isDurableWorkflowUserMessageInterruption(
+  session: Pick<Session, "attemptInterruptionCause" | "attemptInterruptionTurn">,
+  turn: number,
+): boolean {
+  return session.attemptInterruptionCause === "user-message"
+    && session.attemptInterruptionTurn === turn;
+}

--- a/packages/jimmy/src/shared/db.ts
+++ b/packages/jimmy/src/shared/db.ts
@@ -1,0 +1,15 @@
+/**
+ * Upstream-compat shim. Upstream jinn keeps one central sqlite handle in
+ * shared/db.ts (sessions included); this fork's sessions registry owns its own
+ * database. Upstream-authored tests import `initDb` from here to read the rows
+ * the code under test wrote — delegate so they see the same database.
+ *
+ * `__closeDbForTest` is a no-op: the registry keeps its handle for the process
+ * lifetime, and removing a temp test home works with the handle open on the
+ * POSIX platforms this fork targets.
+ */
+export { initDb } from "../sessions/registry.js";
+
+export function __closeDbForTest(): void {
+  /* no-op — see module note */
+}

--- a/packages/jimmy/src/shared/engine-failure.ts
+++ b/packages/jimmy/src/shared/engine-failure.ts
@@ -1,0 +1,130 @@
+/**
+ * What an engine's failure prose actually says.
+ *
+ * Three places used to answer this question with their own regex set — the
+ * rate-limit detector, the workflow retry boundary, and the respawn auth guard —
+ * and they disagreed with each other in ways that were load-bearing rather than
+ * accidental. "overloaded" is a quota window to one of them and an upstream
+ * fault to another, and both readings are correct: the provider is saying two
+ * things at once.
+ *
+ * So a classification here is a SET, not a verdict. This module says which
+ * signals the text carries; each consumer keeps its own reading of them.
+ */
+
+export type EngineFailureClass =
+  | "rate-limit"
+  | "quota"
+  | "provider-outage"
+  | "network"
+  | "auth-terminal"
+  | "invalid-model"
+  | "terminal";
+
+export interface EngineFailureClassification {
+  /** Every class the text carries. Ambiguous prose carries more than one. */
+  classes: ReadonlySet<EngineFailureClass>;
+  /** Unix seconds, and only when the engine stated a time itself. */
+  resetsAt?: number;
+}
+
+/** The account is out of allowance — a window that clears on its own clock. */
+const QUOTA_SIGNATURES: readonly RegExp[] = [
+  /usage.*limit/i,
+  /exceeded.*limit/i,
+  /out of extra usage/i,
+];
+
+/** The request was throttled. `overloaded` lives here AND in provider-outage:
+ *  the provider is refusing load, which reads as both to different callers. */
+const RATE_LIMIT_SIGNATURES: readonly RegExp[] = [
+  /rate.?limit/i,
+  /too many requests/i,
+  /429/,
+  /overloaded/i,
+];
+
+/**
+ * The provider itself is faulting. Fault codes are surfaced verbatim by the
+ * engines (e.g. the Claude PTY's "Interactive turn failed: server_error").
+ */
+const PROVIDER_OUTAGE_SIGNATURES: readonly RegExp[] = [
+  /\b(?:server_error|api_error)\b/i,
+  /overloaded/i,
+  // HTTP 5xx, but only in status context — a bare "503" in a diagnostic is not a
+  // status code, and matching one would misread a genuine failure as an outage.
+  /\b(?:HTTP|status)(?:\s+code)?\s*[:=]?\s*5\d\d\b/i,
+  /\b(?:bad gateway|service unavailable|gateway time-?out|internal server error)\b/i,
+];
+
+/** Socket and DNS faults from the fetch/PTY transport. */
+const NETWORK_SIGNATURES: readonly RegExp[] = [
+  /\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN)\b/,
+  /\b(?:socket hang up|fetch failed|network error)\b/i,
+];
+
+/** Errors no retry can fix, because the credentials themselves are the problem. */
+const AUTH_TERMINAL_SIGNATURES: readonly RegExp[] = [
+  /unauthori[sz]|unauthenticated|forbidden|\b401\b|\b403\b|invalid[ _-]?(api[ _-]?)?key|invalid[ _-]?token|expired[ _-]?(token|credential|session)|credential|authenticat|not logged in|please log in|oauth/i,
+];
+
+/**
+ * The engine refused the model id it was handed. Ours to fix, not the provider's
+ * verdict on the work: the id came from our config or from our own discovery, and
+ * the turn never ran.
+ */
+const INVALID_MODEL_SIGNATURES: readonly RegExp[] = [
+  /\b(?:invalid|unknown|unsupported) model\b/i,
+  /\bmodel[ _]not[ _]found\b/i,
+];
+
+const SIGNATURES: readonly (readonly [EngineFailureClass, readonly RegExp[]])[] = [
+  ["quota", QUOTA_SIGNATURES],
+  ["rate-limit", RATE_LIMIT_SIGNATURES],
+  ["provider-outage", PROVIDER_OUTAGE_SIGNATURES],
+  ["network", NETWORK_SIGNATURES],
+  ["auth-terminal", AUTH_TERMINAL_SIGNATURES],
+  ["invalid-model", INVALID_MODEL_SIGNATURES],
+];
+
+/**
+ * When an engine names the moment its window reopens, it says so in prose. The
+ * captured tail runs to the first real sentence break, so a following clause
+ * does not poison the parse — and a period inside a timestamp does not end it.
+ */
+const RESET_PROSE_RE = /(?:try again|retry|resets?)\s+(?:at|on)\s+([^;)\n]+?)(?=[;)\n]|\.(?:\s|$)|$)/i;
+
+function resetsAtFromProse(text: string): number | undefined {
+  const stated = RESET_PROSE_RE.exec(text)?.[1]?.trim();
+  if (!stated) return undefined;
+  const parsed = Date.parse(stated);
+  return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : undefined;
+}
+
+/**
+ * Every class the given failure text carries. `terminal` is present exactly when
+ * nothing else matched: an unrecognised failure is a verdict, not a maybe, and
+ * guessing generously spends real money on real failures.
+ */
+export function classifyEngineFailureText(
+  text: string | null | undefined,
+): EngineFailureClassification {
+  const classes = new Set<EngineFailureClass>();
+  if (typeof text !== "string" || !text) return { classes: new Set(["terminal"]) };
+
+  for (const [failureClass, signatures] of SIGNATURES) {
+    if (signatures.some((signature) => signature.test(text))) classes.add(failureClass);
+  }
+  if (classes.size === 0) classes.add("terminal");
+
+  const resetsAt = resetsAtFromProse(text);
+  return { classes, ...(resetsAt === undefined ? {} : { resetsAt }) };
+}
+
+/** Whether a classification carries any of the given classes. */
+export function hasEngineFailureClass(
+  classification: EngineFailureClassification,
+  ...classes: EngineFailureClass[]
+): boolean {
+  return classes.some((failureClass) => classification.classes.has(failureClass));
+}

--- a/packages/jimmy/src/shared/engine-fallback.ts
+++ b/packages/jimmy/src/shared/engine-fallback.ts
@@ -1,0 +1,195 @@
+import {
+  blankSourceProblem,
+  malformedSourceProblem,
+  malformedTargetProblem,
+  malformedTargetWarning,
+  mapNotAMappingProblem,
+  targetNotAModelIdProblem,
+  unservedTargetWarning,
+} from "./fallback-map-wire.js";
+import { logger } from "./logger.js";
+import { isSpellableModelId } from "./model-id.js";
+import { ENGINE_NAMES, isKnownEngine, type EngineName } from "./models.js";
+import type { JinnConfig, ModelRegistry } from "./types.js";
+
+const KNOWN_ENGINES = ENGINE_NAMES.join(", ");
+
+/**
+ * Problems with the `fallback` chains under an `engines` mapping (empty = valid).
+ * Unknown names and self-references are refused because a chain naming a typo would
+ * fail silently — it simply never fires — rather than loudly. Cycles across engines
+ * are deliberately accepted: they are how "either of these two" reads in config, and
+ * the runtime walker carries a visited set.
+ */
+export function validateEngineFallbackChains(engines: Record<string, unknown>): string[] {
+  const problems: string[] = [];
+
+  for (const name of ENGINE_NAMES) {
+    const section = engines[name];
+    if (typeof section !== "object" || section === null || Array.isArray(section)) continue;
+
+    const chain = (section as { fallback?: unknown }).fallback;
+    if (chain === undefined) continue;
+    if (!Array.isArray(chain)) {
+      problems.push(`engines.${name}.fallback must be a list of engine names (got ${typeof chain})`);
+      continue;
+    }
+
+    chain.forEach((entry, index) => {
+      if (typeof entry !== "string") {
+        problems.push(`engines.${name}.fallback[${index}] must be a string (got ${typeof entry})`);
+      } else if (entry === name) {
+        problems.push(`engines.${name}.fallback must not name ${name} itself`);
+      } else if (!isKnownEngine(entry)) {
+        problems.push(`engines.${name}.fallback[${index}] "${entry}" is not a known engine (${KNOWN_ENGINES})`);
+      }
+    });
+  }
+
+  return problems;
+}
+
+/** A YAML mapping, as opposed to a scalar, a list, or a key left with no value. */
+function isYamlMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Problems with the entries of one engine's map, which is already a mapping. */
+function modelMapEntryProblems(engine: string, map: Record<string, unknown>): string[] {
+  const problems: string[] = [];
+
+  for (const [from, to] of Object.entries(map)) {
+    // YAML hands every key over as a string, so a blank one is the only way to
+    // write a key with no id in it at all — and a control character is the only
+    // way to write one that LOOKS like an id and can never match.
+    if (!from.trim()) {
+      problems.push(blankSourceProblem(engine));
+    } else if (!isSpellableModelId(from)) {
+      problems.push(malformedSourceProblem(engine, from));
+    }
+    if (typeof to !== "string" || !to.trim()) {
+      problems.push(targetNotAModelIdProblem(engine, from, to));
+    } else if (!isSpellableModelId(to)) {
+      problems.push(malformedTargetProblem(engine, from, to));
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Problems with the `fallbackModelMap` tables under an `engines` mapping (empty = valid).
+ * The map is read with the pinned model as the key at the moment of a swap, so an entry
+ * that is not a model id on both sides is one that can never match — refused here rather
+ * than left to look like a mapping that simply never fires.
+ */
+export function validateEngineFallbackModelMaps(engines: Record<string, unknown>): string[] {
+  const problems: string[] = [];
+
+  for (const name of ENGINE_NAMES) {
+    const section = engines[name];
+    if (!isYamlMapping(section)) continue;
+
+    const map = section.fallbackModelMap;
+    if (map === undefined) continue;
+    if (!isYamlMapping(map)) {
+      problems.push(mapNotAMappingProblem(name, map));
+      continue;
+    }
+
+    problems.push(...modelMapEntryProblems(name, map));
+  }
+
+  return problems;
+}
+
+/**
+ * The model a turn should run on once its engine has been substituted.
+ *
+ * `undefined` is the floor rule and the default answer: drop the pin, let the
+ * substitute's own configured default apply. A model id belongs to exactly one
+ * provider, so carrying one across a swap is how a codex pin reached Anthropic and
+ * came back `model_not_found`. `engines.<from>.fallbackModelMap` is the only way a
+ * pin survives — and only when the substitute actually serves what the map names,
+ * because a map that could name anything would just spell the same bug in config.
+ * An entry validation never saw, because it predates the check or was written by
+ * hand, is refused here too rather than handed to a CLI as an argv.
+ */
+export function resolveSubstituteModel(
+  config: JinnConfig,
+  registry: ModelRegistry,
+  { from, to, model }: { from: string; to: string; model: string | null | undefined },
+): string | undefined {
+  if (!model) return undefined;
+
+  const mapped = config.engines[from as EngineName]?.fallbackModelMap?.[model];
+  if (!mapped) return undefined;
+  if (!isSpellableModelId(mapped)) {
+    logger.warn(malformedTargetWarning({ engine: from, model, target: mapped, substitute: to }));
+    return undefined;
+  }
+  if (registry[to]?.models.some((candidate) => candidate.id === mapped)) return mapped;
+
+  logger.warn(unservedTargetWarning({ engine: from, model, target: mapped, substitute: to }));
+  return undefined;
+}
+
+// Warn once per mapped engine: loadConfig() runs again on every config hot-reload, so
+// one legacy config would otherwise repeat itself through the whole gateway lifetime.
+const warnedLegacyFallbackEngines = new Set<string>();
+
+/**
+ * Map the deprecated `sessions.rateLimitStrategy: "fallback"` / `sessions.fallbackEngine`
+ * pair onto `engines.claude.fallback`, in place. An explicit chain always wins, an
+ * explicit empty one included — that is an operator saying "no fallback" in the current
+ * spelling. Both legacy keys are left on the config so whatever still reads them keeps
+ * behaving exactly as it did.
+ */
+export function applyLegacyFallbackMigration(
+  config: JinnConfig,
+  warn: (message: string) => void = console.warn,
+): void {
+  if (config.sessions?.rateLimitStrategy !== "fallback") return;
+  if (config.engines.claude.fallback !== undefined) return;
+
+  const engine: EngineName = config.sessions.fallbackEngine ?? "codex";
+  config.engines.claude.fallback = [engine];
+
+  if (warnedLegacyFallbackEngines.has(engine)) return;
+  warnedLegacyFallbackEngines.add(engine);
+  warn(
+    `sessions.rateLimitStrategy and sessions.fallbackEngine are deprecated — ` +
+      `write engines.claude.fallback: [${engine}] instead.`,
+  );
+}
+
+function fallbackChain(config: JinnConfig, engine: string): EngineName[] {
+  return config.engines[engine as EngineName]?.fallback ?? [];
+}
+
+/**
+ * The first engine in `from`'s chain that `isUsable` accepts, continuing through the
+ * chain of every engine it rejects. What "usable" means belongs to the caller — the
+ * session runtime asks for registered and installed.
+ *
+ * The visited set is what makes the cycles the validator deliberately allows safe, and
+ * it holds `from` from the start so the engine that just failed is never its own answer.
+ */
+export function resolveFallbackEngine(
+  config: JinnConfig,
+  from: string,
+  isUsable: (engine: EngineName) => boolean,
+): EngineName | null {
+  const visited = new Set<string>([from]);
+  const queue = [...fallbackChain(config, from)];
+
+  for (let i = 0; i < queue.length; i++) {
+    const candidate = queue[i];
+    if (visited.has(candidate)) continue;
+    visited.add(candidate);
+    if (isUsable(candidate)) return candidate;
+    queue.push(...fallbackChain(config, candidate));
+  }
+
+  return null;
+}

--- a/packages/jimmy/src/shared/engine-health.ts
+++ b/packages/jimmy/src/shared/engine-health.ts
@@ -1,0 +1,239 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveFallbackEngine } from "./engine-fallback.js";
+import type { EngineName } from "./models.js";
+import { JINN_HOME } from "./paths.js";
+import type { EngineLimitWindow, JinnConfig, ModelRegistry } from "./types.js";
+
+/**
+ * Whether an engine can actually serve a turn, beside the installed-availability
+ * the model registry reports.
+ *
+ * Advisory by construction, and every part of that is deliberate: reads and
+ * writes swallow their own errors, every record carries the moment it stops
+ * being true, and both dispatchers walk their chain again without health when
+ * health would have left them nothing. The worst a wrong record can do is order
+ * a chain differently — it can never refuse a turn.
+ */
+
+export type EngineHealthState = "ok" | "exhausted" | "degraded";
+
+export interface EngineHealth {
+  state: EngineHealthState;
+  /** ISO. The reopening the engine itself stated, verbatim: what every display
+   *  surface shows, and the moment the record is spent. */
+  until?: string;
+  /** ISO. When a dispatcher may offer the engine a probing turn again, on an
+   *  `exhausted` record. Internal — a shorter belief than `until`, never a
+   *  shorter claim, so it is deliberately not displayed anywhere. */
+  recheckAt?: string;
+  /** The binding quota window as telemetry names it (`5h`, `7d`), when it does. */
+  window?: string;
+  reason?: string;
+  observedAt?: string;
+}
+
+/** Live readings keyed by engine name. An engine with no entry is healthy. */
+export type EngineHealthReading = Record<string, EngineHealth>;
+
+const STATE_PATH = path.join(JINN_HOME, "tmp", "engine-health.json");
+
+/** How long a stated reopening is taken on trust before the engine is offered a
+ *  probing turn regardless. A weekly window is real and is displayed as stated;
+ *  a misparse that reads as one still self-corrects inside this. */
+const REPROBE_INTERVAL_MS = 12 * 60 * 60_000;
+
+/** How long a failure that stated no reopening stays on the record. It says the
+ *  provider just refused a turn, which is worth a brief preference away and is
+ *  not worth believing for an afternoon. */
+const DEGRADED_WINDOW_MS = 15 * 60_000;
+
+const HEALTH_STATES: readonly string[] = ["ok", "exhausted", "degraded"];
+
+function readStore(): EngineHealthReading {
+  try {
+    if (!fs.existsSync(STATE_PATH)) return {};
+    const parsed = JSON.parse(fs.readFileSync(STATE_PATH, "utf-8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const store: EngineHealthReading = {};
+    for (const [engine, record] of Object.entries(parsed as Record<string, EngineHealth | null>)) {
+      if (record && typeof record === "object" && HEALTH_STATES.includes(record.state)) store[engine] = record;
+    }
+    return store;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: EngineHealthReading): void {
+  try {
+    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+    const tmp = `${STATE_PATH}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(store, null, 2), "utf-8");
+    fs.renameSync(tmp, STATE_PATH);
+  } catch {
+    // best-effort only
+  }
+}
+
+/**
+ * Whether a record has outlived what it stated. Expiry is what the clock says
+ * rather than what a sweeper got around to, so a record can never outlive its
+ * own window — and an `until` that will not parse counts as spent, because
+ * fail-open is the only safe direction for advice.
+ */
+function isSpent(record: EngineHealth, now: Date): boolean {
+  if (record.state === "ok") return true;
+  if (record.until === undefined) return false;
+  const until = Date.parse(record.until);
+  return !Number.isFinite(until) || until <= now.getTime();
+}
+
+/** Every engine something has been observed about, with a record whose window
+ *  has passed reading back as `ok`. */
+export function readEngineHealth(now: Date = new Date()): EngineHealthReading {
+  const live: EngineHealthReading = {};
+  for (const [engine, record] of Object.entries(readStore())) {
+    live[engine] = isSpent(record, now)
+      ? { state: "ok", ...(record.observedAt ? { observedAt: record.observedAt } : {}) }
+      : record;
+  }
+  return live;
+}
+
+/** The one question a dispatcher asks, and the only reader of `recheckAt`: past
+ *  the re-probe the engine is offered a turn again even though the record still
+ *  reads — and still displays — as out until its stated reset.
+ *
+ *  `degraded` is deliberately not an answer to it: an engine that named no
+ *  reopening is a preference, never a reason to hold a turn back. A record from
+ *  before re-probes existed carries no `recheckAt` and blocks until `until`,
+ *  which is what it meant when it was written. */
+export function isEngineExhausted(health: EngineHealthReading, engine: string, now: Date = new Date()): boolean {
+  const record = health[engine];
+  if (record?.state !== "exhausted") return false;
+  if (record.recheckAt === undefined) return true;
+  const recheckAt = Date.parse(record.recheckAt);
+  return Number.isFinite(recheckAt) && recheckAt > now.getTime();
+}
+
+/** The record still inside the window it stated, if there is one. What a failed
+ *  re-probe is allowed to keep, rather than replace with a vaguer claim. */
+function liveRecord(store: EngineHealthReading, engine: string, now: Date): EngineHealth | undefined {
+  const record = store[engine];
+  return record && !isSpent(record, now) ? record : undefined;
+}
+
+/** When the engine may be probed again: its stated reopening when that is
+ *  nearer, otherwise the re-probe interval. */
+function recheckFrom(statedMs: number | undefined, now: Date): string {
+  const reprobeAt = now.getTime() + REPROBE_INTERVAL_MS;
+  return new Date(statedMs === undefined ? reprobeAt : Math.min(statedMs, reprobeAt)).toISOString();
+}
+
+/**
+ * Note that an engine could not serve a turn, given whatever it said about when
+ * it can again.
+ *
+ * A stated reopening is stored verbatim and is `exhausted` until then. Silence
+ * is `degraded`, because a failure that named no end says nothing about when to
+ * stop believing it — but silence from an engine already out until a stated
+ * reset is a failed re-probe, and that replaces neither the state nor the
+ * reopening it already stated. A re-probe only ever moves the next re-probe.
+ */
+export function recordEngineUnavailable(
+  engine: string,
+  reason: string,
+  resetsAtSeconds?: number,
+  now: Date = new Date(),
+  window?: string,
+): void {
+  const stated = resetsAtSeconds !== undefined && Number.isFinite(resetsAtSeconds)
+    ? resetsAtSeconds * 1000
+    : undefined;
+  const store = readStore();
+  const observed = { reason, observedAt: now.toISOString(), ...(window === undefined ? {} : { window }) };
+  const live = stated === undefined ? liveRecord(store, engine, now) : undefined;
+
+  let record: EngineHealth;
+  if (stated !== undefined) {
+    record = { state: "exhausted", until: new Date(stated).toISOString(), recheckAt: recheckFrom(stated, now) };
+  } else if (live?.state === "exhausted") {
+    const statedOnRecord = live.until === undefined ? undefined : Date.parse(live.until);
+    record = { ...live, recheckAt: recheckFrom(statedOnRecord, now) };
+  } else {
+    record = { state: "degraded", until: new Date(now.getTime() + DEGRADED_WINDOW_MS).toISOString() };
+  }
+  writeStore({ ...store, [engine]: { ...record, ...observed } });
+}
+
+/**
+ * The same fact a failed turn would have carried, minus the failed turn: a quota
+ * window the provider itself reports as fully spent. When several are spent the
+ * engine is back only once the last of them reopens.
+ */
+export function recordExhaustedWindows(
+  engine: string,
+  windows: readonly EngineLimitWindow[] | undefined,
+  now: Date = new Date(),
+): void {
+  let binding: EngineLimitWindow | undefined;
+  let reopensAt = 0;
+  for (const window of windows ?? []) {
+    if ((window.usedPercent ?? 0) < 100) continue;
+    const resetsAt = window.resetsAt ?? 0;
+    if (resetsAt * 1000 <= now.getTime() || resetsAt <= reopensAt) continue;
+    reopensAt = resetsAt;
+    binding = window;
+  }
+  if (binding) recordEngineUnavailable(engine, "quota window spent", binding.resetsAt, now, binding.name);
+}
+
+/**
+ * The first engine in `from`'s chain that can take the turn: one the caller
+ * accepts AND whose allowance has not run out.
+ *
+ * A chain the health filter empties is walked again without it. Installed
+ * availability stays the only hard gate, so a record that has gone stale can
+ * reorder a chain but can never empty one the caller would have accepted.
+ */
+export function resolveHealthyFallbackEngine(
+  config: JinnConfig,
+  from: string,
+  isUsable: (engine: EngineName) => boolean,
+  health: EngineHealthReading,
+): EngineName | null {
+  return resolveFallbackEngine(config, from, (engine) => isUsable(engine) && !isEngineExhausted(health, engine))
+    ?? resolveFallbackEngine(config, from, isUsable);
+}
+
+/**
+ * The engine a NEW session should start on, given the one it prefers.
+ *
+ * Only ever asked about a preference the caller did not state outright — an
+ * engine named in the request runs, spent allowance or not. Ordering, never
+ * refusal: when nothing left in the chain can serve either, the preference is
+ * handed straight back and the session starts exactly where it would have.
+ */
+export function preferHealthySessionEngine(
+  config: JinnConfig,
+  preferred: EngineName,
+  isUsable: (engine: EngineName) => boolean,
+  health: EngineHealthReading,
+): EngineName {
+  if (!isEngineExhausted(health, preferred)) return preferred;
+  return resolveFallbackEngine(config, preferred, (engine) => isUsable(engine) && !isEngineExhausted(health, engine))
+    ?? preferred;
+}
+
+/** The registry as an API consumer reads it: installed availability from the
+ *  registry, the live reading beside it. */
+export function withEngineHealth(
+  registry: ModelRegistry,
+): Record<string, ModelRegistry[string] & { health: EngineHealth }> {
+  const health = readEngineHealth();
+  return Object.fromEntries(Object.entries(registry).map(([name, entry]) => [
+    name,
+    { ...entry, health: health[name] ?? { state: "ok" as const } },
+  ]));
+}

--- a/packages/jimmy/src/shared/fallback-map-wire.ts
+++ b/packages/jimmy/src/shared/fallback-map-wire.ts
@@ -1,0 +1,103 @@
+/**
+ * The sentences an `engines.<name>.fallbackModelMap` problem is reported in.
+ *
+ * Two surfaces have to say the same thing about the same broken entry: the config
+ * loader, refusing a file that is already on disk, and the Settings model-map
+ * editor, refusing a save before that file is ever written. An operator who reads
+ * one and then the other must not have to work out that they are the same problem,
+ * so the sentence is written once here and both sides render it.
+ *
+ * This module is a pure leaf on purpose — no imports at all. `packages/web` aliases
+ * it as `@jinn/fallback-map-wire` and bundles it for real (unlike `@jinn/workflow-wire`,
+ * which is types-only and never resolves at build time), so anything reachable from
+ * here would have to survive Rollup with no Node polyfills. Keeping the import list
+ * empty is what makes that safe rather than merely true today.
+ */
+
+/** The config path an operator edits to fix a whole map. */
+export function modelMapPath(engine: string): string {
+  return `engines.${engine}.fallbackModelMap`;
+}
+
+/** The config path of one entry within a map, keyed the way YAML spells it. */
+export function modelMapEntryPath(engine: string, model: string): string {
+  return `${modelMapPath(engine)}["${model}"]`;
+}
+
+/** What a config value turned out to be, phrased for the operator reading the error. */
+export function shapeOf(value: unknown): string {
+  if (value === null) return "null";
+  return Array.isArray(value) ? "array" : typeof value;
+}
+
+/** The map itself is a scalar or a list where a mapping belongs. */
+export function mapNotAMappingProblem(engine: string, value: unknown): string {
+  return `${modelMapPath(engine)} must be a mapping of model id to model id (got ${shapeOf(value)})`;
+}
+
+/** A key that is not a model id. YAML hands every key over as a string, so the
+ *  only way to write a non-id key is to leave it blank. */
+export function blankSourceProblem(engine: string): string {
+  return `${modelMapPath(engine)} has a blank model id as a key`;
+}
+
+/** A key carrying a character no model id has — a discovery line pasted whole. */
+export function malformedSourceProblem(engine: string, model: string): string {
+  return `${modelMapPath(engine)} has a key that is not a model id (got ${JSON.stringify(model)})`;
+}
+
+/** The value side of one entry is not a model id. */
+export function targetNotAModelIdProblem(engine: string, model: string, value: unknown): string {
+  return `${modelMapEntryPath(engine, model)} must be a nonempty model id (got ${shapeOf(value)})`;
+}
+
+/** The value side of one entry carries one. `shapeOf` cannot say this: a
+ *  tab-joined `id\tlabel` composite is a perfectly nonempty string. */
+export function malformedTargetProblem(engine: string, model: string, value: string): string {
+  return (
+    `${modelMapEntryPath(engine, model)} must be a model id with no control characters ` +
+    `(got ${JSON.stringify(value)})`
+  );
+}
+
+/** One entry, named the way both the loader and the editor need to talk about it. */
+export interface UnservedTarget {
+  /** The engine whose map holds the entry. */
+  engine: string;
+  /** The model id the entry keys on — the pin that was set when the swap happened. */
+  model: string;
+  /** The model id the entry names. */
+  target: string;
+  /** The engine standing in, which does not serve `target`. */
+  substitute: string;
+}
+
+/**
+ * An entry that can never fire: the engine taking the turn over does not serve the
+ * model the map names for it. The editor renders this verbatim beside the row and
+ * refuses the save; the runtime appends what it does instead, below.
+ */
+export function unservedTargetProblem({ engine, model, target, substitute }: UnservedTarget): string {
+  return (
+    `${modelMapEntryPath(engine, model)} maps to "${target}", ` +
+    `which engine "${substitute}" does not serve`
+  );
+}
+
+/** The same problem, found at swap time rather than at save time, so it also says
+ *  which model the turn ends up on. */
+export function unservedTargetWarning(entry: UnservedTarget): string {
+  return `${unservedTargetProblem(entry)} — running ${entry.substitute} on its own default model instead.`;
+}
+
+/**
+ * The same entry found at swap time. The map is the fault here, not the CLI that
+ * refused the argv, so the sentence names the file the operator edits — the
+ * incident this guards against was read as an antigravity failure for an hour.
+ */
+export function malformedTargetWarning({ engine, model, target, substitute }: UnservedTarget): string {
+  return (
+    `${modelMapEntryPath(engine, model)} in config.yaml maps to ${JSON.stringify(target)}, ` +
+    `which is not a model id — running ${substitute} on its own default model instead.`
+  );
+}

--- a/packages/jimmy/src/shared/model-id.ts
+++ b/packages/jimmy/src/shared/model-id.ts
@@ -1,0 +1,21 @@
+/**
+ * What a model id may be spelled with.
+ *
+ * An id is compared verbatim against what an engine's CLI accepts, so there is no
+ * useful universal rule about its shape — antigravity serves `Gemini 3.5 Flash
+ * (Medium)`, spaces and parentheses included. What there IS a rule about is the
+ * characters no id has and a MANGLED one carries: `agy models` began printing
+ * `id<TAB>label`, the parser kept the whole line, and that composite was handed to
+ * `--model` and written into config as if it were an id.
+ *
+ * A control character is the tell. Nothing else here can separate a good id from a
+ * bad one without asking the CLI, and by then the turn has already failed.
+ */
+
+/** ASCII controls and DEL. Tab is the one that arrived live; the rest travel the same way. */
+const CONTROL_CHARACTER_RE = /[\x00-\x1f\x7f]/;
+
+/** Whether a string can be a model id at all: nonempty, and no control character. */
+export function isSpellableModelId(value: string): boolean {
+  return value.trim().length > 0 && !CONTROL_CHARACTER_RE.test(value);
+}

--- a/packages/jimmy/src/shared/models.ts
+++ b/packages/jimmy/src/shared/models.ts
@@ -16,8 +16,12 @@ import type {
  */
 
 /** Engines registered in this build (mirrors server.ts engine map). */
-const ENGINE_NAMES = ["claude", "codex", "gemini"] as const;
-type EngineName = (typeof ENGINE_NAMES)[number];
+export const ENGINE_NAMES = ["claude", "codex", "gemini"] as const;
+export type EngineName = (typeof ENGINE_NAMES)[number];
+
+export function isKnownEngine(engine: string): engine is EngineName {
+  return (ENGINE_NAMES as readonly string[]).includes(engine);
+}
 
 const EFFORT_MECHANISM: Record<EngineName, EffortMechanism> = {
   claude: "claude-flag",

--- a/packages/jimmy/src/shared/paths.ts
+++ b/packages/jimmy/src/shared/paths.ts
@@ -53,15 +53,14 @@ function resolveHome(): string {
  */
 export const JINN_HOME = resolveHome();
 
-// Fail closed if a test run resolves to a real, non-temp home. Vitest sets
-// VITEST in every worker; a suite that reaches here without the global-setup
-// redirect would silently read and WRITE the production registry.
-if (process.env.VITEST && (
-  JINN_HOME === path.join(os.homedir(), ".ryoko") || JINN_HOME === path.join(os.homedir(), ".jinn")
-)) {
+// Fail closed if a test run resolves into the user's home directory at all —
+// that covers ~/.ryoko, ~/.jinn, and every custom instance home (TBCare-style
+// installs included). Vitest sets VITEST in every worker; a legitimate test
+// home always lives under the OS temp directory.
+if (process.env.VITEST && (JINN_HOME === os.homedir() || JINN_HOME.startsWith(os.homedir() + path.sep))) {
   throw new Error(
-    `Test run resolved JINN_HOME to the real home (${JINN_HOME}). `
-    + "The vitest globalSetup must redirect RYOKO_HOME to a temp directory before any import.",
+    `Test run resolved JINN_HOME inside the real home directory (${JINN_HOME}). `
+    + "The vitest globalSetup must redirect JINN_HOME to a temp directory before any import.",
   );
 }
 

--- a/packages/jimmy/src/shared/paths.ts
+++ b/packages/jimmy/src/shared/paths.ts
@@ -52,8 +52,27 @@ function resolveHome(): string {
  * installs and after the one-time migration above.
  */
 export const JINN_HOME = resolveHome();
+
+// Fail closed if a test run resolves to a real, non-temp home. Vitest sets
+// VITEST in every worker; a suite that reaches here without the global-setup
+// redirect would silently read and WRITE the production registry.
+if (process.env.VITEST && (
+  JINN_HOME === path.join(os.homedir(), ".ryoko") || JINN_HOME === path.join(os.homedir(), ".jinn")
+)) {
+  throw new Error(
+    `Test run resolved JINN_HOME to the real home (${JINN_HOME}). `
+    + "The vitest globalSetup must redirect RYOKO_HOME to a temp directory before any import.",
+  );
+}
+
+/** Upstream-parity alias: resolve the (possibly overridden) home directory. */
+export function resolveJinnHome(): string {
+  return resolveHome();
+}
 export const CONFIG_PATH = path.join(JINN_HOME, "config.yaml");
 export const SESSIONS_DB = path.join(JINN_HOME, "sessions", "registry.db");
+export const WORKFLOWS_DIR = path.join(JINN_HOME, "workflows");
+export const WORKFLOWS_DB_PATH = path.join(WORKFLOWS_DIR, "workflows.db");
 export const CRON_JOBS = path.join(JINN_HOME, "cron", "jobs.json");
 export const CRON_RUNS = path.join(JINN_HOME, "cron", "runs");
 export const UPDATE_STATE = path.join(JINN_HOME, "updates", "state.json");

--- a/packages/jimmy/src/shared/rateLimit.ts
+++ b/packages/jimmy/src/shared/rateLimit.ts
@@ -1,4 +1,14 @@
 import type { EngineResult } from "./types.js";
+import { classifyEngineFailureText, hasEngineFailureClass } from "./engine-failure.js";
+
+/** Whether error text reads as a quota window rather than a fault. Engine
+ *  results are one caller; a settled attempt's stored error is the other, and
+ *  both have to reach the same verdict or the same outage reads two ways.
+ *
+ *  Throttling and allowance are one verdict here: the caller waits either way. */
+export function isRateLimitMessage(text: string | null | undefined): boolean {
+  return hasEngineFailureClass(classifyEngineFailureText(text), "rate-limit", "quota");
+}
 
 const RATE_LIMIT_ERROR_RE =
   /rate.?limit|too many requests|429|overloaded|usage.*limit|exceeded.*limit|out of extra usage/i;

--- a/packages/jimmy/src/shared/test-support/posix-mode.ts
+++ b/packages/jimmy/src/shared/test-support/posix-mode.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import { expect } from "vitest";
+
+/** Windows has no POSIX permission bits. fs.chmod there only toggles the
+ *  read-only attribute, so a file written with mode 0o600 reports 0o666 and a
+ *  directory reports 0o777 — every owner-only assertion fails for a reason the
+ *  code cannot fix.
+ *
+ *  IMPORTANT: this is a gap in the platform, not only in the tests. Files Jinn
+ *  intends to be owner-only (gateway tokens, pairing challenges, per-session MCP
+ *  configs carrying capabilities, instance keys) are NOT restricted on Windows;
+ *  achieving that needs ACLs, which Jinn does not set today. Skipping the
+ *  assertion keeps the suite honest on Windows without implying the property
+ *  holds there. */
+export const POSIX_MODES_SUPPORTED = process.platform !== "win32";
+
+/** Assert permission bits, where the platform can express them. Accepts a path
+ *  or an already-taken Stats, so call sites read the way they did before. */
+export function expectPosixMode(target: string | fs.Stats, expected: number): void {
+  if (!POSIX_MODES_SUPPORTED) return;
+  const stats = typeof target === "string" ? fs.statSync(target) : target;
+  expect(stats.mode & 0o777).toBe(expected);
+}

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -158,6 +158,40 @@ export interface Target {
   replyContext?: ReplyContext;
 }
 
+// --- Workflow attempt contract (ported from upstream jinn) ---
+
+export type SessionAttemptOutcome = "succeeded" | "failed" | "interrupted";
+export type WorkflowAttemptInterruptionCause = "user-message" | "attempt-stop" | "gateway-restart";
+export interface WorkflowAttemptContinuation { engine: string; engineSessionId: string; sourceSessionId: string }
+export interface WorkflowAttemptCommand { owner: { workflowId: string; runId: string; nodeId: string; attempt: number }; employeeId: string; engine: string; model?: string; effort?: "low" | "medium" | "high" | "xhigh"; prompt: string; continueFrom?: WorkflowAttemptContinuation }
+export interface WorkflowAttemptCompletion { sessionId: string; owner: { workflowId: string; runId: string; nodeId: string; attempt: number }; turn: number; terminalVersion: number; outcome: "succeeded" | "failed" | "interrupted"; interruptionCause?: WorkflowAttemptInterruptionCause; finalText?: string; error?: string; completedAt: string }
+export type WorkflowAttemptCompletionListener = (event: WorkflowAttemptCompletion) => void | Promise<void>;
+export interface WorkflowSessionExecutor {
+  startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }>;
+  stopAttempt(input: { sessionId: string; reason: string }): Promise<void>;
+  remind(input: { sessionId: string; text: string }): Promise<void>;
+  attemptState(sessionId: string): { idle: boolean; runningChildren: number } | null;
+}
+
+/** Durable attribution for a workflow-owned employee attempt session. */
+export interface WorkflowSessionProvenance {
+  kind: "phase";
+  workflowId: string;
+  /** Canonical agent-facing workflow name (definition.name, falling back to id). */
+  workflowName: string;
+  runId: string;
+  /** Uniform workflow trigger source: manual, schedule, event-webhook, etc. */
+  triggerSource: string;
+  phase: {
+    nodeId: string;
+    name: string;
+    /** One-based position in the run's frozen execution order. */
+    index: number;
+    round: number;
+    attempt: number;
+  };
+}
+
 export interface Session {
   id: string;
   engine: string;
@@ -173,7 +207,19 @@ export interface Session {
   model: string | null;
   title: string | null;
   parentSessionId: string | null;
+  /** Explicit workflow/run/phase attribution for grouping and filtered reads. */
+  workflowProvenance?: WorkflowSessionProvenance | null;
   status: "idle" | "running" | "error" | "waiting" | "interrupted";
+  /** Durable terminal receipt for the latest execution attempt. Conversational
+   * `idle` alone is never proof that work completed successfully. */
+  attemptOutcome?: SessionAttemptOutcome | null;
+  /** Monotonic terminal-receipt version within the current attempt generation. */
+  attemptTerminalVersion?: number;
+  /** Monotonic count of completed turns in a workflow attempt session. */
+  attemptTurn?: number;
+  /** Durable interruption classification recorded before an engine is killed. */
+  attemptInterruptionCause?: WorkflowAttemptInterruptionCause | null;
+  attemptInterruptionTurn?: number | null;
   effortLevel: string | null;
   totalCost: number;
   totalTurns: number;
@@ -505,6 +551,17 @@ export interface PortalConfig {
   operatorSlackId?: string;
 }
 
+// --- Engine quota/limit snapshots ---
+
+export interface EngineLimitWindow {
+  name: string;
+  usedPercent?: number;
+  windowDurationMins?: number;
+  /** Unix timestamp in seconds. */
+  resetsAt?: number;
+  resetsAtIso?: string;
+}
+
 // --- Model + capability registry ---
 // Single source of truth for which engines/models exist and what they support.
 // Shipping a NEW model is a config edit (`models:` block in config.yaml), zero
@@ -596,13 +653,24 @@ export interface JinnConfig {
        *  Default 5400000 (90 min) — accommodates long autonomous batch runs that
        *  legitimately occupy one turn (e.g. the seminar-demo generator). */
       interactiveTurnTimeoutMs?: number;
+      /** Ordered engine names to try when this engine is unavailable (upstream chain spec). */
+      fallback?: ("claude" | "codex" | "gemini")[];
+      /** Pinned-model → substitute-model map applied when swapping engines. */
+      fallbackModelMap?: Record<string, string>;
     };
-    codex: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string };
-    gemini?: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string };
+    codex: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string; fallback?: ("claude" | "codex" | "gemini")[]; fallbackModelMap?: Record<string, string> };
+    gemini?: { bin: string; model: string; effortLevel?: string; childEffortOverride?: string; fallback?: ("claude" | "codex" | "gemini")[]; fallbackModelMap?: Record<string, string> };
   };
   /** Optional model/capability registry override. Absent → synthesized from
    *  `engines.<name>.model`. See shared/models.ts. */
   models?: ModelsConfig;
+  /** Workflow engine (ported from upstream jinn). Opt-in: absent/false = no
+   *  workflow service, no schedule arming, no workflow API. */
+  workflows?: {
+    enabled?: boolean;
+    /** Canonical git remote/branch a landing-evidence check verifies against. */
+    delivery?: { remote?: string; branch?: string };
+  };
   connectors: Record<string, any> & {
     web?: WebConnectorConfig;
     slack?: SlackConnectorConfig;

--- a/packages/jimmy/src/work-items/claims.ts
+++ b/packages/jimmy/src/work-items/claims.ts
@@ -1,0 +1,15 @@
+/** work-items shim — refuse every Todo claim so no dispatch can ride a Todo
+ *  that OpenRyoko cannot track. Unreachable while the event feed stays empty. */
+
+export interface ClaimWorkItemInput { workItemId: string; owner: string }
+export type ClaimWorkItemResult =
+  | { state: 'acquired' }
+  | { state: 'held'; claim: { owner: string } };
+
+export function claimWorkItem(_input: ClaimWorkItemInput): ClaimWorkItemResult {
+  return { state: 'held', claim: { owner: 'work-items-not-ported' } };
+}
+
+export function releaseWorkItemClaim(_workItemId: string, _owner: string): boolean {
+  return false;
+}

--- a/packages/jimmy/src/work-items/id.ts
+++ b/packages/jimmy/src/work-items/id.ts
@@ -1,0 +1,7 @@
+/**
+ * work-items shim — OpenRyoko has not ported the upstream Todo (work-items)
+ * subsystem. This directory carries only the types and constants the Workflow
+ * runtime references, plus inert implementations of the functions the
+ * todo-status trigger path calls. With no event feed, that path never fires.
+ */
+export const TODO_ID_PATTERN = /^([A-Z]{3})-([1-9][0-9]*)$/;

--- a/packages/jimmy/src/work-items/labels.ts
+++ b/packages/jimmy/src/work-items/labels.ts
@@ -1,0 +1,9 @@
+/** work-items shim — the label normalizer, verbatim from upstream. */
+export function normalizeLabelName(name: string): string {
+  const normalized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!normalized) throw new Error(`label name "${name}" must contain at least one letter or digit`);
+  return normalized;
+}

--- a/packages/jimmy/src/work-items/respawn-guards.ts
+++ b/packages/jimmy/src/work-items/respawn-guards.ts
@@ -1,0 +1,18 @@
+/** work-items shim — no run ledger means no history to guard on; always clear.
+ *  Unreachable while the event feed stays empty. */
+
+export interface RespawnGuardHold { state: 'held'; guard: string; reason: string }
+export type RespawnGuardVerdict = { state: 'clear' } | RespawnGuardHold;
+export interface RespawnGuardOptions { quotaWindowDecided?: boolean }
+
+export function checkRespawnGuard(
+  _workItemId: string,
+  _now: Date = new Date(),
+  _opts: RespawnGuardOptions = {},
+): RespawnGuardVerdict {
+  return { state: 'clear' };
+}
+
+export function appendRespawnGuardHold(_workItemId: string, _hold: RespawnGuardHold, _actor: string): void {
+  // audit-only upstream; nothing to record without the Todo event log
+}

--- a/packages/jimmy/src/work-items/runs.ts
+++ b/packages/jimmy/src/work-items/runs.ts
@@ -1,0 +1,44 @@
+/** work-items shim — run-ledger types and the handoff normalizer, verbatim
+ *  from upstream. The ledger itself is not ported; the Workflow runtime only
+ *  writes through the optional todo ports, which OpenRyoko leaves absent. */
+
+export const TODO_RUN_OUTCOMES = ['completed', 'blocked', 'crashed', 'timed_out', 'abandoned', 'rate_limited'] as const;
+export type TodoRunOutcome = (typeof TODO_RUN_OUTCOMES)[number];
+
+/** What an attempt hands the next one. Everything is optional — the platform
+ *  stores and surfaces what the attempt reported, it never invents it. */
+export interface TodoRunHandoff {
+  changedFiles?: string[];
+  verification?: string;
+  retryNotes?: string;
+  residualRisk?: string;
+}
+
+const HANDOFF_NOTES = [
+  { key: 'verification', wire: 'verification' },
+  { key: 'retryNotes', wire: 'retry_notes' },
+  { key: 'residualRisk', wire: 'residual_risk' },
+] as const;
+
+export function normalizeTodoRunHandoff(value: unknown): TodoRunHandoff {
+  const source = asRecord(value);
+  if (!source) return {};
+  const handoff: TodoRunHandoff = {};
+  const files = stringList(source.changedFiles ?? source.changed_files);
+  if (files.length > 0) handoff.changedFiles = files;
+  for (const note of HANDOFF_NOTES) {
+    const reported = source[note.key] ?? source[note.wire];
+    if (typeof reported === 'string' && reported.length > 0) handoff[note.key] = reported;
+  }
+  return handoff;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+}

--- a/packages/jimmy/src/work-items/store.ts
+++ b/packages/jimmy/src/work-items/store.ts
@@ -1,0 +1,11 @@
+/** work-items shim — status/source unions as upstream defines them. */
+export type WorkItemStatus =
+  | 'backlog'
+  | 'assigned'
+  | 'executing'
+  | 'in_review'
+  | 'done'
+  | 'blocked'
+  | 'escalated'
+  | 'cancelled';
+export type WorkItemSource = 'human' | 'delegation' | 'cron' | 'workflow' | 'session' | 'connector' | 'goal';

--- a/packages/jimmy/src/work-items/workflow-event-feed.ts
+++ b/packages/jimmy/src/work-items/workflow-event-feed.ts
@@ -1,0 +1,58 @@
+/** work-items shim — the todo-status event feed contract with an inert
+ *  implementation: no Todo subsystem means no status events, ever. The types
+ *  are upstream's, so a later work-items port swaps the factory, not callers. */
+import type { WorkItemSource, WorkItemStatus } from './store.js';
+
+export interface WorkflowTodoStatusEvent {
+  id: string;
+  workItemId: string;
+  fromStatus: WorkItemStatus | null;
+  toStatus: WorkItemStatus;
+  actor: string | null;
+  armedAsDelegate: string | null;
+  quotaWindowDecided: boolean;
+  armedAsRecovery?: boolean;
+  item: {
+    source: WorkItemSource;
+    department: string | null;
+    assignee: string | null;
+    labels: Array<{ id: string; name: string }>;
+    live: { assignee: string | null; parentId: string | null; status: WorkItemStatus } | null;
+  };
+}
+
+export interface WorkflowTodoEventClaimOutcome {
+  workflowId: string;
+  outcome: 'started' | 'duplicate' | 'suppressed' | 'superseded' | 'deferred-then-superseded' | 'failed';
+  runId?: string;
+  detail: string;
+}
+
+export type WorkflowTodoEventClaim =
+  | { state: 'acquired'; definitionIds: string[]; deferred?: boolean }
+  | { state: 'busy' }
+  | { state: 'processed'; outcomes: WorkflowTodoEventClaimOutcome[] };
+
+export interface WorkflowTodoEventFeed {
+  claimEvent(eventId: string, definitionIds: string[]): WorkflowTodoEventClaim;
+  completeEvent(eventId: string, outcomes: WorkflowTodoEventClaimOutcome[]): void;
+  deferEvent(eventId: string, definitionIds: string[], outcomes: WorkflowTodoEventClaimOutcome[]): void;
+  releaseEvent(eventId: string): void;
+  listPendingEvents(limit?: number): WorkflowTodoStatusEvent[];
+}
+
+export interface WorkflowTodoEventFeedOptions {
+  ownerId?: string;
+  now?: () => Date;
+  leaseMs?: number;
+}
+
+export function createWorkflowTodoEventFeed(_options: WorkflowTodoEventFeedOptions = {}): WorkflowTodoEventFeed {
+  return {
+    claimEvent: () => ({ state: 'busy' }),
+    completeEvent: () => {},
+    deferEvent: () => {},
+    releaseEvent: () => {},
+    listPendingEvents: () => [],
+  };
+}

--- a/packages/jimmy/src/work-items/workflow-event-winners.ts
+++ b/packages/jimmy/src/work-items/workflow-event-winners.ts
@@ -1,0 +1,4 @@
+/** work-items shim — with no Todo event claims there are never later winners. */
+export function startedAfterEvent(_eventId: string): Map<string, string> {
+  return new Map();
+}

--- a/packages/jimmy/src/work-items/workflow-ownership.ts
+++ b/packages/jimmy/src/work-items/workflow-ownership.ts
@@ -1,0 +1,4 @@
+/** work-items shim — with no Todo event log there is no owning workflow. */
+export function owningWorkflowId(_todoId: string): string | undefined {
+  return undefined;
+}

--- a/packages/jimmy/src/workflows/__tests__/approval-choice-binding.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/approval-choice-binding.test.ts
@@ -1,0 +1,300 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Employee, ModelRegistry } from "../../shared/types.js";
+import type { WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+import { type WorkflowTodoApprovalMirror } from "../runner.js";
+import { parseTodoApprovalRef } from "../todo-approval-ref.js";
+
+/* Gap 2 (choice approvals decided ON the Todo) + Gap 4 (the run ↔ Todo binding
+ * that gives a mirrored gate somewhere to land). */
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete the task.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+const VARIANTS = ["variant-a", "variant-b", "variant-c"];
+
+/** These workflows park on an Approval before any Employee node, so the
+ *  executor only has to exist. */
+function idleExecutor(): WorkflowSessionExecutor {
+  return {
+    async startAttempt() { return { sessionId: "unused" }; },
+    async stopAttempt() {},
+    subscribe() { return () => {}; },
+    readTerminalCompletion() { return null; },
+  } as unknown as WorkflowSessionExecutor;
+}
+
+class RecordingMirror implements WorkflowTodoApprovalMirror {
+  readonly requests: Array<Parameters<WorkflowTodoApprovalMirror["request"]>[0]> = [];
+  readonly parked: Array<Parameters<WorkflowTodoApprovalMirror["notifyParked"]>[0]> = [];
+  request(input: Parameters<WorkflowTodoApprovalMirror["request"]>[0]): void { this.requests.push(input); }
+  notifyParked(input: Parameters<WorkflowTodoApprovalMirror["notifyParked"]>[0]): void { this.parked.push(input); }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let mirror: RecordingMirror;
+let service: WorkflowService;
+const now = new Date("2026-07-21T10:00:00.000Z");
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function saveDefinition(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({ ...created, inputs: [], nodes, edges }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+/** A workflow that parks on one Approval node and ends either way. */
+function gateDefinition(id: string, config: Record<string, unknown>): WorkflowDefinition {
+  return saveDefinition(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "review", type: "approval", name: "Review", config } as WorkflowNode,
+    { id: "accepted", type: "end", name: "Accepted", config: { result: "success" } },
+    { id: "declined", type: "end", name: "Declined", config: { result: "success" } },
+  ], [
+    edge("start-review", "start", "success", "review"),
+    edge("review-approved", "review", "approved", "accepted"),
+    edge("review-rejected", "review", "rejected", "declined"),
+  ]);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-choice-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  mirror = new RecordingMirror();
+  service = new WorkflowService({
+    repository, executor: idleExecutor(),
+    employees: () => new Map([[employee.name, employee]]), models: () => models,
+    now: () => now.toISOString(), todoApprovals: mirror,
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("run ↔ Todo binding", () => {
+  it("carries the bound Todo id on the run's trigger", async () => {
+    const definition = gateDefinition("bound", { description: "Approve?" });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-1" });
+    expect(run.trigger.todoId).toBe("OPS-1");
+    expect(service.getRun(definition.id, run.id)!.trigger.todoId).toBe("OPS-1");
+  });
+
+  it("leaves an unbound run's trigger without a Todo id", async () => {
+    const definition = gateDefinition("unbound", { description: "Approve?" });
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(run.trigger.todoId).toBeUndefined();
+  });
+
+  it("does NOT mirror a parked gate when the run is unbound", async () => {
+    const definition = gateDefinition("unbound-gate", { description: "Approve?" });
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(run.status).toBe("waiting");
+    expect(mirror.requests).toEqual([]);
+  });
+});
+
+describe("mirroring a parked gate onto the bound Todo", () => {
+  it("mirrors the description, a run-scoped ref, and the offered options", async () => {
+    const definition = gateDefinition("mirrored", { description: "Which variant ships?", options: VARIANTS });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-2" });
+    expect(mirror.requests).toEqual([{
+      todoId: "OPS-2", request: "Which variant ships?", options: VARIANTS,
+      ref: `workflow:${definition.id}:${run.id}:review`,
+    }]);
+  });
+
+  it("routes the mirrored gate to the node's resolved approver", async () => {
+    const definition = gateDefinition("mirrored-approver", {
+      description: "Approve?", approver: { source: "fixed", value: "reviewer" },
+    });
+    await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-3" });
+    expect(mirror.requests[0]).toMatchObject({ approver: "reviewer" });
+  });
+
+  it("the ref round-trips back to the workflow, run, and node that parked", async () => {
+    const definition = gateDefinition("roundtrip", { description: "Approve?" });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-4" });
+    expect(parseTodoApprovalRef(mirror.requests[0]!.ref))
+      .toEqual({ workflowId: definition.id, runId: run.id, nodeId: "review" });
+  });
+
+  it("ignores refs that did not come from a workflow mirror", () => {
+    expect(parseTodoApprovalRef(null)).toBeNull();
+    expect(parseTodoApprovalRef("delegate:abc:123")).toBeNull();
+    expect(parseTodoApprovalRef("workflow:wf:run")).toBeNull();
+  });
+
+  it("a mirror that throws still leaves the gate parked and decidable", async () => {
+    const definition = gateDefinition("mirror-throws", { description: "Approve?" });
+    service.dispose();
+    service = new WorkflowService({
+      repository, executor: idleExecutor(),
+      employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+      todoApprovals: { request: () => { throw new Error("Todo is gone"); }, notifyParked: () => {} },
+    });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-5" });
+    expect(run.status).toBe("waiting");
+    expect(run.approvals).toEqual([expect.objectContaining({ nodeId: "review", status: "pending" })]);
+  });
+});
+
+/** The same gate, but each port leads to a step that reads the decision's own words back out of it. */
+function reasonDefinition(id: string): WorkflowDefinition {
+  const reader = (nodeId: string): WorkflowNode => ({ id: nodeId, type: "employee", name: nodeId,
+    config: { employee: { source: "fixed", value: "worker" }, prompt: "Act on: {{ node.review.fields.reason }}",
+      output: { fields: {}, allowAdditionalFields: true } } });
+  return saveDefinition(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "review", type: "approval", name: "Review", config: { description: "Approve?" } } as WorkflowNode,
+    reader("on-approve"), reader("on-reject"),
+    { id: "shipped", type: "end", name: "Shipped", config: { result: "success" } },
+    { id: "revised", type: "end", name: "Revised", config: { result: "success" } },
+  ], [
+    edge("start-review", "start", "success", "review"),
+    edge("review-approved", "review", "approved", "on-approve"),
+    edge("review-rejected", "review", "rejected", "on-reject"),
+    edge("approve-end", "on-approve", "success", "shipped"),
+    edge("reject-end", "on-reject", "success", "revised"),
+  ]);
+}
+
+describe("reading the decision's reason back into the run", () => {
+  it.each(["approve", "reject"] as const)("carries a %s reason into the gate's output fields", async (decision) => {
+    const definition = reasonDefinition(`reason-${decision}`);
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision, decidedBy: "operator", reason: "  The staging soak was clean.  ", expectedRevision: run.revision });
+
+    expect(decided.nodeRuns.find((node) => node.nodeId === "review")?.output)
+      .toMatchObject({ fields: { port: decision === "approve" ? "approved" : "rejected",
+        reason: "The staging soak was clean." } });
+    // The whole point of putting it in `fields`: the next step can read it.
+    expect(decided.attempts.at(-1)?.promptText).toContain("Act on: The staging soak was clean.");
+  });
+
+  it("leaves no reason field when the decision carried none", async () => {
+    const definition = gateDefinition("no-reason", { description: "Approve?" });
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", expectedRevision: run.revision });
+    expect(decided.nodeRuns.find((node) => node.nodeId === "review")?.output?.fields).toEqual({ port: "approved" });
+  });
+});
+
+describe("reading the pick back into the run", () => {
+  it("exposes the choice as the Approval node's output", async () => {
+    const definition = gateDefinition("reads-back", { description: "Which?", options: VARIANTS });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-6" });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", choice: "variant-b", expectedRevision: run.revision });
+    expect(decided.nodeRuns.find((node) => node.nodeId === "review")?.output)
+      .toMatchObject({ choice: "variant-b", fields: { port: "approved" } });
+    expect(decided.status).toBe("completed");
+  });
+
+  it("refuses approving a choice gate with no pick", async () => {
+    const definition = gateDefinition("needs-pick", { description: "Which?", options: VARIANTS });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-7" });
+    await expect(service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", expectedRevision: run.revision }))
+      .rejects.toThrow(/requires choosing one of/i);
+  });
+
+  it("refuses a pick that was never offered", async () => {
+    const definition = gateDefinition("bad-pick", { description: "Which?", options: VARIANTS });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-8" });
+    await expect(service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", choice: "variant-z", expectedRevision: run.revision }))
+      .rejects.toThrow(/does not offer that choice/i);
+  });
+
+  it("refuses a pick on a node that offers no options", async () => {
+    const definition = gateDefinition("no-options", { description: "Approve?" });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-9" });
+    await expect(service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", choice: "variant-a", expectedRevision: run.revision }))
+      .rejects.toThrow(/does not offer that choice/i);
+  });
+
+  it("still allows rejecting a choice gate without a pick", async () => {
+    const definition = gateDefinition("reject-no-pick", { description: "Which?", options: VARIANTS });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-10" });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "reject", decidedBy: "operator", expectedRevision: run.revision });
+    expect(decided.approvals).toEqual([expect.objectContaining({ status: "rejected" })]);
+  });
+});
+
+/* An operator-only gate. Default routing sends an approval to the org
+ * hierarchy root, so the COO can approve a pipeline the COO started — a
+ * governance hole when the gate authorizes something irreversible. */
+describe("operator-only approval gates", () => {
+  it("refuses an employee decision, including the COO's", async () => {
+    const definition = gateDefinition("operator-gate", { description: "Merge to main?", operatorOnly: true });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-11" });
+
+    await expect(service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "Jimbo", expectedRevision: run.revision }))
+      .rejects.toThrow(/operator-only/i);
+
+    expect(service.getRun(definition.id, run.id)!.approvals[0]!.status).toBe("pending");
+  });
+
+  it("lets the operator decide it and the run advances", async () => {
+    const definition = gateDefinition("operator-gate-ok", { description: "Merge to main?", operatorOnly: true });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-12" });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", expectedRevision: run.revision });
+    expect(decided.status).toBe("completed");
+  });
+
+  it("leaves an ordinary gate decidable by an employee", async () => {
+    const definition = gateDefinition("ordinary-gate", {
+      description: "Approve?", approver: { source: "fixed", value: "worker" },
+    });
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-13" });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "worker", expectedRevision: run.revision });
+    expect(decided.status).toBe("completed");
+  });
+
+  it("refuses a definition that is both operator-only and approver-routed, naming why", () => {
+    let issues: unknown;
+    expect(() => {
+      try {
+        gateDefinition("contradictory", {
+          description: "Approve?", operatorOnly: true, approver: { source: "fixed", value: "worker" },
+        });
+      } catch (error) {
+        issues = (error as { issues?: unknown }).issues;
+        throw error;
+      }
+    }).toThrow(/Workflow definition is invalid/i);
+    expect(issues).toContainEqual(expect.objectContaining({
+      message: "An operator-only approval cannot also name an approver.",
+    }));
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/approval-description-binding.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/approval-description-binding.test.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Employee, ModelRegistry } from "../../shared/types.js";
+import type { WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+import { type WorkflowTodoApprovalMirror } from "../runner.js";
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete the task.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+/** Most of these workflows park on an Approval before any Employee node, so the
+ *  executor only has to exist. The description-binding cases run one step first,
+ *  and reach it back through `submitAttemptOutput` by this session id. */
+const STEP_SESSION = "session:step";
+
+function idleExecutor(): WorkflowSessionExecutor {
+  return {
+    async startAttempt() { return { sessionId: STEP_SESSION }; },
+    async stopAttempt() {},
+    subscribe() { return () => {}; },
+    readTerminalCompletion() { return null; },
+  } as unknown as WorkflowSessionExecutor;
+}
+
+class RecordingMirror implements WorkflowTodoApprovalMirror {
+  readonly requests: Array<Parameters<WorkflowTodoApprovalMirror["request"]>[0]> = [];
+  readonly parked: Array<Parameters<WorkflowTodoApprovalMirror["notifyParked"]>[0]> = [];
+  request(input: Parameters<WorkflowTodoApprovalMirror["request"]>[0]): void { this.requests.push(input); }
+  notifyParked(input: Parameters<WorkflowTodoApprovalMirror["notifyParked"]>[0]): void { this.parked.push(input); }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let mirror: RecordingMirror;
+let service: WorkflowService;
+const now = new Date("2026-07-21T10:00:00.000Z");
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function saveDefinition(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({ ...created, inputs: [], nodes, edges }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+/** A workflow that parks on one Approval node and ends either way. */
+function gateDefinition(id: string, config: Record<string, unknown>): WorkflowDefinition {
+  return saveDefinition(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "review", type: "approval", name: "Review", config } as WorkflowNode,
+    { id: "accepted", type: "end", name: "Accepted", config: { result: "success" } },
+    { id: "declined", type: "end", name: "Declined", config: { result: "success" } },
+  ], [
+    edge("start-review", "start", "success", "review"),
+    edge("review-approved", "review", "approved", "accepted"),
+    edge("review-rejected", "review", "rejected", "declined"),
+  ]);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-gate-description-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  mirror = new RecordingMirror();
+  service = new WorkflowService({
+    repository, executor: idleExecutor(),
+    employees: () => new Map([[employee.name, employee]]), models: () => models,
+    now: () => now.toISOString(), todoApprovals: mirror,
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("interpolating the description an operator reads at the gate", () => {
+  const SHOT = "attachment:OPS-20:wia_ab12cd34ef56:image/png";
+
+  /** step (produces `shot`) → approval. The gate's description is authored as a
+   *  template over that step's output. */
+  function stepThenGate(id: string, description: string): WorkflowDefinition {
+    return saveDefinition(id, [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "step", type: "employee", name: "Step", config: {
+        employee: { source: "fixed", value: employee.name },
+        prompt: "Capture the screen.",
+        output: { fields: { shot: { type: "attachment", required: true } }, allowAdditionalFields: false },
+      } },
+      { id: "review", type: "approval", name: "Review", config: { description } },
+      { id: "accepted", type: "end", name: "Accepted", config: { result: "success" } },
+      { id: "declined", type: "end", name: "Declined", config: { result: "success" } },
+    ], [
+      edge("start-step", "start", "success", "step"),
+      edge("step-review", "step", "success", "review"),
+      edge("review-approved", "review", "approved", "accepted"),
+      edge("review-rejected", "review", "rejected", "declined"),
+    ]);
+  }
+
+  async function parkOnGate(definition: WorkflowDefinition, todoId: string): Promise<void> {
+    await service.startManual({ workflowId: definition.id, input: {}, todoId });
+    await service.submitAttemptOutput({ sessionId: STEP_SESSION, fields: { shot: SHOT } });
+  }
+
+  it("resolves an upstream field into the request the Todo shows", async () => {
+    const definition = stepThenGate("described", "Ship this? {{ node.step.fields.shot }}");
+    await parkOnGate(definition, "OPS-20");
+
+    expect(mirror.requests[0]!.request).toBe(`Ship this? ${SHOT}`);
+    expect(mirror.parked[0]!.request).toBe(`Ship this? ${SHOT}`);
+  });
+
+  it("leaves a description with no template exactly as authored", async () => {
+    const definition = gateDefinition("plain", { description: "Approve?" });
+    await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-21" });
+
+    expect(mirror.requests[0]!.request).toBe("Approve?");
+  });
+
+  it("falls back to the raw description, and still parks a decidable gate, when the template cannot resolve", async () => {
+    const definition = stepThenGate("unresolvable", "Ship this? {{ node.step.fields.missing }}");
+    await parkOnGate(definition, "OPS-22");
+
+    expect(mirror.requests[0]!.request).toBe("Ship this? {{ node.step.fields.missing }}");
+    const run = service.listRuns(definition.id, {}).items[0]!;
+    expect(service.getRun(definition.id, run.id)!.status).toBe("waiting");
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "review",
+      decision: "approve", decidedBy: "operator", expectedRevision: service.getRun(definition.id, run.id)!.revision });
+    expect(decided.status).toBe("completed");
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/attachment-ref.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/attachment-ref.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { formatAttachmentRef, parseAttachmentRef } from '../attachment-ref.js';
+
+const REF = 'attachment:PLA-135:wia_ab12cd34ef56:image/png';
+
+describe('parseAttachmentRef', () => {
+  it('parses a well-formed ref into its three parts', () => {
+    expect(parseAttachmentRef(REF)).toEqual({
+      workItemId: 'PLA-135',
+      attachmentId: 'wia_ab12cd34ef56',
+      mime: 'image/png',
+    });
+  });
+
+  it('accepts the mime shapes the attachment store actually produces', () => {
+    for (const mime of ['image/jpeg', 'image/svg+xml', 'application/pdf', 'text/plain', 'application/vnd.ms-excel']) {
+      expect(parseAttachmentRef(`attachment:PLA-1:wia_000000000000:${mime}`)?.mime).toBe(mime);
+    }
+  });
+
+  const rejected: Array<[string, string]> = [
+    ['empty string', ''],
+    ['a bare filename', 'screenshot.png'],
+    ['the wrong scheme', 'file:PLA-135:wia_ab12cd34ef56:image/png'],
+    ['a leading space', ' attachment:PLA-135:wia_ab12cd34ef56:image/png'],
+    ['a trailing space', 'attachment:PLA-135:wia_ab12cd34ef56:image/png '],
+    ['inner whitespace', 'attachment:PLA-135:wia_ab12cd34ef56:image/png extra'],
+    ['a tab', 'attachment:PLA-135:wia_ab12cd34ef56:image/p\tng'],
+    ['a newline', 'attachment:PLA-135:wia_ab12cd34ef56:image/png\n'],
+    ['a parent-directory hop', 'attachment:PLA-135:wia_ab12cd34ef56:../../etc/passwd'],
+    ['a parent-directory hop in the id', 'attachment:PLA-135:wia_../../../etc:image/png'],
+    ['an absolute path', 'attachment:PLA-135:wia_ab12cd34ef56:/etc/passwd'],
+    ['an absolute path as the whole value', '/etc/passwd'],
+    ['a slash outside the mime', 'attachment:PLA/135:wia_ab12cd34ef56:image/png'],
+    ['a second slash inside the mime', 'attachment:PLA-135:wia_ab12cd34ef56:image/png/x'],
+    ['a mime with no slash', 'attachment:PLA-135:wia_ab12cd34ef56:image'],
+    ['a missing mime', 'attachment:PLA-135:wia_ab12cd34ef56'],
+    ['a trailing separator', 'attachment:PLA-135:wia_ab12cd34ef56:'],
+    ['an extra segment', 'attachment:PLA-135:wia_ab12cd34ef56:image/png:more'],
+    ['a lowercase Todo prefix', 'attachment:pla-135:wia_ab12cd34ef56:image/png'],
+    ['a Todo number with a leading zero', 'attachment:PLA-0135:wia_ab12cd34ef56:image/png'],
+    ['a Todo number of zero', 'attachment:PLA-0:wia_ab12cd34ef56:image/png'],
+    ['the wrong attachment prefix', 'attachment:PLA-135:wic_ab12cd34ef56:image/png'],
+    ['an attachment id that is too short', 'attachment:PLA-135:wia_ab12cd34ef5:image/png'],
+    ['an attachment id that is too long', 'attachment:PLA-135:wia_ab12cd34ef567:image/png'],
+    ['an uppercase attachment id', 'attachment:PLA-135:wia_AB12CD34EF56:image/png'],
+    ['an uppercase mime', 'attachment:PLA-135:wia_ab12cd34ef56:Image/PNG'],
+  ];
+
+  for (const [label, value] of rejected) {
+    it(`rejects ${label}`, () => {
+      expect(parseAttachmentRef(value)).toBeNull();
+    });
+  }
+
+  it('rejects a value that is not a string', () => {
+    expect(parseAttachmentRef(null)).toBeNull();
+    expect(parseAttachmentRef(undefined)).toBeNull();
+  });
+});
+
+describe('formatAttachmentRef', () => {
+  it('round-trips through the parser', () => {
+    const ref = formatAttachmentRef({ workItemId: 'PLA-135', id: 'wia_ab12cd34ef56', mime: 'image/png' });
+    expect(ref).toBe(REF);
+    expect(parseAttachmentRef(ref)).toEqual({
+      workItemId: 'PLA-135',
+      attachmentId: 'wia_ab12cd34ef56',
+      mime: 'image/png',
+    });
+  });
+
+  it('lower-cases the mime so the token it produces always parses', () => {
+    const ref = formatAttachmentRef({ workItemId: 'PLA-135', id: 'wia_ab12cd34ef56', mime: 'IMAGE/PNG' });
+    expect(parseAttachmentRef(ref)?.mime).toBe('image/png');
+  });
+
+  it('falls back to a generic mime rather than emitting a token that would not parse', () => {
+    for (const mime of ['image/png; charset=utf-8', 'image', '../../etc/passwd', 'image/p..ng']) {
+      const ref = formatAttachmentRef({ workItemId: 'PLA-135', id: 'wia_ab12cd34ef56', mime });
+      expect(parseAttachmentRef(ref)?.mime).toBe('application/octet-stream');
+    }
+  });
+
+  it('falls back to a generic mime when the stored row has none', () => {
+    const ref = formatAttachmentRef({ workItemId: 'PLA-135', id: 'wia_ab12cd34ef56', mime: '' });
+    expect(parseAttachmentRef(ref)?.mime).toBe('application/octet-stream');
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/bindings.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/bindings.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  interpolateWorkflowPrompt,
+  resolveBinding,
+  validateBindingPath,
+  WorkflowBindingError,
+  type WorkflowBindingContext,
+} from '../bindings.js';
+import { bindingSchema, type Binding, type JsonValue } from '../model.js';
+import type { WorkflowError } from '../runtime.js';
+
+function context(): WorkflowBindingContext {
+  return {
+    input: {
+      reviewer: 'reviewer',
+      count: 2,
+      approved: true,
+      empty: null,
+      unicode: 'Здравей',
+      negativeZero: -0,
+      list: ['one', { nested: true }],
+      record: { nested: { value: 'safe' } },
+      braces: '{{ trigger.kind }}',
+    },
+    trigger: { kind: 'event', payload: { repository: 'example/repository' } },
+    nodes: {
+      plan: {
+        status: 'completed',
+        output: { text: 'Plan ready.', fields: { reviewer: 'reviewer', scores: [1, 2] } },
+        error: null,
+      },
+      empty: { status: 'completed', output: null, error: null },
+    },
+    run: { id: 'run-1', startedAt: '2026-07-20T00:00:00.000Z' },
+  };
+}
+
+function expectBindingError(action: () => unknown, code: WorkflowBindingError['code']): WorkflowBindingError {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkflowBindingError);
+  expect(thrown).toMatchObject({ name: 'WorkflowBindingError', code });
+  return thrown as WorkflowBindingError;
+}
+
+function ownRecord(key: PropertyKey, value: unknown): Record<string, JsonValue> {
+  const record = Object.create(null) as Record<string, JsonValue>;
+  Object.defineProperty(record, key, { value, enumerable: true, configurable: true, writable: true });
+  return record;
+}
+
+describe('WorkflowBindingContext', () => {
+  it('owns the locked binding-context shape', () => {
+    const error: WorkflowError = { code: 'failed', message: 'Failed.', retryable: false };
+    const value = context();
+    value.nodes.plan!.error = error;
+
+    expect(value.nodes.plan).toMatchObject({ status: 'completed', error });
+    expectTypeOf(value).toEqualTypeOf<WorkflowBindingContext>();
+  });
+});
+
+describe('WorkflowBindingError', () => {
+  it('has the exact public name, code union, and Error behavior', () => {
+    const error = new WorkflowBindingError('invalid-path', 'Invalid binding path');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('WorkflowBindingError');
+    expect(error.code).toBe('invalid-path');
+    expectTypeOf(error.code).toEqualTypeOf<'invalid-path' | 'missing-value' | 'type-mismatch' | 'unsafe-value'>();
+  });
+});
+
+describe('validateBindingPath', () => {
+  it.each([
+    ['value', ['value']],
+    ['Valid_name-2', ['Valid_name-2']],
+    ['a'.repeat(256), ['a'.repeat(256)]],
+    [Array.from({ length: 16 }, (_, index) => `s${index}`).join('.'), Array.from({ length: 16 }, (_, index) => `s${index}`)],
+    ['input', ['input']],
+    ['trigger', ['trigger']],
+    ['run', ['run']],
+    ['nodes', ['nodes']],
+    ['safe.input.trigger.run.nodes', ['safe', 'input', 'trigger', 'run', 'nodes']],
+  ])('accepts the valid relative path %s', (path, expected) => {
+    expect(validateBindingPath(path)).toEqual(expected);
+  });
+
+  it('returns a fresh segments array without mutable global state', () => {
+    const first = validateBindingPath('fields.reviewer');
+    first[0] = 'changed';
+    expect(validateBindingPath('fields.reviewer')).toEqual(['fields', 'reviewer']);
+  });
+
+  it.each([
+    '',
+    'a'.repeat(257),
+    Array.from({ length: 17 }, (_, index) => `s${index}`).join('.'),
+    '.value', 'value.', 'a..b', 'with space', ' value', 'value ', '0value',
+    '$.value', 'items[0]', 'call()', 'a+b', 'a/b', String.raw`a\b`, String.raw`a\u002eb`,
+    '__proto__', 'safe.__proto__.value', 'prototype', 'safe.prototype', 'constructor', 'safe.constructor',
+    'input.value', 'trigger.payload', 'run.id', 'nodes.plan',
+  ])('rejects the invalid relative path %s', (path) => {
+    expectBindingError(() => validateBindingPath(path), 'invalid-path');
+  });
+
+  it.each([undefined, null, 1, {}, new String('value')])('maps non-string input to invalid-path without leaking arbitrary errors', (path) => {
+    expectBindingError(() => validateBindingPath(path as string), 'invalid-path');
+  });
+});
+
+describe('resolveBinding source roots', () => {
+  it('resolves single-segment source words as ordinary own field names', () => {
+    const value = context();
+    (value.input as Record<string, JsonValue>).input = 'input value';
+    (value.trigger as unknown as Record<string, JsonValue>).trigger = 'trigger value';
+    (value.run as unknown as Record<string, JsonValue>).run = 'run value';
+    (value.nodes.plan!.output as unknown as Record<string, JsonValue>).nodes = 'nodes value';
+    expect(resolveBinding({ source: 'input', path: 'input' }, value)).toBe('input value');
+    expect(resolveBinding({ source: 'trigger', path: 'trigger' }, value)).toBe('trigger value');
+    expect(resolveBinding({ source: 'run', path: 'run' }, value)).toBe('run value');
+    expect(resolveBinding({ source: 'node', nodeId: 'plan', path: 'nodes' }, value)).toBe('nodes value');
+    expect(interpolateWorkflowPrompt('{{ input.input }} / {{ node.plan.nodes }}', value)).toBe('input value / nodes value');
+  });
+
+  it.each([
+    { source: 'input', path: 'input' }, { source: 'trigger', path: 'trigger' },
+    { source: 'run', path: 'run' }, { source: 'node', nodeId: 'plan', path: 'nodes' },
+  ] as Binding[])('maps an absent single-segment source word for $source to missing-value', (binding) => {
+    expectBindingError(() => resolveBinding(binding, context()), 'missing-value');
+  });
+
+  it.each<[string, Binding, unknown]>([
+    ['fixed string', { source: 'fixed', value: 'value' }, 'value'],
+    ['fixed number', { source: 'fixed', value: -0 }, -0],
+    ['fixed boolean', { source: 'fixed', value: false }, false],
+    ['fixed null', { source: 'fixed', value: null }, null],
+    ['fixed array', { source: 'fixed', value: [1, { ok: true }] }, [1, { ok: true }]],
+    ['fixed object', { source: 'fixed', value: { ok: true } }, { ok: true }],
+    ['input', { source: 'input', path: 'reviewer' }, 'reviewer'],
+    ['trigger kind', { source: 'trigger', path: 'kind' }, 'event'],
+    ['trigger payload', { source: 'trigger', path: 'payload.repository' }, 'example/repository'],
+    ['run id', { source: 'run', path: 'id' }, 'run-1'],
+    ['run timestamp', { source: 'run', path: 'startedAt' }, '2026-07-20T00:00:00.000Z'],
+    ['node field', { source: 'node', nodeId: 'plan', path: 'fields.reviewer' }, 'reviewer'],
+    ['node text', { source: 'node', nodeId: 'plan', path: 'text' }, 'Plan ready.'],
+    ['whole array', { source: 'input', path: 'list' }, ['one', { nested: true }]],
+    ['whole object', { source: 'input', path: 'record' }, { nested: { value: 'safe' } }],
+    ['node array', { source: 'node', nodeId: 'plan', path: 'fields.scores' }, [1, 2]],
+  ])('resolves %s', (_label, binding, expected) => {
+    const resolved = resolveBinding(binding, context());
+    expect(resolved).toEqual(expected);
+    if (Object.is(expected, -0)) expect(Object.is(resolved, -0)).toBe(true);
+  });
+
+  it('does not expose node status or error through the output root', () => {
+    expectBindingError(() => resolveBinding({ source: 'node', nodeId: 'plan', path: 'status' }, context()), 'missing-value');
+    expectBindingError(() => resolveBinding({ source: 'node', nodeId: 'plan', path: 'error' }, context()), 'missing-value');
+  });
+
+  it('does not expose array implementation properties as JSON paths', () => {
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'list.length' }, context()), 'missing-value');
+  });
+
+  it.each([
+    { source: 'input', path: 'absent' },
+    { source: 'input', path: 'record.absent' },
+    { source: 'node', nodeId: 'absent', path: 'text' },
+    { source: 'node', nodeId: 'empty', path: 'text' },
+  ] as Binding[])('maps absent values for $source to missing-value', (binding) => {
+    expectBindingError(() => resolveBinding(binding, context()), 'missing-value');
+  });
+});
+
+describe('own record traversal and canonical node identifiers', () => {
+  it('reads own properties only', () => {
+    const inherited: Record<string, JsonValue> = { own: 'safe' };
+    const value = context();
+    value.input = inherited;
+    expect(resolveBinding({ source: 'input', path: 'own' }, value)).toBe('safe');
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'toString' }, value), 'missing-value');
+  });
+
+  it('supports null-prototype context records', () => {
+    const value = Object.create(null) as WorkflowBindingContext;
+    Object.defineProperties(value, {
+      input: { value: ownRecord('reviewer', 'reviewer'), enumerable: true },
+      trigger: { value: Object.assign(Object.create(null), { kind: 'manual', payload: Object.create(null) }), enumerable: true },
+      nodes: { value: Object.create(null), enumerable: true },
+      run: { value: Object.assign(Object.create(null), { id: 'run-null', startedAt: 'now' }), enumerable: true },
+    });
+    expect(resolveBinding({ source: 'input', path: 'reviewer' }, value)).toBe('reviewer');
+    expect(resolveBinding({ source: 'run', path: 'id' }, value)).toBe('run-null');
+  });
+
+  it.each(['constructor', 'prototype'])('accepts canonical node ID %s and resolves only its own node descriptor', (nodeId) => {
+    const binding = { source: 'node', nodeId, path: 'fields.value' } as const;
+    const value = context();
+    value.nodes = ownRecord(nodeId, { status: 'completed', output: { text: 'safe', fields: { value: nodeId } }, error: null }) as WorkflowBindingContext['nodes'];
+    expect(bindingSchema.safeParse(binding).success).toBe(true);
+    expect(resolveBinding(binding, value)).toBe(nodeId);
+    expect(interpolateWorkflowPrompt(`{{ node.${nodeId}.fields.value }}`, value)).toBe(nodeId);
+    expectBindingError(() => resolveBinding(binding, context()), 'missing-value');
+  });
+
+  it.each(['Constructor', 'node.dot', '1node', `a${'b'.repeat(64)}`, '__proto__'])('defers invalid node ID %s to canonical schema', (nodeId) => {
+    const binding = { source: 'node', nodeId, path: 'text' } as unknown as Binding;
+    expect(bindingSchema.safeParse(binding).success).toBe(false);
+    expectBindingError(() => resolveBinding(binding, context()), 'invalid-path');
+  });
+
+  it('never invokes inherited nodes, node-map getters, or Proxy traps', () => {
+    const before = Object.getOwnPropertyDescriptor(Object.prototype, 'constructor');
+    let calls = 0;
+    const getter = {} as WorkflowBindingContext['nodes'];
+    Object.defineProperty(getter, 'constructor', { enumerable: true, get() { calls += 1; return {}; } });
+    const value = context();
+    value.nodes = getter;
+    expectBindingError(() => resolveBinding({ source: 'node', nodeId: 'constructor', path: 'text' }, value), 'unsafe-value');
+    value.nodes = new Proxy({}, { ownKeys() { calls += 1; throw new Error('trap'); } });
+    expectBindingError(() => resolveBinding({ source: 'node', nodeId: 'prototype', path: 'text' }, value), 'unsafe-value');
+    expect(calls).toBe(0);
+    expect(Object.getOwnPropertyDescriptor(Object.prototype, 'constructor')).toEqual(before);
+  });
+});
+
+describe('fail-closed traversal and normalization', () => {
+  it('never invokes getters', () => {
+    let calls = 0;
+    const input: Record<string, JsonValue> = {};
+    Object.defineProperty(input, 'secret', { enumerable: true, get() { calls += 1; return 'unsafe'; } });
+    const value = context();
+    value.input = input;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'secret' }, value), 'unsafe-value');
+
+    const nested: Record<string, JsonValue> = {};
+    Object.defineProperty(nested, 'secret', { enumerable: true, get() { calls += 1; return 'unsafe'; } });
+    value.input = { nested };
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'nested' }, value), 'unsafe-value');
+    expect(calls).toBe(0);
+  });
+
+  it.each([
+    ['benign', (target: object) => new Proxy(target, {})],
+    ['throwing ownKeys', (target: object) => new Proxy(target, { ownKeys() { throw new Error('trap'); } })],
+    ['throwing descriptor', (target: object) => new Proxy(target, { getOwnPropertyDescriptor() { throw new Error('trap'); } })],
+    ['throwing prototype', (target: object) => new Proxy(target, { getPrototypeOf() { throw new Error('trap'); } })],
+    ['stateful', (target: object) => new Proxy(target, { ownKeys(value) { Object.defineProperty(value, 'later', { value: true }); return Reflect.ownKeys(value); } })],
+  ])('rejects %s Proxies before traps can escape', (_label, makeProxy) => {
+    const value = context();
+    value.input = makeProxy({ reviewer: 'reviewer' }) as Record<string, JsonValue>;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'reviewer' }, value), 'unsafe-value');
+  });
+
+  it('rejects revoked Proxies without leaking their native exception', () => {
+    const revoked = Proxy.revocable({ reviewer: 'reviewer' }, {});
+    revoked.revoke();
+    const value = context();
+    value.input = revoked.proxy;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'reviewer' }, value), 'unsafe-value');
+  });
+
+  it('keeps root Binding Proxies unsafe while classifying expected field accessors as invalid', () => {
+    expectBindingError(() => resolveBinding(new Proxy({ source: 'input', path: 'reviewer' }, {}) as Binding, context()), 'unsafe-value');
+    const revoked = Proxy.revocable({ source: 'input', path: 'reviewer' }, {});
+    revoked.revoke();
+    expectBindingError(() => resolveBinding(revoked.proxy as Binding, context()), 'unsafe-value');
+    let calls = 0;
+    const binding = { source: 'input' } as unknown as Binding;
+    Object.defineProperty(binding, 'path', { enumerable: true, get() { calls += 1; return 'reviewer'; } });
+    expectBindingError(() => resolveBinding(binding, context()), 'invalid-path');
+    expect(calls).toBe(0);
+  });
+
+  it('classifies hostile malformed source, path, and nodeId fields as invalid without traps', () => {
+    let traps = 0;
+    const hostile = new Proxy({}, { ownKeys() { traps += 1; throw new Error('trap'); }, get() { traps += 1; throw new Error('trap'); } });
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    class Box {}
+    const malformed = [hostile, revoked.proxy, new String('reviewer'), [], {}, new Box()];
+    for (const field of malformed) {
+      expectBindingError(() => resolveBinding({ source: 'input', path: field } as unknown as Binding, context()), 'invalid-path');
+      expectBindingError(() => resolveBinding({ source: field, path: 'reviewer' } as unknown as Binding, context()), 'invalid-path');
+      expectBindingError(() => resolveBinding({ source: 'node', nodeId: field, path: 'text' } as unknown as Binding, context()), 'invalid-path');
+    }
+    expect(traps).toBe(0);
+  });
+
+  it('classifies extra or misplaced hostile descriptors as invalid without getters', () => {
+    let calls = 0;
+    for (const key of ['extra', 'value']) {
+      const binding = { source: 'input', path: 'reviewer' } as unknown as Binding;
+      Object.defineProperty(binding, key, { enumerable: true, get() { calls += 1; return new Proxy({}, {}); } });
+      expectBindingError(() => resolveBinding(binding, context()), 'invalid-path');
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+describe('canonical value normalization', () => {
+  it.each([
+    ['class', new (class Unsafe { value = true; })()],
+    ['Date', new Date()],
+    ['Map', new Map()],
+    ['array subclass', new (class UnsafeArray extends Array<unknown> {})(1)],
+    ['nonfinite', Number.POSITIVE_INFINITY],
+    ['NaN', Number.NaN],
+    ['function', () => true],
+    ['bigint', 1n],
+    ['symbol', Symbol('value')],
+  ])('rejects unsafe %s final values', (_label, unsafe) => {
+    const value = context();
+    value.input = { unsafe } as unknown as Record<string, JsonValue>;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'unsafe' }, value), 'unsafe-value');
+    expectBindingError(() => resolveBinding({ source: 'fixed', value: unsafe as JsonValue }, value), 'unsafe-value');
+  });
+
+  it('maps an own undefined context value to missing-value while rejecting fixed undefined', () => {
+    const value = context();
+    value.input = { unsafe: undefined } as unknown as Record<string, JsonValue>;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'unsafe' }, value), 'missing-value');
+    expectBindingError(() => resolveBinding({ source: 'fixed', value: undefined as unknown as JsonValue }, value), 'unsafe-value');
+  });
+
+  it('rejects cycles, symbol keys, dangerous keys, and extra array properties', () => {
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    const symbolKey = ownRecord(Symbol('unsafe'), true);
+    const dangerousKey = ownRecord('constructor', true);
+    const array: unknown[] & { extra?: boolean } = [1];
+    array.extra = true;
+    for (const unsafe of [cycle, symbolKey, dangerousKey, array]) {
+      const value = context();
+      value.input = { unsafe } as unknown as Record<string, JsonValue>;
+      expectBindingError(() => resolveBinding({ source: 'input', path: 'unsafe' }, value), 'unsafe-value');
+    }
+  });
+
+  it('keeps hostile fixed values in the deep unsafe-value boundary', () => {
+    let calls = 0;
+    const getter: Record<string, unknown> = {};
+    Object.defineProperty(getter, 'value', { enumerable: true, get() { calls += 1; return true; } });
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    for (const value of [new Proxy({}, {}), getter, cycle, new Date()]) {
+      expectBindingError(() => resolveBinding({ source: 'fixed', value } as unknown as Binding, context()), 'unsafe-value');
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+describe('canonical array traversal', () => {
+  it('rejects sparse arrays at context, source, intermediate, and final boundaries', () => {
+    const sparse = Array(2) as unknown as Record<string, JsonValue>;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'value' }, [] as unknown as WorkflowBindingContext), 'unsafe-value');
+    for (const [source, path] of [['input', 'value'], ['trigger', 'kind'], ['run', 'id']] as const) {
+      const value = context() as unknown as Record<string, unknown>;
+      value[source] = sparse;
+      expectBindingError(() => resolveBinding({ source, path }, value as unknown as WorkflowBindingContext), 'unsafe-value');
+    }
+    const nodes = context();
+    nodes.nodes = sparse as unknown as WorkflowBindingContext['nodes'];
+    expectBindingError(() => resolveBinding({ source: 'node', nodeId: 'plan', path: 'text' }, nodes), 'unsafe-value');
+    const nested = context();
+    nested.input = { nested: sparse } as unknown as Record<string, JsonValue>;
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'nested.value' }, nested), 'unsafe-value');
+    expectBindingError(() => resolveBinding({ source: 'input', path: 'nested' }, nested), 'unsafe-value');
+  });
+
+  it('rejects exotic arrays without invoking accessors while cloning dense arrays', () => {
+    class ArraySubclass extends Array<unknown> {}
+    const extra: unknown[] & { extra?: boolean } = [1];
+    extra.extra = true;
+    const symbol = [1];
+    Object.defineProperty(symbol, Symbol('unsafe'), { value: true, enumerable: true });
+    const hidden = [1];
+    Object.defineProperty(hidden, '0', { value: 1, enumerable: false });
+    let calls = 0;
+    const accessor = [1];
+    Object.defineProperty(accessor, '0', { enumerable: true, get() { calls += 1; return 1; } });
+    for (const array of [new ArraySubclass(1), extra, symbol, hidden, accessor]) {
+      const value = context();
+      value.input = { array } as unknown as Record<string, JsonValue>;
+      expectBindingError(() => resolveBinding({ source: 'input', path: 'array' }, value), 'unsafe-value');
+    }
+    const dense = [1, { safe: true }];
+    const value = context();
+    value.input = { dense };
+    const resolved = resolveBinding({ source: 'input', path: 'dense' }, value);
+    expect(resolved).toEqual(dense);
+    expect(resolved).not.toBe(dense);
+    expect(calls).toBe(0);
+  });
+
+  it('returns canonical copies and never mutates or leaks live references', () => {
+    const original = { nested: [{ value: 'before' }] };
+    const binding = { source: 'input', path: 'data' } as const;
+    const value = context();
+    value.input = { data: original };
+    const snapshot = structuredClone(value.input);
+    const resolved = resolveBinding(binding, value) as { nested: Array<{ value: string }> };
+
+    expect(resolved).toEqual(original);
+    expect(resolved).not.toBe(original);
+    expect(resolved.nested).not.toBe(original.nested);
+    resolved.nested[0]!.value = 'after';
+    expect(original.nested[0]!.value).toBe('before');
+    expect(value.input).toEqual(snapshot);
+    expect(binding).toEqual({ source: 'input', path: 'data' });
+  });
+
+  it('maps malformed binding shapes to invalid-path and never leaks Zod errors', () => {
+    for (const binding of [null, {}, { source: 'unknown' }, { source: 'input' }, { source: 'input', path: 1 }]) {
+      expectBindingError(() => resolveBinding(binding as Binding, context()), 'invalid-path');
+    }
+  });
+});
+
+describe('interpolateWorkflowPrompt', () => {
+  it('interpolates every source with optional inner whitespace', () => {
+    expect(interpolateWorkflowPrompt(
+      'Review {{input.reviewer}} from {{ trigger.payload.repository }} in {{run.id}}: {{ node.plan.text }}',
+      context(),
+    )).toBe('Review reviewer from example/repository in run-1: Plan ready.');
+  });
+
+  it.each([
+    ['{{ input.unicode }}', 'Здравей'],
+    ['{{ input.count }}', '2'],
+    ['{{ input.approved }}', 'true'],
+    ['{{ input.empty }}', 'null'],
+    ['{{ input.negativeZero }}', '0'],
+  ])('renders the primitive placeholder %s explicitly', (template, expected) => {
+    expect(interpolateWorkflowPrompt(template, context())).toBe(expected);
+  });
+
+  it('resolves repeated placeholders independently in one pass', () => {
+    expect(interpolateWorkflowPrompt('{{ input.reviewer }} / {{ input.reviewer }}', context())).toBe('reviewer / reviewer');
+    expect(interpolateWorkflowPrompt('{{ input.braces }}', context())).toBe('{{ trigger.kind }}');
+  });
+
+  it.each(['{{ input.list }}', '{{ input.record }}', '{{ node.plan.fields }}'])('rejects composite prompt value %s', (template) => {
+    expectBindingError(() => interpolateWorkflowPrompt(template, context()), 'type-mismatch');
+  });
+
+  it.each([
+    '{{ }}', '{{ unknown.value }}', '{{ fixed.value }}', '{{ node }}', '{{ node.plan }}',
+    '{{ input.input.value }}', '{{ trigger.trigger.payload }}', '{{ run.run.id }}', '{{ node.plan.nodes.other }}',
+    '{{ input.items[0] }}', '{{ input.call() }}', '{{ input.a+b }}',
+    '{{ input.__proto__ }}', '{{ input.prototype }}', '{{ input.constructor }}',
+    '{{{ input.reviewer }}}', '{{ input.{{ reviewer }} }}', '{{ input.reviewer }}}',
+    '{{ input.reviewer ', 'input.reviewer }}', '{{ input.reviewer }} {{', '}}',
+  ])('rejects malformed placeholder %s', (template) => {
+    expectBindingError(() => interpolateWorkflowPrompt(template, context()), 'invalid-path');
+  });
+
+  it.each([
+    ['input.input.x', '{{ input.input.x }}'], ['trigger.trigger.x', '{{ trigger.trigger.x }}'],
+    ['run.run.x', '{{ run.run.x }}'], ['nodes.plan.x', '{{ node.plan.nodes.plan }}'],
+  ])('rejects duplicated multi-segment root %s in direct and prompt paths', (path, prompt) => {
+    expectBindingError(() => resolveBinding({ source: 'input', path } as Binding, context()), 'invalid-path');
+    expectBindingError(() => interpolateWorkflowPrompt(prompt, context()), 'invalid-path');
+  });
+
+  it('returns plain text without double braces unchanged', () => {
+    expect(interpolateWorkflowPrompt('Plain {text} stays unchanged.', context())).toBe('Plain {text} stays unchanged.');
+  });
+
+  it('aborts on an unresolved placeholder instead of returning a partial result', () => {
+    expectBindingError(() => interpolateWorkflowPrompt('resolved {{ input.reviewer }}, missing {{ input.absent }}', context()), 'missing-value');
+  });
+
+  it('maps non-string templates to invalid-path', () => {
+    expectBindingError(() => interpolateWorkflowPrompt({} as string, context()), 'invalid-path');
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/capacity.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/capacity.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowBindingContext } from '../bindings.js';
+import {
+  resolveFanoutConcurrency,
+  systemConcurrencyCeiling,
+  type WorkflowCapacitySnapshot,
+} from '../capacity.js';
+import type { WorkflowCallNode } from '../model.js';
+
+const GIB = 1024 ** 3;
+
+function snapshot(overrides: Partial<WorkflowCapacitySnapshot> = {}): WorkflowCapacitySnapshot {
+  return { cpus: 9, freeMemBytes: 64 * GIB, activeEngineSessions: 0, ...overrides };
+}
+
+function callNode(concurrency: WorkflowCallNode['config']['concurrency']): WorkflowCallNode {
+  return {
+    id: 'children', type: 'workflow-call', name: 'Children',
+    config: { workflowId: { source: 'fixed', value: 'child-flow' }, concurrency },
+  };
+}
+
+function context(output: Record<string, unknown> | null): WorkflowBindingContext {
+  return {
+    input: {},
+    trigger: { kind: 'manual', payload: {} },
+    nodes: { plan: { status: 'completed', output: output === null ? null : { text: '', fields: output as never }, error: null } },
+    run: { id: 'run_1', startedAt: '2026-08-05T12:00:00.000Z' },
+  };
+}
+
+describe('systemConcurrencyCeiling', () => {
+  it('is bound by the cores left over once the gateway keeps one', () => {
+    expect(systemConcurrencyCeiling(snapshot({ cpus: 5 }))).toBe(4);
+  });
+
+  it('is bound by free memory when the machine would otherwise swap', () => {
+    expect(systemConcurrencyCeiling(snapshot({ cpus: 17, freeMemBytes: 1 * GIB }))).toBe(2);
+  });
+
+  it('is bound by the engine sessions already holding the machine', () => {
+    expect(systemConcurrencyCeiling(snapshot({ activeEngineSessions: 5 }))).toBe(3);
+  });
+
+  it('never drops below one, however starved the machine is', () => {
+    expect(systemConcurrencyCeiling({ cpus: 1, freeMemBytes: 0, activeEngineSessions: 99 })).toBe(1);
+  });
+
+  it('never rises above the authored maximum of sixteen', () => {
+    expect(systemConcurrencyCeiling({ cpus: 64, freeMemBytes: 1024 * GIB, activeEngineSessions: 0 })).toBe(16);
+  });
+});
+
+describe('resolveFanoutConcurrency', () => {
+  it('passes an authored number through when no capacity signal is wired', () => {
+    expect(resolveFanoutConcurrency(callNode(6), context({ degree: 3 }), null))
+      .toEqual({ requested: 6, effective: 6, limitedBy: 'requested' });
+  });
+
+  it('takes the degree a predecessor node emitted', () => {
+    expect(resolveFanoutConcurrency(callNode({ source: 'node', nodeId: 'plan', path: 'fields.degree' }), context({ degree: 7 }), null))
+      .toEqual({ requested: 7, effective: 7, limitedBy: 'requested' });
+  });
+
+  it('clamps a request the machine cannot serve and says so', () => {
+    expect(resolveFanoutConcurrency(callNode(9), context(null), snapshot({ cpus: 4 })))
+      .toEqual({ requested: 9, effective: 3, limitedBy: 'system-ceiling' });
+  });
+
+  it('leaves a request under the ceiling alone', () => {
+    expect(resolveFanoutConcurrency(callNode(2), context(null), snapshot({ cpus: 4 })))
+      .toEqual({ requested: 2, effective: 2, limitedBy: 'requested' });
+  });
+
+  const rejected: [string, unknown][] = [
+    ['zero', 0],
+    ['a negative', -3],
+    ['a fraction', 2.5],
+    ['a string', 'many'],
+    ['null', null],
+    ['above the authored maximum', 40],
+  ];
+  for (const [label, degree] of rejected) {
+    it(`fails, naming the node, when the binding resolves to ${label}`, () => {
+      expect(() => resolveFanoutConcurrency(
+        callNode({ source: 'node', nodeId: 'plan', path: 'fields.degree' }),
+        context({ degree: degree as never }),
+        null,
+      )).toThrow(/Workflow Call children concurrency/);
+    });
+  }
+
+  it('fails, naming the node, when the bound path does not exist', () => {
+    expect(() => resolveFanoutConcurrency(
+      callNode({ source: 'node', nodeId: 'plan', path: 'fields.missing' }),
+      context({ degree: 3 }),
+      null,
+    )).toThrow(/Workflow Call children concurrency/);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/contract.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/contract.test.ts
@@ -1,0 +1,84 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import { buildNodeContract } from "../contract.js";
+import type { EmployeeNode, WorkflowOutputSchema } from "../model.js";
+
+function employeeNode(output?: WorkflowOutputSchema): EmployeeNode {
+  return {
+    id: "draft",
+    type: "employee",
+    name: "Draft",
+    config: {
+      employee: { source: "fixed", value: "writer" },
+      prompt: "Draft the release.",
+      ...(output ? { output } : {}),
+    },
+  };
+}
+
+describe("workflow node completion contract", () => {
+  it("renders every declared field with type, required marker, and description", () => {
+    const contract = buildNodeContract(employeeNode({
+      fields: {
+        title: { type: "string", required: true, description: "Published title" },
+        score: { type: "number", required: false, description: "Confidence | 0-100" },
+      },
+      allowAdditionalFields: false,
+    }), []);
+
+    expect(contract).toContain("| `title` | string | yes | Published title |");
+    expect(contract).toContain("| `score` | number | no | Confidence \\| 0-100 |");
+    expect(contract).toContain("call the `workflow_submit_output` tool with these fields");
+  });
+
+  it("tells the employee how to produce an attachment ref, only when one is declared", () => {
+    const withAttachment = buildNodeContract(employeeNode({
+      fields: { shot: { type: "attachment", required: true }, notes: { type: "attachment[]", required: false } },
+      allowAdditionalFields: false,
+    }), []);
+
+    expect(withAttachment).toContain("| `shot` | attachment | yes |  |");
+    expect(withAttachment).toContain("| `notes` | attachment[] | no |  |");
+    expect(withAttachment).toContain("attach_to_work_item");
+    expect(withAttachment).toContain("attachment:<TODO-ID>:<attachment-id>:<mime>");
+
+    const withoutAttachment = buildNodeContract(employeeNode({
+      fields: { title: { type: "string", required: true } },
+      allowAdditionalFields: false,
+    }), []);
+
+    expect(withoutAttachment).not.toContain("attach_to_work_item");
+  });
+
+  it("omits the field table when no structured output schema is declared", () => {
+    const contract = buildNodeContract(employeeNode(), []);
+
+    expect(contract).not.toContain("| Field |");
+    expect(contract).toContain("Calling `workflow_submit_output` is what completes this workflow step");
+    expect(contract).toContain("```jinn-output");
+  });
+
+  it("lists readable upstream sessions and omits entries without a session", () => {
+    const contract = buildNodeContract(employeeNode(), [
+      { nodeId: "research", sessionId: "session-research" },
+      { nodeId: "approval" },
+      { nodeId: "review", sessionId: "session-review" },
+    ]);
+
+    expect(contract).toContain("read_session");
+    expect(contract).toContain("get_message_context");
+    expect(contract).toContain("`research: session-research`");
+    expect(contract).toContain("`review: session-review`");
+    expect(contract).not.toContain("`approval:");
+  });
+
+  it("stays below 4 KiB for a twenty-field schema", () => {
+    const fields = Object.fromEntries(Array.from({ length: 20 }, (_, index) => [
+      `field_${index}`,
+      { type: "string" as const, required: index % 2 === 0, description: `Field ${index} result` },
+    ]));
+    const contract = buildNodeContract(employeeNode({ fields, allowAdditionalFields: false }), []);
+
+    expect(Buffer.byteLength(contract, "utf8")).toBeLessThan(4 * 1024);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/definition-retirement.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/definition-retirement.test.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletionListener } from '../../shared/types.js';
+import type { WorkflowDefinition, WorkflowNode } from '../model.js';
+import { openWorkflowDatabase } from '../repository-migrations.js';
+import { WorkflowRepository, WorkflowRepositoryError } from '../repository.js';
+import type { WorkflowSessionExecutor } from '../session-executor.js';
+import { WorkflowService } from '../service.js';
+
+/* Retiring used to be a trapdoor: `retired_at` was set and nothing could clear it,
+ * so an archived Workflow was frozen out of every other mutation for good. These
+ * cover the way back, and the guards that keep each direction one-way per call. */
+
+class Executor {
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    return { sessionId: `session:${command.owner.runId}` };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+}
+
+const employee: Employee = { name: 'worker', displayName: 'Worker', department: 'operations', rank: 'employee',
+  engine: 'test-engine', model: 'test-model', effortLevel: 'high', persona: 'Complete work.' };
+const models: ModelRegistry = { 'test-engine': { name: 'test-engine', available: true, defaultModel: 'test-model',
+  effortMechanism: 'codex-config', models: [{ id: 'test-model', label: 'Test', supportsEffort: true, effortLevels: ['high'] }] } };
+const trigger: WorkflowNode = { id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } };
+const finish: WorkflowNode = { id: 'finish', type: 'end', name: 'Finish', config: { result: 'success' } };
+const edges = [{ id: 'start-finish', from: { nodeId: 'start', port: 'success' as const },
+  to: { nodeId: 'finish', port: 'input' as const } }];
+
+const RETIRED_AT = '2026-07-21T03:30:00.000Z';
+
+let root: string;
+let db: Database.Database;
+let repository: WorkflowRepository;
+let definitionChanges: Array<{ workflowId: string; revision: number }>;
+let service: WorkflowService;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'jinn-workflow-retirement-'));
+  db = openWorkflowDatabase(path.join(root, 'workflows.db'));
+  repository = new WorkflowRepository(db, () => '2026-07-21T04:00:00.000Z');
+  definitionChanges = [];
+  service = new WorkflowService({
+    repository,
+    executor: new Executor() as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    onDefinitionChange: (change) => definitionChanges.push(change),
+    now: () => RETIRED_AT,
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  db.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+/** A runnable definition: a manual trigger a run can be created against. */
+function runnable(id: string): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  return repository.saveDefinition({ ...created, nodes: [trigger, finish], edges }, created.revision);
+}
+
+function retiredColumn(id: string): string | null {
+  return db.prepare('SELECT retired_at FROM workflow_definitions WHERE id = ?').pluck().get(id) as string | null;
+}
+
+function expectCode(action: () => unknown, code: WorkflowRepositoryError['code']): void {
+  expect(action).toThrow(expect.objectContaining({ name: 'WorkflowRepositoryError', code }));
+}
+
+describe('WorkflowRepository.setRetired', () => {
+  it('clears the retirement, bumps the revision, and leaves the definition disabled', () => {
+    const created = repository.createDefinition({ id: 'round-trip', title: 'Round trip' });
+    const enabled = repository.setEnabled(created.id, true, created.revision);
+    const retired = repository.setRetired(created.id, true, enabled.revision, RETIRED_AT);
+    expect(retired).toMatchObject({ enabled: false, retiredAt: RETIRED_AT, revision: 3 });
+
+    const unretired = repository.setRetired(created.id, false, retired.revision, RETIRED_AT);
+
+    expect(unretired).not.toHaveProperty('retiredAt');
+    expect(unretired).toMatchObject({ enabled: false, revision: 4 });
+    // The column and the JSON blob are written separately, and a disagreement
+    // between them is what `parseStoredDefinition` reports as a corrupt record.
+    expect(retiredColumn(created.id)).toBeNull();
+    expect(repository.getDefinition(created.id)).toEqual(unretired);
+  });
+
+  it('leaves the row untouched when the expected revision is stale', () => {
+    const created = repository.createDefinition({ id: 'stale', title: 'Stale' });
+    const retired = repository.setRetired(created.id, true, created.revision, RETIRED_AT);
+
+    expectCode(() => repository.setRetired(created.id, false, retired.revision - 1, RETIRED_AT), 'revision-conflict');
+
+    expect(repository.getDefinition(created.id)).toEqual(retired);
+    expect(retiredColumn(created.id)).toBe(RETIRED_AT);
+  });
+
+  it('refuses to unretire a definition that is not retired', () => {
+    const created = repository.createDefinition({ id: 'live', title: 'Live' });
+
+    expectCode(() => repository.setRetired(created.id, false, created.revision, RETIRED_AT), 'bad-input');
+
+    expect(repository.getDefinition(created.id)).toEqual(created);
+  });
+
+  it('still refuses to retire a definition that is already retired', () => {
+    const created = repository.createDefinition({ id: 'twice', title: 'Twice' });
+    const retired = repository.setRetired(created.id, true, created.revision, RETIRED_AT);
+
+    expectCode(() => repository.setRetired(created.id, true, retired.revision, RETIRED_AT), 'retired');
+  });
+
+  it('reports a missing definition as not-found', () => {
+    expectCode(() => repository.setRetired('missing', false, 1, RETIRED_AT), 'not-found');
+  });
+
+  it('validates its arguments before taking the write lock', () => {
+    const created = repository.createDefinition({ id: 'guarded', title: 'Guarded' });
+    const prepare = vi.spyOn(db, 'prepare');
+
+    expectCode(() => repository.setRetired('Invalid', false, 1, RETIRED_AT), 'bad-input');
+    expectCode(() => repository.setRetired(created.id, 'yes' as unknown as boolean, 1, RETIRED_AT), 'bad-input');
+    expectCode(() => repository.setRetired(created.id, true, 1.5, RETIRED_AT), 'revision-conflict');
+    expectCode(() => repository.setRetired(created.id, true, 1, 1 as unknown as string), 'bad-input');
+
+    expect(prepare).not.toHaveBeenCalled();
+    prepare.mockRestore();
+  });
+
+  it('makes the definition editable and enable-able again', () => {
+    const created = runnable('editable');
+    const retired = repository.setRetired(created.id, true, created.revision, RETIRED_AT);
+    expectCode(() => repository.setEnabled(created.id, true, retired.revision), 'retired');
+    expectCode(() => repository.saveDefinition({ ...retired, title: 'Changed' }, retired.revision), 'retired');
+
+    const unretired = repository.setRetired(created.id, false, retired.revision, RETIRED_AT);
+    const saved = repository.saveDefinition({ ...unretired, title: 'Changed' }, unretired.revision);
+    const enabled = repository.setEnabled(saved.id, true, saved.revision);
+
+    expect(enabled).toMatchObject({ title: 'Changed', enabled: true });
+  });
+
+  it('keeps the runs a definition had before it was archived', () => {
+    const created = runnable('with-runs');
+    const run = repository.createRun({ workflowId: created.id, input: {},
+      trigger: { nodeId: 'start', kind: 'manual', payload: {} } });
+    const retired = repository.setRetired(created.id, true, created.revision, RETIRED_AT);
+
+    expect(repository.listRuns(created.id, {}).items.map((item) => item.id)).toEqual([run.id]);
+
+    repository.setRetired(created.id, false, retired.revision, RETIRED_AT);
+
+    expect(repository.listRuns(created.id, {}).items.map((item) => item.id)).toEqual([run.id]);
+  });
+});
+
+describe('WorkflowService.setRetired', () => {
+  it('reports the change so triggers are rebuilt in both directions', () => {
+    const created = service.createDefinition({ id: 'notified', title: 'Notified' });
+    const retired = service.setRetired({ id: created.id, retired: true, expectedRevision: created.revision });
+    definitionChanges.length = 0;
+
+    const unretired = service.setRetired({ id: created.id, retired: false, expectedRevision: retired.revision });
+
+    expect(unretired).not.toHaveProperty('retiredAt');
+    expect(unretired.enabled).toBe(false);
+    expect(definitionChanges).toEqual([{ workflowId: created.id, revision: unretired.revision }]);
+  });
+
+  it('stamps the retirement with the service clock', () => {
+    const created = service.createDefinition({ id: 'stamped', title: 'Stamped' });
+
+    const retired = service.setRetired({ id: created.id, retired: true, expectedRevision: created.revision });
+
+    expect(retired.retiredAt).toBe(RETIRED_AT);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/employee-continuation.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/employee-continuation.test.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { continuationPrompt, resolveEmployeeContinuation } from '../employee-continuation.js';
+import type { EmployeeNode, WorkflowDefinition, WorkflowNode } from '../model.js';
+import { workflowDefinitionSchema } from '../model.js';
+import { openWorkflowDatabase } from '../repository-migrations.js';
+import { WorkflowRepository } from '../repository.js';
+import type { ResolvedEmployeeConfig, WorkflowRunDetail, WorkflowRunRecord } from '../runtime.js';
+import { validateExecutableWorkflow } from '../validation.js';
+
+const CONFIG: ResolvedEmployeeConfig = {
+  employeeId: 'worker', engine: 'codex', model: 'gpt',
+  retry: { attempts: 1, delaySeconds: 0, backoff: 'fixed' },
+};
+
+function nodes(continueFrom?: { nodeId: string; prompt: string }): WorkflowNode[] {
+  return [
+    { id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } },
+    { id: 'first', type: 'employee', name: 'First', config: { employee: { source: 'fixed', value: 'worker' }, prompt: 'Do the work.' } },
+    { id: 'second', type: 'employee', name: 'Second', config: {
+      employee: { source: 'fixed', value: 'worker' }, prompt: 'Do the work again.', ...(continueFrom ? { continueFrom } : {}) } },
+    { id: 'finish', type: 'end', name: 'Finish', config: { result: 'success' } },
+  ];
+}
+
+function definition(continueFrom?: { nodeId: string; prompt: string }): WorkflowDefinition {
+  return {
+    schemaVersion: 1, id: 'flow', title: 'Flow', revision: 1, enabled: false, nodes: nodes(continueFrom),
+    edges: [
+      { id: 'a', from: { nodeId: 'start', port: 'success' }, to: { nodeId: 'first', port: 'input' } },
+      { id: 'b', from: { nodeId: 'first', port: 'success' }, to: { nodeId: 'second', port: 'input' } },
+      { id: 'c', from: { nodeId: 'second', port: 'success' }, to: { nodeId: 'finish', port: 'input' } },
+    ],
+    createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+function node(id: 'first' | 'second', continueFrom?: { nodeId: string; prompt: string }): EmployeeNode {
+  return nodes(continueFrom).find((item) => item.id === id) as EmployeeNode;
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+
+function run(input: {
+  runId: string; todoId?: string; startedAt?: string;
+  attempts?: Array<{ nodeId: string; status: string; sessionId?: string }>;
+}): WorkflowRunDetail {
+  const startedAt = input.startedAt ?? '2026-08-01T00:00:00.000Z';
+  return {
+    id: input.runId, workflowId: 'flow', workflowTitle: 'Flow', definitionRevision: 1, definition: definition(),
+    input: {}, trigger: { nodeId: 'start', kind: 'manual', payload: {}, ...(input.todoId ? { todoId: input.todoId } : {}) },
+    status: 'running', revision: 1, startedAt, nodeRuns: [], approvals: [], childRuns: [],
+    attempts: (input.attempts ?? []).map((attempt, index) => ({
+      runId: input.runId, nodeId: attempt.nodeId, attempt: index + 1, status: attempt.status, resolvedConfig: CONFIG,
+      input: {}, startedAt, remindersSent: 0, extensions: 0, lastProcessedTurn: 0,
+      ...(attempt.sessionId ? { sessionId: attempt.sessionId } : {}),
+    })),
+  } as unknown as WorkflowRunDetail;
+}
+
+/** The instant a millisecond either side of a stored run, so a test can place the
+ *  run it is resolving for either side of one the repository stamped itself. */
+const before = (instant: string) => new Date(Date.parse(instant) - 1).toISOString();
+const after = (instant: string) => new Date(Date.parse(instant) + 1).toISOString();
+
+/** Records a completed attempt of `first` in a run of `flow` bound to `todoId`. */
+function priorRun(input: {
+  runId: string; todoId?: string; sessionId: string; status?: string; engine?: string;
+}): WorkflowRunRecord {
+  const created = repository.createRun({
+    workflowId: 'flow', input: {}, idempotencyKey: input.runId,
+    trigger: { nodeId: 'start', kind: 'manual', payload: {}, ...(input.todoId ? { todoId: input.todoId } : {}) },
+  }, definition());
+  const dispatched = repository.mutateRun(created.id, created.revision, (tx) => {
+    tx.setNodeStatus('first', 'dispatching', { activated: true });
+    tx.createAttempt({ nodeId: 'first', resolvedConfig: { ...CONFIG, engine: input.engine ?? CONFIG.engine }, input: {} });
+    tx.settleAttempt('first', 1, { status: 'running', sessionId: input.sessionId });
+    return tx;
+  }) && repository.getRun('flow', created.id)!;
+  const endedAt = '2026-08-01T01:00:00.000Z';
+  repository.mutateRun(created.id, dispatched.revision, (tx) => {
+    tx.settleAttempt('first', 1, input.status === 'failed'
+      ? { status: 'failed', endedAt, error: { code: 'boom', message: 'Attempt failed.', retryable: false } }
+      : { status: 'completed', endedAt, output: { text: 'done', fields: {} } });
+  });
+  return created;
+}
+
+const always = (id: string) => `engine-of-${id}`;
+const never = () => null;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'jinn-continuation-'));
+  database = openWorkflowDatabase(path.join(root, 'workflows.db'));
+  repository = new WorkflowRepository(database);
+  repository.createDefinition({ id: 'flow', title: 'Flow' });
+});
+
+afterEach(() => {
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('continueFrom validation', () => {
+  it('accepts a definition naming an existing node and rejects an unknown one', () => {
+    const known = definition({ nodeId: 'first', prompt: 'Continue.' });
+    expect(workflowDefinitionSchema.safeParse(known).success).toBe(true);
+    expect(validateExecutableWorkflow(known)).toEqual({ ok: true, issues: [] });
+
+    const unknown = definition({ nodeId: 'ghost', prompt: 'Continue.' });
+    expect(validateExecutableWorkflow(unknown)).toEqual({ ok: false, issues: [
+      { code: 'unknown-continue-node', message: 'Continuation references an unknown node.', nodeId: 'second', path: 'nodes.2.config.continueFrom.nodeId' },
+    ] });
+  });
+
+  it('leaves a definition without the field valid', () => {
+    expect(validateExecutableWorkflow(definition())).toEqual({ ok: true, issues: [] });
+  });
+});
+
+describe('resolving an employee continuation', () => {
+  const options = (resumable: (sessionId: string, engine: string) => string | null) =>
+    ({ repository, resumableEngineSession: resumable });
+
+  it('is null for a node that does not declare one', () => {
+    const detail = run({ runId: 'run-1', attempts: [{ nodeId: 'first', status: 'completed', sessionId: 'session-1' }] });
+    expect(resolveEmployeeContinuation(detail, node('second'), 'codex', options(always))).toBeNull();
+  });
+
+  it('prefers the newest completed attempt of the named node in this run', () => {
+    const detail = run({ runId: 'run-1', todoId: 'PLA-1', attempts: [
+      { nodeId: 'first', status: 'completed', sessionId: 'session-old' },
+      { nodeId: 'first', status: 'completed', sessionId: 'session-new' },
+    ] });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'codex', options(always)))
+      .toEqual({ sessionId: 'session-new', engineSessionId: 'engine-of-session-new' });
+  });
+
+  it('falls back to a prior run of the same Workflow bound to the same Todo', () => {
+    const prior = priorRun({ runId: 'prior', todoId: 'PLA-1', sessionId: 'session-prior' });
+    const detail = run({ runId: 'run-2', todoId: 'PLA-1', startedAt: after(prior.startedAt) });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'codex', options(always)))
+      .toEqual({ sessionId: 'session-prior', engineSessionId: 'engine-of-session-prior' });
+  });
+
+  it.each([
+    ['a prior run bound to a different Todo', { todoId: 'PLA-999', status: 'completed' }, 'PLA-1'],
+    ['a prior run bound to no Todo', { status: 'completed' }, 'PLA-1'],
+    ['an attempt that did not complete', { todoId: 'PLA-1', status: 'failed' }, 'PLA-1'],
+    ['a completed attempt of another engine', { todoId: 'PLA-1', status: 'completed', engine: 'claude' }, 'PLA-1'],
+  ])('never selects %s', (_label, prior: { todoId?: string; status?: string; engine?: string }, todoId) => {
+    const stored = priorRun({ runId: 'prior', sessionId: 'session-prior', ...prior });
+    const detail = run({ runId: 'run-2', todoId, startedAt: after(stored.startedAt) });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'codex', options(always))).toBeNull();
+  });
+
+  it('never selects a run of the same Todo that started after this one', () => {
+    const later = priorRun({ runId: 'later', todoId: 'PLA-1', sessionId: 'session-from-later-run' });
+    const detail = run({ runId: 'run-2', todoId: 'PLA-1', startedAt: before(later.startedAt) });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'codex', options(always))).toBeNull();
+  });
+
+  it('never selects a candidate this run cannot resume on its own engine', () => {
+    const detail = run({ runId: 'run-1', todoId: 'PLA-1', attempts: [{ nodeId: 'first', status: 'completed', sessionId: 'session-1' }] });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'claude', options(never))).toBeNull();
+  });
+
+  it('never selects an in-run attempt that ran on another engine, however resumable its session looks', () => {
+    // The attempt ran on codex. Its session has since switched to claude and holds
+    // a claude thread — a ref that belongs to no round of this node.
+    const detail = run({ runId: 'run-1', todoId: 'PLA-1', attempts: [{ nodeId: 'first', status: 'completed', sessionId: 'session-1' }] });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'claude', options(always))).toBeNull();
+  });
+
+  it('does not look across runs when this run is bound to no Todo', () => {
+    const prior = priorRun({ runId: 'prior', todoId: 'PLA-1', sessionId: 'session-prior' });
+    const detail = run({ runId: 'run-2', startedAt: after(prior.startedAt) });
+    expect(resolveEmployeeContinuation(detail, node('second', { nodeId: 'first', prompt: 'Continue.' }), 'codex', options(always))).toBeNull();
+  });
+});
+
+describe('the prompt an attempt goes out with', () => {
+  it('is the delta when it continues something and the node brief otherwise', () => {
+    const continuing = node('second', { nodeId: 'first', prompt: 'Only the findings.' });
+    expect(continuationPrompt(continuing, true)).toBe('Only the findings.');
+    expect(continuationPrompt(continuing, false)).toBe('Do the work again.');
+    expect(continuationPrompt(node('second'), true)).toBe('Do the work again.');
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/engine-chain.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/engine-chain.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { ModelRegistry } from "../../shared/types.js";
+import { engineAvailabilityFailure, engineChain, selectSubstituteEngine } from "../engine-chain.js";
+import type { WorkflowRunDetail } from "../runtime.js";
+
+/**
+ * The walk that decides which engine covers for one that could not serve a turn.
+ * Its rules are all about what NOT to try again: the engine that just failed,
+ * anything this node already burned an attempt on, and anything the registry
+ * does not have.
+ */
+
+const CHAINS: Record<string, readonly string[]> = {
+  codex: ["claude", "grok"],
+  claude: ["codex"],
+  grok: ["pi"],
+};
+const chainFor = (engine: string): readonly string[] => CHAINS[engine] ?? [];
+
+const MODELS = {
+  codex: { name: "codex", available: true, defaultModel: "sol", models: [] },
+  claude: { name: "claude", available: true, defaultModel: "opus", models: [] },
+  grok: { name: "grok", available: true, defaultModel: "grok-4", models: [] },
+  pi: { name: "pi", available: false, defaultModel: "gemma", models: [] },
+} as unknown as ModelRegistry;
+
+/** Just the slice the walk reads: the node's authored fallback and what this
+ *  node has already run on. */
+function run(fallback: unknown, engines: string[]): WorkflowRunDetail {
+  return {
+    definition: { nodes: [{ id: "work", type: "employee", name: "Work", config: { fallback } }] },
+    attempts: engines.map((engine, index) => ({ nodeId: "work", attempt: index + 1, resolvedConfig: { engine } })),
+  } as unknown as WorkflowRunDetail;
+}
+
+const deps = { models: () => MODELS, engineFallback: { chainFor } };
+
+/** The engine's own account of a turn it could not serve. */
+const turnFailed = (message: string) => ({ code: "workflow-step-failed", message, retryable: false });
+
+describe("engineChain", () => {
+  it("walks the config chain transitively, first preference first", () => {
+    expect(engineChain("codex", undefined, chainFor)).toEqual(["claude", "grok", "pi"]);
+  });
+
+  it("terminates on a chain that names its way back", () => {
+    expect(engineChain("claude", "inherit", chainFor)).toEqual(["codex", "grok", "pi"]);
+  });
+
+  it("uses an explicit chain verbatim, ignoring config", () => {
+    expect(engineChain("codex", ["pi", "hermes"], chainFor)).toEqual(["pi", "hermes"]);
+  });
+
+  it("offers nothing when the node opted out", () => {
+    expect(engineChain("codex", "none", chainFor)).toEqual([]);
+  });
+});
+
+describe("selectSubstituteEngine", () => {
+  it("names the first chain member for an availability failure", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", turnFailed("429 rate limit"), deps))
+      .toEqual({ engine: "claude", from: "codex", reason: "rate-limited" });
+  });
+
+  it("skips a member this node already ran on", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex", "claude"]), "work", "codex", turnFailed("usage limit reached"), deps))
+      .toEqual({ engine: "grok", from: "codex", reason: "out of quota" });
+  });
+
+  it("skips a member the registry does not have", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex", "claude", "grok"]), "work", "codex", turnFailed("usage limit reached"), deps))
+      .toBeUndefined();
+  });
+
+  it("offers nothing for a failure another engine cannot get past", () => {
+    for (const failure of [turnFailed("invalid api key"), turnFailed("the tests did not pass"), undefined]) {
+      expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", failure, deps)).toBeUndefined();
+    }
+  });
+
+  it("offers nothing for a verdict the employee submitted, whatever prose it carries", () => {
+    const submitted = { code: "workflow-submitted-failure", message: "Stopping: the API is rate limited.", retryable: false };
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", submitted, deps)).toBeUndefined();
+  });
+
+  it("offers nothing when the base engine has not been attempted yet", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "claude", turnFailed("429 rate limit"), deps)).toBeUndefined();
+  });
+
+  it("offers nothing without a configured chain", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", turnFailed("429 rate limit"), { models: () => MODELS }))
+      .toBeUndefined();
+  });
+});
+
+describe("selectSubstituteEngine — engine health", () => {
+  const quota = turnFailed("usage limit reached");
+  const reading = (state: "exhausted" | "degraded" | "ok", ...engines: string[]) =>
+    ({ ...deps, engineHealth: () => Object.fromEntries(engines.map((engine) => [engine, { state }])) });
+
+  it("prefers a healthy member over one that is out of allowance", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", quota, reading("exhausted", "claude")))
+      .toEqual({ engine: "grok", from: "codex", reason: "out of quota" });
+  });
+
+  it("offers an exhausted member once the healthy ones are spent", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex", "grok"]), "work", "codex", quota, reading("exhausted", "claude")))
+      .toEqual({ engine: "claude", from: "codex", reason: "out of quota" });
+  });
+
+  it("still answers when every member is exhausted, so health cannot empty a chain", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", quota, reading("exhausted", "claude", "grok")))
+      .toEqual({ engine: "claude", from: "codex", reason: "out of quota" });
+  });
+
+  it("takes a member back once its window has passed and it reads ok again", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", quota, reading("ok", "claude")))
+      .toEqual({ engine: "claude", from: "codex", reason: "out of quota" });
+  });
+
+  it("holds back only exhausted members — a degraded one keeps its place", () => {
+    expect(selectSubstituteEngine(run(undefined, ["codex"]), "work", "codex", quota, reading("degraded", "claude")))
+      .toEqual({ engine: "claude", from: "codex", reason: "out of quota" });
+  });
+});
+
+describe("engineAvailabilityFailure", () => {
+  it("carries the reset the engine stated", () => {
+    const at = new Date("2026-08-19T14:00:00.000Z");
+    expect(engineAvailabilityFailure(turnFailed(`usage limit reached — resets at ${at.toISOString()}`)))
+      .toEqual({ reason: "out of quota", resetsAt: at.getTime() / 1000 });
+  });
+
+  it("reads nothing off a failure that is not the engine's own account of the turn", () => {
+    expect(engineAvailabilityFailure({ code: "workflow-attempt-interrupted", message: "usage limit reached", retryable: true } as never))
+      .toBeUndefined();
+    expect(engineAvailabilityFailure(turnFailed("the phase refused to proceed"))).toBeUndefined();
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/fanout-concurrency.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/fanout-concurrency.test.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { Binding, JsonValue, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { workflowNodeSchema } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+import { validateExecutableWorkflow } from "../validation.js";
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class Executor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}` };
+  }
+  async stopAttempt(): Promise<void> { /* nothing to stop in this harness */ }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+  async settle(command: WorkflowAttemptCommand, fields: Record<string, JsonValue>): Promise<void> {
+    const event: WorkflowAttemptCompletion = {
+      sessionId: `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`,
+      owner: command.owner, terminalVersion: 1, turn: 1, outcome: "succeeded",
+      finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\``,
+      completedAt: "2026-08-05T12:05:00.000Z",
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: Executor;
+let service: WorkflowService;
+
+/** `activeEngineSessions` absent leaves the fan-out unclamped, so a test that is
+ *  about the authored degree never depends on the machine it runs on. A large
+ *  count drives the ceiling to its floor of 1 on any machine, which is what
+ *  makes the clamped case deterministic too. */
+function buildService(activeEngineSessions?: () => number): WorkflowService {
+  return new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => "2026-08-05T12:00:00.000Z",
+    ...(activeEngineSessions ? { activeEngineSessions } : {}),
+  });
+}
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function save(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = service.createDefinition({ id, title: id });
+  const saved = service.saveDefinition({ ...created, nodes, edges }, created.revision);
+  return service.setEnabled({ id, enabled: true, expectedRevision: saved.revision });
+}
+
+function childWorkflow(): WorkflowDefinition {
+  return save("child-flow", [
+    { id: "start", type: "trigger", name: "Called", config: { kind: "workflow-call" } },
+    { id: "work", type: "employee", name: "Work", config: {
+      employee: { source: "fixed", value: "worker" }, prompt: "Process {{ input.topic }}.",
+    } },
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+  ], [edge("start-work", "start", "success", "work"), edge("work-finish", "work", "success", "finish")]);
+}
+
+/** A planner node that names the degree of parallelism, then a fan-out that takes
+ *  its width from what the planner emitted. */
+function plannedParent(concurrency: number | Binding<number>, items = 5): WorkflowDefinition {
+  return save("planned-parent", [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "plan", type: "employee", name: "Plan", config: {
+      employee: { source: "fixed", value: "worker" }, prompt: "Decide the degree.",
+    } },
+    { id: "children", type: "workflow-call", name: "Children", config: {
+      workflowId: { source: "fixed", value: "child-flow" },
+      items: { source: "fixed", value: Array.from({ length: items }, (_, index) => ({ topic: index + 1 })) },
+      input: { topic: { source: "trigger", path: "item.topic" } },
+      concurrency,
+    } },
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+  ], [
+    edge("start-plan", "start", "success", "plan"),
+    edge("plan-children", "plan", "success", "children"),
+    edge("children-finish", "children", "success", "finish"),
+  ]);
+}
+
+const DEGREE_FROM_PLAN: Binding<number> = { source: "node", nodeId: "plan", path: "fields.degree" };
+
+async function runWithPlannedDegree(degree: JsonValue): Promise<string> {
+  childWorkflow();
+  const parent = plannedParent(DEGREE_FROM_PLAN);
+  const run = await service.startManual({ workflowId: parent.id, input: {} });
+  await executor.settle(executor.commands[0]!, { degree });
+  return run.id;
+}
+
+function fanoutNode(runId: string) {
+  return service.getRun("planned-parent", runId)!.nodeRuns.find((node) => node.nodeId === "children")!;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-fanout-concurrency-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => "2026-08-05T12:00:00.000Z");
+  executor = new Executor();
+  service = buildService();
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+/** Fix the machine the ceiling is read from, so a scheduling test says the same
+ *  thing on a busy laptop as on a CI box. */
+function pinMachine(cpuHeadroom: number): void {
+  vi.spyOn(os, "availableParallelism").mockReturnValue(cpuHeadroom + 1);
+  vi.spyOn(os, "freemem").mockReturnValue(cpuHeadroom * 512 * 1024 * 1024);
+}
+
+function liveChildren(runId: string): number {
+  return repository.listChildRuns(runId, "children")
+    .filter((child) => !["completed", "failed", "cancelled"].includes(child.status)).length;
+}
+
+/** A child run ends by waking its caller through a fired-and-forgotten advance, so
+ *  the parent's refill lands a few ticks after the child settles. */
+async function refilled(): Promise<void> {
+  for (let tick = 0; tick < 10; tick += 1) await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("adaptive fan-out concurrency", () => {
+  it("runs the number of children a planner node asked for, not the authored default", async () => {
+    const runId = await runWithPlannedDegree(4);
+
+    expect(repository.listChildRuns(runId, "children")).toHaveLength(4);
+    expect(fanoutNode(runId).resolvedConfig).toMatchObject({
+      concurrency: 4, concurrencyEffective: 4, concurrencyLimitedBy: "requested",
+    });
+  });
+
+  it("clamps to what the machine can serve and records both numbers", async () => {
+    service.dispose();
+    service = buildService(() => 1_000);
+    const runId = await runWithPlannedDegree(4);
+
+    expect(repository.listChildRuns(runId, "children")).toHaveLength(1);
+    expect(fanoutNode(runId).resolvedConfig).toMatchObject({
+      concurrency: 4, concurrencyEffective: 1, concurrencyLimitedBy: "system-ceiling",
+    });
+  });
+
+  it("refills a drained wave without charging itself for its own children", async () => {
+    pinMachine(8);
+    let started: string | undefined;
+    service.dispose();
+    service = buildService(() => (started ? liveChildren(started) : 0));
+    childWorkflow();
+    const parent = plannedParent(DEGREE_FROM_PLAN, 12);
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    started = run.id;
+    await executor.settle(executor.commands[0]!, { degree: 8 });
+    expect(repository.listChildRuns(run.id, "children")).toHaveLength(8);
+
+    // The gateway's session count is these eight children; a ceiling that reads it
+    // whole leaves the fan-out competing with itself and the last four items never start.
+    for (const command of executor.commands.slice(1, 5)) await executor.settle(command, {});
+    await refilled();
+
+    expect(repository.listChildRuns(run.id, "children")).toHaveLength(12);
+    expect(fanoutNode(run.id).resolvedConfig).toMatchObject({
+      concurrency: 8, concurrencyEffective: 8, concurrencyLimitedBy: "requested",
+    });
+  });
+
+  it("keeps a bare number scheduling exactly as it always has", async () => {
+    childWorkflow();
+    const parent = plannedParent(3);
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    await executor.settle(executor.commands[0]!, { degree: 5 });
+
+    expect(repository.listChildRuns(run.id, "children")).toHaveLength(3);
+  });
+
+  for (const [label, degree] of [
+    ["zero", 0], ["a negative", -2], ["a fraction", 1.5], ["a string", "four"], ["null", null],
+  ] as [string, JsonValue][]) {
+    it(`fails the run, naming the node, when the planner emits ${label}`, async () => {
+      const runId = await runWithPlannedDegree(degree);
+
+      const run = service.getRun("planned-parent", runId)!;
+      expect(run.status).toBe("failed");
+      expect(fanoutNode(runId)).toMatchObject({
+        status: "failed",
+        error: { message: expect.stringContaining("Workflow Call children concurrency") },
+      });
+      expect(repository.listChildRuns(runId, "children")).toEqual([]);
+    });
+  }
+
+  it("fails the run when the bound path is missing rather than falling back to a default", async () => {
+    childWorkflow();
+    const parent = plannedParent({ source: "node", nodeId: "plan", path: "fields.absent" });
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    await executor.settle(executor.commands[0]!, { degree: 3 });
+
+    expect(service.getRun(parent.id, run.id)?.status).toBe("failed");
+    expect(fanoutNode(run.id).error?.message).toContain("Workflow Call children concurrency");
+    expect(repository.listChildRuns(run.id, "children")).toEqual([]);
+  });
+});
+
+describe("concurrency as an authored value", () => {
+  const node = (concurrency: unknown) => ({
+    id: "children", type: "workflow-call", name: "Children",
+    config: { workflowId: { source: "fixed", value: "child-flow" }, concurrency },
+  });
+
+  it("accepts a bare number and every binding source", () => {
+    for (const concurrency of [1, 16, DEGREE_FROM_PLAN, { source: "fixed", value: 4 }, { source: "input", path: "degree" }]) {
+      expect(workflowNodeSchema.parse(node(concurrency))).toEqual(node(concurrency));
+    }
+  });
+
+  it("rejects a value outside the authored bounds in either arm", () => {
+    for (const concurrency of [0, 17, 2.5, "4", null, { source: "fixed", value: 0 }, { source: "fixed", value: 17 }]) {
+      expect(workflowNodeSchema.safeParse(node(concurrency)).success).toBe(false);
+    }
+  });
+
+  it("reports a concurrency binding that does not point at a predecessor", () => {
+    const definition: WorkflowDefinition = {
+      ...service.createDefinition({ id: "unreachable-degree", title: "Unreachable degree" }),
+      nodes: [
+        { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+        { id: "children", type: "workflow-call", name: "Children", config: {
+          workflowId: { source: "fixed", value: "child-flow" },
+          concurrency: { source: "node", nodeId: "finish", path: "fields.degree" },
+        } },
+        { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+      ],
+      edges: [edge("start-children", "start", "success", "children"), edge("children-finish", "children", "success", "finish")],
+    };
+
+    const result = validateExecutableWorkflow(definition);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? [] : result.issues).toContainEqual(expect.objectContaining({
+      code: "non-predecessor-binding", nodeId: "children", path: "nodes.1.config.concurrency",
+    }));
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/git-landing-evidence.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/git-landing-evidence.test.ts
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createGitLandingEvidence } from "../git-landing-evidence.js";
+
+const roots: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("canonical git landing evidence", () => {
+  it("refuses a local-main-only commit until it reaches the fetched canonical remote branch", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-canonical-landing-"));
+    roots.push(root);
+    const remote = path.join(root, "origin.git");
+    const checkout = path.join(root, "checkout");
+    execFileSync("git", ["init", "--bare", "--initial-branch=main", remote], { stdio: "ignore" });
+    execFileSync("git", ["clone", remote, checkout], { stdio: "ignore" });
+    git(checkout, "config", "user.email", "test@example.invalid");
+    git(checkout, "config", "user.name", "Jinn Test");
+    fs.writeFileSync(path.join(checkout, "proof.txt"), "base\n");
+    git(checkout, "add", "proof.txt");
+    git(checkout, "commit", "-m", "base");
+    git(checkout, "push", "-u", "origin", "main");
+
+    fs.appendFileSync(path.join(checkout, "proof.txt"), "local only\n");
+    git(checkout, "commit", "-am", "local only");
+    const commit = git(checkout, "rev-parse", "HEAD");
+    const evidence = createGitLandingEvidence({ remote: "origin", branch: "main" });
+
+    await expect(evidence.mergedIntoMain({ commit, checkout })).resolves.toBe(false);
+
+    git(checkout, "push", "origin", "main");
+    await expect(evidence.mergedIntoMain({ commit, checkout })).resolves.toBe(true);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/helpers/settle-waits.ts
+++ b/packages/jimmy/src/workflows/__tests__/helpers/settle-waits.ts
@@ -1,0 +1,34 @@
+import { expect, vi } from "vitest";
+import type { SessionManager } from "../../../sessions/manager.js";
+import { getSession } from "../../../sessions/registry.js";
+
+/**
+ * Every wait here is on an observed state change, never on elapsed time — but how long reaching
+ * that state takes is bounded by scheduling, not by wall clock: the service subscribes an async
+ * completion listener the publisher never awaits, and workflow dispatch hops through
+ * `setImmediate` plus a serial session queue. vitest's implicit 1 s `vi.waitFor` ceiling is
+ * therefore a bet on an idle machine, and with several vitest runs contending for the same cores
+ * that bet loses. This ceiling only decides how long a starved machine is allowed to take; it is
+ * not a timing assumption. A state observed never to arrive inside it is a settle-ordering bug in
+ * the runner, not a ceiling to raise.
+ */
+const SETTLE_CEILING_MS = 10_000;
+
+/** Importers pin their test timeout to this: a bare `vitest run` gives 5 s, under the ceiling. */
+export const SETTLE_TEST_TIMEOUT_MS = 30_000;
+
+export function waitForSettle<T>(condition: () => T | Promise<T>): Promise<T> {
+  return vi.waitFor(condition, { timeout: SETTLE_CEILING_MS, interval: 10 });
+}
+
+/**
+ * A late engine result on an already-terminal attempt writes nothing durable — which is what the
+ * cancellation tests assert, and why sequencing them on `setImmediate` ticks left the assertion
+ * resting on a guessed number of event-loop turns. The session's queue slot is released only once
+ * the whole turn task has run, so this is the observable that says the late turn really did land
+ * and really did change nothing.
+ */
+export function waitForTurnDrained(manager: SessionManager, sessionId: string): Promise<void> {
+  const sessionKey = getSession(sessionId)!.sessionKey;
+  return waitForSettle(() => { expect(manager.getQueue().isRunning(sessionKey)).toBe(false); });
+}

--- a/packages/jimmy/src/workflows/__tests__/import-v1.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/import-v1.test.ts
@@ -1,0 +1,225 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { importLegacyWorkflowDefinitions } from "../import-v1.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+
+const roots: string[] = [];
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "jinn-workflow-v1-import-"));
+  roots.push(root);
+  const legacyDirectory = path.join(root, "workflow-evidence", "workflows");
+  const legacyRunsDirectory = path.join(root, "workflow-evidence", "reports", "runs");
+  const reportPath = path.join(root, "workflows", "legacy-v1-import-report.json");
+  mkdirSync(legacyDirectory, { recursive: true });
+  mkdirSync(legacyRunsDirectory, { recursive: true });
+  const db = openWorkflowDatabase(path.join(root, "workflows.db"));
+  return { root, legacyDirectory, legacyRunsDirectory, reportPath, db };
+}
+
+function writeLegacy(directory: string, value: unknown): void {
+  const id = (value as { id: string }).id;
+  writeFileSync(path.join(directory, `${id}.definition.json`), `${JSON.stringify(value)}\n`);
+}
+
+const morningDigest = {
+  schemaVersion: 1,
+  id: "morning-digest",
+  title: "Morning Digest",
+  version: 1,
+  status: "active",
+  updatedAt: "2026-07-11T08:12:13.559Z",
+  nodes: [{
+    id: "trigger",
+    type: "trigger",
+    label: "Trigger",
+    position: { x: 80, y: 120 },
+    trigger: { kind: "manual" },
+  }],
+  edges: [],
+};
+
+const planImplementVerify = {
+  schemaVersion: 1,
+  id: "plan-implement-verify",
+  title: "Plan → Implement → Verify",
+  version: 1,
+  status: "active",
+  updatedAt: "2026-07-12T08:48:50.041Z",
+  nodes: [
+    { id: "trigger", type: "trigger", label: "Manual trigger", position: { x: 0, y: 0 }, trigger: { kind: "manual" } },
+    { id: "plan", type: "step", label: "PLAN", position: { x: 320, y: -100 },
+      actor: { kind: "engine", ref: "codex" }, instructions: "Plan the requested change.",
+      options: { model: "gpt-5.6-sol", effort: "xhigh", retry: { maxAttempts: 2 }, timeoutMinutes: 120 } },
+    { id: "implement", type: "step", label: "IMPLEMENT", position: { x: 760, y: -100 },
+      actor: { kind: "engine", ref: "codex" }, instructions: "Implement the approved plan." },
+    { id: "verify", type: "step", label: "VERIFY", position: { x: 1200, y: -100 },
+      actor: { kind: "engine", ref: "codex" }, instructions: "Verify the implementation." },
+  ],
+  edges: [
+    { id: "trigger-to-plan", from: "trigger", to: "plan", kind: "sequence" },
+    { id: "plan-to-implement", from: "plan", to: "implement", kind: "handoff" },
+    { id: "implement-to-verify", from: "implement", to: "verify", kind: "handoff" },
+  ],
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("legacy Workflow definition import", () => {
+  it("imports behavior-equivalent v1 shapes once as disabled v2 drafts and writes an auditable report", () => {
+    const { legacyDirectory, legacyRunsDirectory, reportPath, db } = fixture();
+    writeLegacy(legacyDirectory, morningDigest);
+    writeLegacy(legacyDirectory, planImplementVerify);
+    const runDirectory = path.join(legacyRunsDirectory, planImplementVerify.id);
+    mkdirSync(runDirectory, { recursive: true });
+    writeFileSync(path.join(runDirectory, "run-active.json"), JSON.stringify({
+      runId: "run-active",
+      workflowId: planImplementVerify.id,
+      status: "running",
+    }));
+    const logs: string[] = [];
+
+    expect(importLegacyWorkflowDefinitions(db, {
+      legacyDirectory,
+      legacyRunsDirectory,
+      reportPath,
+      now: () => "2026-07-24T08:00:00.000Z",
+      log: (_level, message) => logs.push(message),
+    })).toEqual({ imported: 2, failed: 0, skipped: false });
+
+    const rows = db.prepare("SELECT id, enabled, definition_json FROM workflow_definitions ORDER BY id")
+      .all() as Array<{ id: string; enabled: number; definition_json: string }>;
+    expect(rows.map(({ id, enabled }) => ({ id, enabled }))).toEqual([
+      { id: "morning-digest", enabled: 0 },
+      { id: "plan-implement-verify", enabled: 0 },
+    ]);
+    const morning = JSON.parse(rows[0]!.definition_json);
+    const pipeline = JSON.parse(rows[1]!.definition_json);
+    expect(morning.nodes).toEqual([
+      { id: "trigger", type: "trigger", name: "Trigger", config: { kind: "manual" } },
+    ]);
+    expect(pipeline.nodes.map((node: { type: string }) => node.type)).toEqual([
+      "trigger", "employee", "employee", "employee",
+    ]);
+    expect(pipeline.edges).toHaveLength(3);
+    expect(pipeline.ui.positions.verify).toEqual({ x: 1200, y: -100 });
+    expect(logs.filter((line) => line.includes("imported legacy Workflow"))).toHaveLength(2);
+    expect(logs).toEqual(expect.arrayContaining([
+      expect.stringContaining("active legacy Workflow run"),
+      expect.stringContaining(reportPath),
+    ]));
+    expect(existsSync(path.join(legacyDirectory, "morning-digest.definition.json"))).toBe(true);
+    expect(existsSync(path.join(legacyDirectory, "plan-implement-verify.definition.json"))).toBe(true);
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    expect(report).toEqual({
+      schemaVersion: 1,
+      createdAt: "2026-07-24T08:00:00.000Z",
+      legacyDefinitionDirectory: legacyDirectory,
+      legacyRunDirectory: legacyRunsDirectory,
+      definitions: [
+        {
+          file: "morning-digest.definition.json",
+          id: "morning-digest",
+          sourceSha256: createHash("sha256").update(readFileSync(path.join(legacyDirectory, "morning-digest.definition.json"))).digest("hex"),
+          outcome: "imported",
+        },
+        {
+          file: "plan-implement-verify.definition.json",
+          id: "plan-implement-verify",
+          sourceSha256: createHash("sha256").update(readFileSync(path.join(legacyDirectory, "plan-implement-verify.definition.json"))).digest("hex"),
+          outcome: "imported",
+        },
+      ],
+      legacyRuns: {
+        count: 1,
+        active: [{
+          file: "plan-implement-verify/run-active.json",
+          workflowId: "plan-implement-verify",
+          runId: "run-active",
+          status: "running",
+        }],
+      },
+    });
+
+    expect(importLegacyWorkflowDefinitions(db, {
+      legacyDirectory,
+      legacyRunsDirectory,
+      reportPath,
+    })).toEqual({
+      imported: 0, failed: 0, skipped: true,
+    });
+    expect(db.prepare("SELECT count(*) FROM workflow_definitions").pluck().get()).toBe(2);
+    db.close();
+  });
+
+  it("preserves every definition whose behavior cannot be represented exactly and reports why", () => {
+    const { legacyDirectory, legacyRunsDirectory, reportPath, db } = fixture();
+    const definitions = [
+      {
+        ...morningDigest,
+        id: "scheduled-workflow",
+        nodes: [{ ...morningDigest.nodes[0], trigger: { kind: "schedule", cron: "0 8 * * *" } }],
+      },
+      {
+        ...planImplementVerify,
+        id: "gated-workflow",
+        nodes: planImplementVerify.nodes.map((node) => node.id === "plan"
+          ? { ...node, gates: [{ kind: "approval", approvalRef: "operator-review" }] }
+          : node),
+      },
+      {
+        ...planImplementVerify,
+        id: "conditional-workflow",
+        edges: [{
+          id: "conditional",
+          from: "plan",
+          to: "implement",
+          kind: "handoff",
+          when: [{ path: "steps.plan.output.ready", op: "eq", value: true }],
+        }],
+      },
+      {
+        ...planImplementVerify,
+        id: "loop-workflow",
+        edges: [{ id: "loop", from: "verify", to: "plan", kind: "loop" }],
+      },
+      {
+        ...planImplementVerify,
+        id: "session-workflow",
+        nodes: planImplementVerify.nodes.map((node) => node.id === "plan"
+          ? { ...node, options: { ...node.options, session: { mode: "existing", sessionId: "session-1" } } }
+          : node),
+      },
+    ];
+    for (const definition of definitions) writeLegacy(legacyDirectory, definition);
+    const logs: string[] = [];
+    expect(importLegacyWorkflowDefinitions(db, {
+      legacyDirectory,
+      legacyRunsDirectory,
+      reportPath,
+      now: () => "2026-07-24T08:01:00.000Z",
+      log: (_level, message) => logs.push(message),
+    })).toEqual({ imported: 0, failed: 5, skipped: false });
+    expect(logs.filter((line) => line.includes("preserved unsupported legacy Workflow"))).toHaveLength(5);
+    for (const definition of definitions) {
+      expect(existsSync(path.join(legacyDirectory, `${definition.id}.definition.json`))).toBe(true);
+    }
+    expect(db.prepare("SELECT count(*) FROM workflow_definitions").pluck().get()).toBe(0);
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    expect(report.definitions).toHaveLength(5);
+    expect(report.definitions.every((entry: { outcome: string; reason?: string }) => (
+      entry.outcome === "preserved" && typeof entry.reason === "string" && entry.reason.length > 0
+    ))).toBe(true);
+    expect(report.definitions.find((entry: { id: string }) => entry.id === "scheduled-workflow").reason).toMatch(/trigger/i);
+    expect(report.definitions.find((entry: { id: string }) => entry.id === "gated-workflow").reason).toMatch(/gate/i);
+    expect(report.definitions.find((entry: { id: string }) => entry.id === "conditional-workflow").reason).toMatch(/condition/i);
+    expect(report.definitions.find((entry: { id: string }) => entry.id === "loop-workflow").reason).toMatch(/loop/i);
+    expect(report.definitions.find((entry: { id: string }) => entry.id === "session-workflow").reason).toMatch(/session/i);
+    db.close();
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/iteration-harness.ts
+++ b/packages/jimmy/src/workflows/__tests__/iteration-harness.ts
@@ -1,0 +1,58 @@
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue } from "../model.js";
+
+/** The one employee, engine and executor a bounded-iteration run needs. Split
+ *  out of the suite so the suite stays about the loop. */
+
+export const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work.",
+};
+
+export const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+export class Executor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: this.sessionId(command) };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+  /** Settle the attempt the body is currently parked on, reporting `fields`. */
+  async settleLatest(fields: Record<string, JsonValue>): Promise<void> {
+    await this.emit({ outcome: "succeeded", finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\`` });
+  }
+  /** Break the attempt the body is parked on, the way a crashed round arrives. */
+  async failLatest(): Promise<void> {
+    await this.emit({ outcome: "failed", error: "The body blew up." });
+  }
+  private async emit(outcome: Partial<WorkflowAttemptCompletion>): Promise<void> {
+    const command = this.commands.at(-1)!;
+    const event = {
+      sessionId: this.sessionId(command), owner: command.owner, terminalVersion: 1, turn: 1,
+      completedAt: "2026-08-20T12:05:00.000Z", ...outcome,
+    } as WorkflowAttemptCompletion;
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+  private sessionId(command: WorkflowAttemptCommand): string {
+    return `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+  }
+}

--- a/packages/jimmy/src/workflows/__tests__/iteration-validation.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/iteration-validation.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type { Binding, WorkflowCallNode, WorkflowDefinition, WorkflowEdge, WorkflowNode } from '../model.js';
+import { MAX_ITERATION_ROUNDS, workflowNodeSchema } from '../model.js';
+import { outputPorts, validateExecutableWorkflow } from '../validation.js';
+
+/**
+ * The authoring half of bounded iteration: a loop without a finite bound, or
+ * without anywhere to go once it spends that bound, must not be something a
+ * runnable definition can say.
+ */
+
+const fixed = (value: string): Binding<string> => ({ source: 'fixed', value });
+
+type IterateConfig = NonNullable<WorkflowCallNode['config']['iterate']>;
+
+function rework(round: string): IterateConfig['continueWhile'] {
+  return [{ left: { source: 'node', nodeId: 'loop', path: 'fields.last.verdict' }, operator: 'equals', right: fixed(round) }];
+}
+
+function loop(iterate: Partial<IterateConfig>, extra: Partial<WorkflowCallNode['config']> = {}): WorkflowNode {
+  return {
+    id: 'loop',
+    type: 'workflow-call',
+    name: 'Loop',
+    config: {
+      workflowId: fixed('child-flow'),
+      input: { round: { source: 'trigger', path: 'round' } },
+      concurrency: 1,
+      iterate: { continueWhile: rework('rework'), ...iterate } as IterateConfig,
+      ...extra,
+    },
+  };
+}
+
+function edge(id: string, from: string, to: string, port = 'success'): WorkflowEdge {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: 'input' } };
+}
+
+/** A trigger, the loop, and both of the loop's exits wired to their own ends. */
+function definition(node: WorkflowNode, edges: WorkflowEdge[]): WorkflowDefinition {
+  return {
+    schemaVersion: 1,
+    id: 'iteration-fixture',
+    title: 'Iteration fixture',
+    revision: 1,
+    enabled: false,
+    nodes: [
+      { id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } },
+      node,
+      { id: 'shipped', type: 'end', name: 'Shipped', config: { result: 'success' } },
+      { id: 'escalated', type: 'end', name: 'Escalated', config: { result: 'success' } },
+    ],
+    edges,
+    createdAt: '2026-08-20T00:00:00.000Z',
+    updatedAt: '2026-08-20T00:00:00.000Z',
+  };
+}
+
+const wiredBoth = [
+  edge('start-loop', 'start', 'loop'),
+  edge('loop-shipped', 'loop', 'shipped'),
+  edge('loop-escalated', 'loop', 'escalated', 'exhausted'),
+];
+
+function codes(value: WorkflowDefinition): string[] {
+  return validateExecutableWorkflow(value).issues.map((entry) => entry.code);
+}
+
+describe('bounded iteration validation', () => {
+  it('rejects an iteration with no finite bound, and accepts the same definition once it has one', () => {
+    const unbounded = definition(loop({}), wiredBoth);
+
+    const rejected = validateExecutableWorkflow(unbounded);
+
+    expect(rejected.ok).toBe(false);
+    const found = rejected.issues.find((entry) => entry.code === 'unbounded-iteration');
+    expect(found).toMatchObject({ nodeId: 'loop', path: 'nodes.1.config.iterate.maxRounds' });
+    expect(found?.message).toContain('maxRounds');
+
+    expect(validateExecutableWorkflow(definition(loop({ maxRounds: 2 }), wiredBoth))).toEqual({ ok: true, issues: [] });
+  });
+
+  it('refuses a bound the definition cannot state as a literal', () => {
+    // A binding resolves mid-run, so it could not be read off the definition —
+    // the schema is where that is settled, before any rule gets to look.
+    for (const maxRounds of [0, -1, 1.5, MAX_ITERATION_ROUNDS + 1, { source: 'input', path: 'rounds' }]) {
+      expect(workflowNodeSchema.safeParse(loop({ maxRounds } as unknown as Partial<IterateConfig>)).success,
+        `maxRounds ${JSON.stringify(maxRounds)}`).toBe(false);
+    }
+    expect(workflowNodeSchema.safeParse(loop({ maxRounds: MAX_ITERATION_ROUNDS })).success).toBe(true);
+  });
+
+  it('refuses to both iterate and fan out over items', () => {
+    const both = definition(loop({ maxRounds: 2 }, { items: { source: 'fixed', value: [{ topic: 'one' }] } }), wiredBoth);
+
+    expect(codes(both)).toContain('iteration-with-fanout');
+  });
+
+  it('refuses an iteration with nowhere to go once it spends every round', () => {
+    const unwired = definition(loop({ maxRounds: 2 }), [
+      edge('start-loop', 'start', 'loop'),
+      edge('loop-shipped', 'loop', 'shipped'),
+    ]);
+
+    expect(codes(unwired)).toContain('iteration-missing-exhausted-route');
+  });
+
+  it('gives an iterating node an exhausted port and leaves a plain call with only success', () => {
+    expect(outputPorts(loop({ maxRounds: 2 }))).toEqual(['success', 'exhausted']);
+    expect(outputPorts({
+      id: 'plain', type: 'workflow-call', name: 'Plain',
+      config: { workflowId: fixed('child-flow'), concurrency: 2 },
+    })).toEqual(['success']);
+  });
+
+  it('lets continueWhile read the round that just finished, but keeps every other binding forward-only', () => {
+    expect(codes(definition(loop({ maxRounds: 2 }), wiredBoth))).not.toContain('non-predecessor-binding');
+
+    const selfInput = loop({ maxRounds: 2 }) as WorkflowCallNode;
+    selfInput.config.input = { echo: { source: 'node', nodeId: 'loop', path: 'fields.last' } };
+
+    expect(codes(definition(selfInput, wiredBoth))).toContain('non-predecessor-binding');
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/landing-evidence.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/landing-evidence.test.ts
@@ -1,0 +1,258 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletion, WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+import type { WorkflowTodoLifecycle } from "../runner.js";
+import { endRequirementIssues } from "../validation.js";
+
+/* PLA-180: the operator approved the landing, the land phase then aborted on five
+ * rebase conflicts and reported that it had merged nothing — and the Todo closed
+ * `done` anyway, because reaching a success End behind an approved gate was the
+ * whole test. A success End can now demand the evidence, and an End that demands
+ * it and does not get it blocks the Todo instead of closing it. */
+
+const MERGED = "a5a56ba8c0ffee1234567890abcdef1234567890";
+const PHANTOM = "0123456789abcdef0123456789abcdef01234567";
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete the task.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: `session:${command.owner.nodeId}:${command.owner.attempt}` };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null { return null; }
+  attemptState(): { idle: boolean; runningChildren: number } { return { idle: true, runningChildren: 0 }; }
+
+  async succeed(nodeId: string, fields: Record<string, JsonValue> = {}): Promise<void> {
+    await this.emit(nodeId, { outcome: "succeeded", finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\`` });
+  }
+  async report(nodeId: string, error: string): Promise<void> {
+    await this.emit(nodeId, { outcome: "failed", error });
+  }
+  private async emit(nodeId: string, outcome: Partial<WorkflowAttemptCompletion>): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    await Promise.all([...this.listeners].map((listener) => listener({
+      sessionId: `session:${nodeId}:${command.owner.attempt}`, owner: command.owner,
+      terminalVersion: 1, turn: 1, completedAt: now.toISOString(), outcome: "succeeded", ...outcome,
+    } as WorkflowAttemptCompletion)));
+  }
+}
+
+class RecordingLifecycle implements WorkflowTodoLifecycle {
+  readonly reflections: Array<{ status: string; nodeId: string }> = [];
+  readonly failures: Array<{ nodeId: string; code: string; message: string }> = [];
+  readonly completions: Array<Parameters<WorkflowTodoLifecycle["complete"]>[0]> = [];
+  reflect(input: Parameters<WorkflowTodoLifecycle["reflect"]>[0]): void {
+    this.reflections.push({ status: input.status, nodeId: input.nodeId });
+  }
+  recordFailure(input: Parameters<WorkflowTodoLifecycle["recordFailure"]>[0]): void {
+    this.failures.push({ nodeId: input.nodeId, code: input.error.code, message: input.error.message });
+  }
+  requestRevision(): void {}
+  recordApprovalDecision(): void {}
+  complete(input: typeof this.completions[number]): void { this.completions.push(input); }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let lifecycle: RecordingLifecycle;
+let service: WorkflowService;
+let asked: Array<{ commit: string; checkout: string }>;
+let onMain: boolean | Error;
+const now = new Date("2026-08-22T19:59:00.000Z");
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+function worker(id: string, field: string): WorkflowNode {
+  return {
+    id, type: "employee", name: id, config: {
+      employee: { source: "fixed", value: "worker" }, prompt: `Run ${id}.`,
+      output: { fields: { [field]: { type: "string", required: false } }, allowAdditionalFields: true },
+    },
+  };
+}
+function save(id: string, nodes: WorkflowNode[], edges: ReturnType<typeof edge>[]): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({ ...created, inputs: [], nodes, edges }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+/** trigger → plan → operator gate → land, where the success End demands the
+ *  commit `land` says it produced, in the checkout `plan` named. */
+function landingPipeline(id: string, errorRoute = false): WorkflowDefinition {
+  const requires = { nodeId: "land", field: "mergeCommit", commitIn: { nodeId: "plan", field: "worktree" } };
+  return save(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    worker("plan", "worktree"),
+    { id: "gate", type: "approval", name: "Gate", config: { description: "Approving merges this branch.", operatorOnly: true } },
+    worker("land", "mergeCommit"),
+    { id: "done", type: "end", name: "Done", config: { result: "success", requires } },
+    { id: "not-merged", type: "end", name: "Not merged", config: { result: "failure" } },
+    ...(errorRoute ? [{ id: "handled", type: "end", name: "Handled", config: { result: "success", requires } } as WorkflowNode] : []),
+  ], [
+    edge("start-plan", "start", "success", "plan"),
+    edge("plan-gate", "plan", "success", "gate"),
+    edge("gate-land", "gate", "approved", "land"),
+    edge("gate-stop", "gate", "rejected", "not-merged"),
+    edge("land-done", "land", "success", "done"),
+    ...(errorRoute ? [edge("land-handled", "land", "error", "handled")] : []),
+  ]);
+}
+
+/** Run the PLA-180 sequence up to the point where the landing reports back. */
+async function approvedLanding(id: string, errorRoute = false): Promise<{ definition: WorkflowDefinition; runId: string }> {
+  const definition = landingPipeline(id, errorRoute);
+  const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "PLA-180" });
+  await executor.succeed("plan", { worktree: "/checkouts/pla-180" });
+  await service.decideApproval({ workflowId: definition.id, runId: run.id, nodeId: "gate", decision: "approve",
+    decidedBy: "operator", expectedRevision: service.getRun(definition.id, run.id)!.revision });
+  return { definition, runId: run.id };
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-landing-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  executor = new FakeExecutor();
+  lifecycle = new RecordingLifecycle();
+  asked = [];
+  onMain = true;
+  service = new WorkflowService({
+    repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+    todoLifecycle: lifecycle,
+    landingEvidence: { mergedIntoMain: async (input) => {
+      asked.push(input);
+      if (onMain instanceof Error) throw onMain;
+      return onMain;
+    } },
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("a success End that demands landing evidence", () => {
+  it("blocks the Todo when the landing reported no merge commit", async () => {
+    const { definition, runId } = await approvedLanding("landing-absent");
+    await executor.succeed("land", { summary: "Landing blocked: 5 conflicts, nothing merged." });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("failed");
+    expect(lifecycle.completions).toEqual([]);
+    expect(lifecycle.reflections.at(-1)).toEqual({ status: "blocked", nodeId: "done" });
+    expect(lifecycle.failures.at(-1)).toMatchObject({ code: "workflow-landing-unverified" });
+    expect(lifecycle.failures.at(-1)!.message).toContain("reported no mergeCommit");
+    expect(asked).toEqual([]);
+  });
+
+  it("blocks the Todo when the landing reported a blank merge commit", async () => {
+    const { definition, runId } = await approvedLanding("landing-blank");
+    await executor.succeed("land", { mergeCommit: "  " });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("failed");
+    expect(lifecycle.completions).toEqual([]);
+    expect(lifecycle.failures.at(-1)!.message).toContain("reported no mergeCommit");
+  });
+
+  it("blocks the Todo and names the SHA when the commit is not on main", async () => {
+    onMain = false;
+    const { definition, runId } = await approvedLanding("landing-phantom");
+    await executor.succeed("land", { mergeCommit: PHANTOM });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("failed");
+    expect(lifecycle.completions).toEqual([]);
+    expect(lifecycle.reflections.at(-1)).toEqual({ status: "blocked", nodeId: "done" });
+    expect(lifecycle.failures.at(-1)!.message).toContain(PHANTOM);
+    expect(asked).toEqual([{ commit: PHANTOM, checkout: "/checkouts/pla-180" }]);
+  });
+
+  it("blocks the Todo when canonical delivery cannot be checked", async () => {
+    onMain = new Error("origin is unavailable");
+    const { definition, runId } = await approvedLanding("landing-unreadable");
+    await executor.succeed("land", { mergeCommit: PHANTOM });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("failed");
+    expect(lifecycle.completions).toEqual([]);
+    expect(lifecycle.failures.at(-1)!.message).toContain("could not be verified on the canonical branch");
+  });
+
+  it("completes the Todo when the reported commit is on main", async () => {
+    const { definition, runId } = await approvedLanding("landing-merged");
+    await executor.succeed("land", { mergeCommit: MERGED });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("completed");
+    expect(asked).toEqual([{ commit: MERGED, checkout: "/checkouts/pla-180" }]);
+    expect(lifecycle.completions).toEqual([{
+      todoId: "PLA-180", workflowId: definition.id, runId, nodeId: "gate",
+      approvedBy: "operator", approvedAt: now.toISOString(),
+    }]);
+  });
+
+  it("does not let a submitted failure launder into done down an error edge", async () => {
+    const { definition, runId } = await approvedLanding("landing-error-route", true);
+    await service.submitAttemptOutput({ sessionId: "session:land:1", outcome: "failure", summary: "Landing blocked: 5 conflicts." });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("failed");
+    expect(lifecycle.completions).toEqual([]);
+    expect(lifecycle.reflections.at(-1)).toEqual({ status: "blocked", nodeId: "handled" });
+  });
+});
+
+describe("a requirement is refused at save time when it names nothing", () => {
+  const end = (requires: JsonValue): WorkflowNode =>
+    ({ id: "done", type: "end", name: "Done", config: { result: "success", requires } } as unknown as WorkflowNode);
+  const definition = (requires: JsonValue): WorkflowDefinition =>
+    ({ nodes: [worker("land", "mergeCommit"), end(requires)] } as unknown as WorkflowDefinition);
+
+  it("names the node and the field when the node does not exist", () => {
+    expect(endRequirementIssues(definition({ nodeId: "ship", field: "mergeCommit" }))).toEqual([{
+      code: "unknown-required-node", nodeId: "done", path: "nodes.1.config.requires.nodeId",
+      message: "An End requires field `mergeCommit` from node `ship`, which this Workflow does not define.",
+    }]);
+  });
+
+  it("names the node and the field when the node declares no such output", () => {
+    expect(endRequirementIssues(definition({ nodeId: "land", field: "sha" }))).toEqual([{
+      code: "unknown-required-field", nodeId: "done", path: "nodes.1.config.requires.field",
+      message: "An End requires field `sha` from node `land`, which that node does not declare as an output field.",
+    }]);
+  });
+
+  it("checks the checkout reference too", () => {
+    expect(endRequirementIssues(definition({
+      nodeId: "land", field: "mergeCommit", commitIn: { nodeId: "plan", field: "worktree" },
+    }))).toMatchObject([{ code: "unknown-required-node", path: "nodes.1.config.requires.commitIn.nodeId" }]);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/model.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/model.test.ts
@@ -1,0 +1,805 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { ZodError } from 'zod';
+import {
+  jsonValueSchema,
+  workflowIdSchema,
+  workflowDefinitionSchema,
+  workflowDraftSchema,
+  workflowNodeSchema,
+  type ApprovalNode,
+  type Binding,
+  type ConditionNode,
+  type ConditionPredicate,
+  type EmployeeNode,
+  type EndNode,
+  type JsonPrimitive,
+  type JsonValue,
+  type MergeNode,
+  type TriggerNode,
+  type WaitNode,
+  type WorkflowDefinition,
+  type WorkflowDraft,
+  type WorkflowEdge,
+  type WorkflowInputField,
+  type WorkflowNode,
+  type WorkflowNodeOutput,
+  type WorkflowOutputSchema,
+} from '../model.js';
+
+const KiB = 1024;
+
+type SafeParseSchema = {
+  parse(value: unknown): unknown;
+  safeParse(value: unknown): { success: boolean };
+};
+
+function expectSafeRejected(schema: SafeParseSchema, value: unknown): void {
+  let result: { success: boolean } | undefined;
+  expect(() => { result = schema.safeParse(value); }).not.toThrow();
+  expect(result?.success).toBe(false);
+  expect(result).not.toHaveProperty('data');
+}
+
+function expectCanonicalRejected(schema: SafeParseSchema, value: unknown): void {
+  expectSafeRejected(schema, value);
+  let thrown: unknown;
+  try {
+    schema.parse(value);
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(ZodError);
+}
+
+function ownDataRecord(key: PropertyKey, value: unknown): Record<string, unknown> {
+  const record: Record<string, unknown> = {};
+  Object.defineProperty(record, key, { value, enumerable: true, configurable: true, writable: true });
+  return record;
+}
+
+function fixedJsonNode(value: unknown): EndNode {
+  const node: any = endNode();
+  node.config.output = { source: 'fixed', value };
+  return node;
+}
+
+const triggerNode = (config: TriggerNode['config'] = { kind: 'manual' }): TriggerNode => ({
+  id: 'start',
+  type: 'trigger',
+  name: 'Start',
+  config,
+});
+
+const employeeNode = (id = 'work', prompt = 'Do the work.'): EmployeeNode => ({
+  id,
+  type: 'employee',
+  name: 'Work',
+  config: {
+    employee: { source: 'fixed', value: 'worker' },
+    prompt,
+  },
+});
+
+const conditionNode = (): ConditionNode => ({
+  id: 'route',
+  type: 'condition',
+  name: 'Route',
+  config: {
+    cases: [{
+      port: 'matched',
+      label: 'Matched',
+      all: [{ left: { source: 'input', path: 'approved' }, operator: 'equals', right: { source: 'fixed', value: true } }],
+    }],
+    defaultPort: 'default',
+  },
+});
+
+const mergeNode = (): MergeNode => ({ id: 'join', type: 'merge', name: 'Join', config: { mode: 'wait-all' } });
+const approvalNode = (): ApprovalNode => ({
+  id: 'approve',
+  type: 'approval',
+  name: 'Approve',
+  config: { description: 'Approve this result.', approver: { source: 'run', path: 'id' } },
+});
+const waitNode = (): WaitNode => ({ id: 'pause', type: 'wait', name: 'Pause', config: { mode: 'duration', minutes: 1 } });
+const workflowCallNode = () => ({
+  id: 'children',
+  type: 'workflow-call' as const,
+  name: 'Run children',
+  config: {
+    workflowId: { source: 'fixed' as const, value: 'child-flow' },
+    items: { source: 'node' as const, nodeId: 'work', path: 'fields.items' },
+    input: {
+      topic: { source: 'trigger' as const, path: 'item.topic' },
+      ordinal: { source: 'trigger' as const, path: 'itemIndex' },
+    },
+    concurrency: 4,
+  },
+});
+const endNode = (): EndNode => ({
+  id: 'done',
+  type: 'end',
+  name: 'Done',
+  config: { result: 'success', output: { source: 'node', nodeId: 'work', path: 'fields.result' } },
+});
+
+const edge = (id = 'edge-1'): WorkflowEdge => ({
+  id,
+  from: { nodeId: 'start', port: 'success' },
+  to: { nodeId: 'work', port: 'input' },
+});
+
+function definition(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    schemaVersion: 1,
+    id: 'example-workflow',
+    title: 'Example workflow',
+    description: 'A generic workflow fixture.',
+    revision: 1,
+    enabled: false,
+    inputs: [{ key: 'approved', label: 'Approved', type: 'boolean', required: true }],
+    nodes: [triggerNode(), employeeNode(), conditionNode(), mergeNode(), approvalNode(), waitNode(), endNode()],
+    edges: [edge()],
+    ui: { positions: { start: { x: 0, y: 0 }, work: { x: 280, y: 0 } } },
+    createdAt: '2026-07-20T00:00:00.000Z',
+    updatedAt: '2026-07-20T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function draft(overrides: Partial<WorkflowDraft> = {}): WorkflowDraft {
+  return {
+    nodes: [triggerNode(), employeeNode()],
+    edges: [edge()],
+    ...overrides,
+  };
+}
+
+function definitionAtBytes(targetBytes: number, unit = 'x'): WorkflowDefinition {
+  const value = definition({ description: '' });
+  const baseBytes = Buffer.byteLength(JSON.stringify(value), 'utf8');
+  const unitBytes = Buffer.byteLength(unit, 'utf8');
+  const remaining = targetBytes - baseBytes;
+  if (remaining < 0 || unitBytes < 1) throw new Error('invalid byte fixture');
+  value.description = unit.repeat(Math.floor(remaining / unitBytes)) + 'x'.repeat(remaining % unitBytes);
+  if (Buffer.byteLength(JSON.stringify(value), 'utf8') !== targetBytes) throw new Error('byte fixture drifted');
+  return value;
+}
+
+function expectDefinitionRejected(value: unknown, message?: RegExp): void {
+  expect(() => workflowDefinitionSchema.parse(value)).toThrow(message);
+}
+
+const schemaSeams: Array<[string, SafeParseSchema, () => object]> = [
+  ['jsonValueSchema', jsonValueSchema, () => ({ safe: true })],
+  ['workflowNodeSchema', workflowNodeSchema, () => employeeNode()],
+  ['workflowDraftSchema', workflowDraftSchema, () => draft()],
+  ['workflowDefinitionSchema', workflowDefinitionSchema, () => definition()],
+];
+
+const hostileProxyFactories: Array<[string, (value: object) => object]> = [
+  ['ownKeys', (value) => new Proxy(value, { ownKeys() { throw new Error('ownKeys trap'); } })],
+  ['getOwnPropertyDescriptor', (value) => new Proxy(value, { getOwnPropertyDescriptor() { throw new Error('descriptor trap'); } })],
+  ['getPrototypeOf', (value) => new Proxy(value, { getPrototypeOf() { throw new Error('prototype trap'); } })],
+  ['get', (value) => new Proxy(value, { get() { throw new Error('get trap'); } })],
+];
+
+function ownKeysMutationProxy(value: object): object {
+  let calls = 0;
+  return new Proxy(value, {
+    ownKeys(target) {
+      const keys = Reflect.ownKeys(target);
+      if (++calls === 2) Object.defineProperty(target, 'later', { value: true, enumerable: true });
+      return keys;
+    },
+  });
+}
+
+function mutateObservedValue(value: unknown): unknown {
+  if (typeof value === 'string') return `${value}-changed`;
+  if (typeof value === 'number') return value + 1;
+  if (typeof value === 'boolean') return !value;
+  if (Array.isArray(value)) return [...value];
+  return value === null ? {} : { ...(value as object) };
+}
+
+function dataMutationProxy(value: object): object {
+  const watched = Reflect.ownKeys(value).find((key) => key !== 'length')!;
+  let reads = 0;
+  return new Proxy(value, {
+    get(target, key, receiver) {
+      const observed = Reflect.get(target, key, receiver);
+      if (key === watched && ++reads === 2) {
+        Object.defineProperty(target, key, { ...Reflect.getOwnPropertyDescriptor(target, key), value: mutateObservedValue(observed) });
+      }
+      return observed;
+    },
+  });
+}
+
+function prototypeMutationProxy(value: object): object {
+  let calls = 0;
+  return new Proxy(value, {
+    getPrototypeOf(target) {
+      const prototype = Reflect.getPrototypeOf(target);
+      if (++calls === 2) Object.setPrototypeOf(target, null);
+      return prototype;
+    },
+  });
+}
+
+function arrayMutationProxy(): unknown[] {
+  const target = [1];
+  let calls = 0;
+  return new Proxy(target, {
+    ownKeys(value) {
+      const keys = Reflect.ownKeys(value);
+      if (++calls === 2) value.push(2);
+      return keys;
+    },
+    getOwnPropertyDescriptor(value, key) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      return key === 'length' ? { ...descriptor, value: 1 } : descriptor;
+    },
+    get(value, key, receiver) {
+      return key === 'length' ? 1 : Reflect.get(value, key, receiver);
+    },
+  });
+}
+
+describe('canonical workflow node model', () => {
+  it('parses exactly the eight node discriminators', () => {
+    const nodes: WorkflowNode[] = [
+      triggerNode(),
+      employeeNode(),
+      workflowCallNode(),
+      conditionNode(),
+      mergeNode(),
+      approvalNode(),
+      waitNode(),
+      endNode(),
+    ];
+
+    expect(nodes.map((node) => workflowNodeSchema.parse(node).type)).toEqual([
+      'trigger', 'employee', 'workflow-call', 'condition', 'merge', 'approval', 'wait', 'end',
+    ]);
+    expectTypeOf<WorkflowNode['type']>().toEqualTypeOf<
+      'trigger' | 'employee' | 'workflow-call' | 'condition' | 'merge' | 'approval' | 'wait' | 'end'
+    >();
+  });
+
+  it('round-trips workflow-call bindings and applies only the authored concurrency default', () => {
+    const authored = workflowCallNode();
+    expect(workflowNodeSchema.parse(authored)).toEqual(authored);
+    const { concurrency: _concurrency, ...withoutConcurrency } = authored.config;
+    expect(workflowNodeSchema.parse({ ...authored, config: withoutConcurrency })).toEqual({
+      ...authored,
+      config: { ...withoutConcurrency, concurrency: 2 },
+    });
+    expect(workflowNodeSchema.safeParse({
+      ...authored,
+      config: { ...authored.config, unexpected: true },
+    }).success).toBe(false);
+  });
+
+  it('parses all five trigger kinds and both Wait modes', () => {
+    const triggerConfigs: TriggerNode['config'][] = [
+      { kind: 'manual' },
+      { kind: 'schedule', cron: '0 9 * * 1', timezone: 'UTC' },
+      { kind: 'event', eventName: 'release.ready', tokenRef: 'release-token' },
+      { kind: 'todo-status', status: 'in_review' },
+      { kind: 'workflow-call' },
+    ];
+    const waits: WaitNode[] = [
+      waitNode(),
+      { ...waitNode(), config: { mode: 'until', timestamp: { source: 'trigger', path: 'payload.resumeAt' } } },
+    ];
+
+    expect(triggerConfigs.map((config) => workflowNodeSchema.parse(triggerNode(config)).config)).toEqual(triggerConfigs);
+    expect(waits.map((node) => {
+      const parsed = workflowNodeSchema.parse(node);
+      if (parsed.type !== 'wait') throw new Error('expected Wait node');
+      return parsed.config.mode;
+    })).toEqual(['duration', 'until']);
+  });
+
+  it('parses each live todo-status filter on its own and refuses a stored false', () => {
+    const triggerConfigs: TriggerNode['config'][] = [
+      { kind: 'todo-status', status: 'assigned', unlabeled: true },
+      { kind: 'todo-status', status: 'assigned', unassigned: true },
+      { kind: 'todo-status', status: 'assigned', rootOnly: true },
+    ];
+
+    expect(triggerConfigs.map((config) => workflowNodeSchema.parse(triggerNode(config)).config)).toEqual(triggerConfigs);
+    expect(workflowNodeSchema.safeParse(triggerNode(
+      { kind: 'todo-status', status: 'assigned', unlabeled: false } as unknown as TriggerNode['config'],
+    )).success).toBe(false);
+  });
+});
+
+describe('employee runtime boundaries', () => {
+  it('parses all five Binding sources without a parallel expression model', () => {
+    const bindings: Binding[] = [
+      { source: 'fixed', value: { approved: true } },
+      { source: 'input', path: 'reviewer' },
+      { source: 'trigger', path: 'payload.repository' },
+      { source: 'run', path: 'id' },
+      { source: 'node', nodeId: 'work', path: 'fields.result' },
+    ];
+    const node = conditionNode();
+    node.config.cases[0]!.all = bindings.map((left) => ({ left, operator: 'exists' }));
+
+    const parsed = workflowNodeSchema.parse(node);
+    if (parsed.type !== 'condition') throw new Error('expected Condition node');
+    expect(parsed.config.cases[0]!.all.map((predicate) => predicate.left)).toEqual(bindings);
+  });
+
+  it('preserves optional retry and timeout fields instead of applying runtime defaults during parse', () => {
+    const parsed = workflowNodeSchema.parse(employeeNode());
+    expect(parsed.type).toBe('employee');
+    if (parsed.type !== 'employee') return;
+    expect(parsed.config).not.toHaveProperty('retry');
+    expect(parsed.config).not.toHaveProperty('timeoutMinutes');
+
+    const configured = employeeNode();
+    configured.config.retry = { attempts: 5, delaySeconds: 0, backoff: 'exponential' };
+    configured.config.timeoutMinutes = 1440;
+    expect(workflowNodeSchema.parse(configured)).toEqual(configured);
+  });
+
+  it('enforces integer retry, timeout, and Wait numeric boundaries', () => {
+    const configured = employeeNode();
+    configured.config.retry = { attempts: 1, delaySeconds: 0, backoff: 'fixed' };
+    configured.config.timeoutMinutes = 1;
+    expect(workflowNodeSchema.safeParse(configured).success).toBe(true);
+
+    for (const attempts of [0, 6, 1.5]) {
+      const node: any = employeeNode();
+      node.config.retry = { attempts, delaySeconds: 0, backoff: 'fixed' };
+      expect(workflowNodeSchema.safeParse(node).success, `attempts=${attempts}`).toBe(false);
+    }
+    for (const [field, values] of [
+      ['delaySeconds', [-1, 0.5]],
+      ['timeoutMinutes', [0, 1.5, 1441]],
+    ] as const) {
+      for (const value of values) {
+        const node: any = employeeNode();
+        if (field === 'delaySeconds') node.config.retry = { attempts: 1, delaySeconds: value, backoff: 'fixed' };
+        else node.config.timeoutMinutes = value;
+        expect(workflowNodeSchema.safeParse(node).success, `${field}=${value}`).toBe(false);
+      }
+    }
+    expect(workflowNodeSchema.safeParse({ ...waitNode(), config: { mode: 'duration', minutes: 1 } }).success).toBe(true);
+    expect(workflowNodeSchema.safeParse({ ...waitNode(), config: { mode: 'duration', minutes: 43_200 } }).success).toBe(true);
+    expect(workflowNodeSchema.safeParse({ ...waitNode(), config: { mode: 'duration', minutes: 0 } }).success).toBe(false);
+    expect(workflowNodeSchema.safeParse({ ...waitNode(), config: { mode: 'duration', minutes: 1.5 } }).success).toBe(false);
+    expect(workflowNodeSchema.safeParse({ ...waitNode(), config: { mode: 'duration', minutes: 43_201 } }).success).toBe(false);
+  });
+});
+
+describe('employee Binding and output declarations', () => {
+  it('locks fixed and dynamic Binding shapes for Employee runtime selectors', () => {
+    const dynamic = employeeNode();
+    dynamic.config.employee = { source: 'input', path: 'employee' };
+    dynamic.config.engine = { source: 'trigger', path: 'payload.engine' };
+    dynamic.config.model = { source: 'node', nodeId: 'work', path: 'fields.model' };
+    dynamic.config.effort = { source: 'run', path: 'effort' };
+    expect(workflowNodeSchema.safeParse(dynamic).success).toBe(true);
+
+    const fixed = employeeNode();
+    fixed.config.engine = { source: 'fixed', value: 'codex' };
+    fixed.config.model = { source: 'fixed', value: 'model-name' };
+    fixed.config.effort = { source: 'fixed', value: 'xhigh' };
+    expect(workflowNodeSchema.safeParse(fixed).success).toBe(true);
+
+    for (const [field, binding] of [
+      ['employee', { source: 'fixed', value: 1 }],
+      ['engine', { source: 'fixed', value: false }],
+      ['model', { source: 'fixed', value: { name: 'model' } }],
+      ['effort', { source: 'fixed', value: 'extreme' }],
+      ['employee', { source: 'input', path: 'employee', value: 'worker' }],
+      ['effort', { source: 'fixed', value: 'low', path: 'effort' }],
+    ] as const) {
+      const node: any = employeeNode();
+      node.config[field] = binding;
+      expect(workflowNodeSchema.safeParse(node).success, `${field}:${JSON.stringify(binding)}`).toBe(false);
+    }
+  });
+
+  it('supports flat closed output declarations', () => {
+    const output: WorkflowOutputSchema = {
+      fields: {
+        summary: { type: 'string', required: true, description: 'Short result.' },
+        scores: { type: 'string[]', required: false },
+      },
+      allowAdditionalFields: false,
+    };
+    const node = employeeNode();
+    node.config.output = output;
+
+    expect(workflowNodeSchema.parse(node)).toEqual(node);
+    expect(() => workflowNodeSchema.parse({
+      ...node,
+      config: { ...node.config, output: { ...output, fields: { bad: { type: 'object', required: true } } } },
+    })).toThrow();
+  });
+
+  it('requires addressable output field keys without narrowing arbitrary fixed JSON keys', () => {
+    for (const key of ['valid_field', 'Valid-Field2']) {
+      const node: any = employeeNode();
+      node.config.output = { fields: { [key]: { type: 'string', required: true } }, allowAdditionalFields: false };
+      expect(workflowNodeSchema.safeParse(node).success, key).toBe(true);
+    }
+    for (const key of ['dotted.field', 'field[0]', '0field', '__proto__', 'prototype', 'constructor']) {
+      const fields = ownDataRecord(key, { type: 'string', required: true });
+      const node: any = employeeNode();
+      node.config.output = { fields, allowAdditionalFields: false };
+      expect(workflowNodeSchema.safeParse(node).success, key).toBe(false);
+    }
+
+    expect(jsonValueSchema.safeParse({ 'dotted.key': true, 'bracket[key]': false }).success).toBe(true);
+  });
+});
+
+describe('closed structural parsing', () => {
+  it.each([
+    ['definition', (value: any) => { value.extra = true; }],
+    ['input declaration', (value: any) => { value.inputs[0].extra = true; }],
+    ['node', (value: any) => { value.nodes[1].actor = {}; }],
+    ['node config', (value: any) => { value.nodes[1].config.extra = true; }],
+    ['Binding', (value: any) => { value.nodes[1].config.employee.extra = true; }],
+    ['output schema', (value: any) => { value.nodes[1].config.output = { fields: {}, allowAdditionalFields: false, extra: true }; }],
+    ['output field', (value: any) => { value.nodes[1].config.output = { fields: { result: { type: 'string', required: true, extra: true } }, allowAdditionalFields: false }; }],
+    ['retry', (value: any) => { value.nodes[1].config.retry = { attempts: 1, delaySeconds: 0, backoff: 'fixed', extra: true }; }],
+    ['edge', (value: any) => { value.edges[0].extra = true; }],
+    ['edge source', (value: any) => { value.edges[0].from.extra = true; }],
+    ['edge target', (value: any) => { value.edges[0].to.extra = true; }],
+    ['ui', (value: any) => { value.ui.extra = true; }],
+    ['ui point', (value: any) => { value.ui.positions.start.z = 1; }],
+  ])('rejects unknown fields at the %s boundary', (_label, mutate) => {
+    const value: any = structuredClone(definition());
+    mutate(value);
+    expectDefinitionRejected(value);
+  });
+
+  it.each([
+    ['manual trigger with schedule fields', { ...triggerNode(), config: { kind: 'manual', cron: '* * * * *' } }],
+    ['input Binding with a fixed value', { ...employeeNode(), config: { ...employeeNode().config, employee: { source: 'input', path: 'worker', value: 'worker' } } }],
+    ['fixed Binding with a path', { ...endNode(), config: { result: 'success', output: { source: 'fixed', value: true, path: 'value' } } }],
+    ['until Wait with duration fields', { ...waitNode(), config: { mode: 'until', timestamp: { source: 'input', path: 'resumeAt' }, minutes: 1 } }],
+  ])('rejects misplaced fields in %s', (_label, node) => {
+    expect(() => workflowNodeSchema.parse(node)).toThrow();
+  });
+
+  it('rejects invalid node, trigger, Binding, Wait, and End discriminators', () => {
+    expect(() => workflowNodeSchema.parse({ ...employeeNode(), type: 'step' })).toThrow();
+    expect(() => workflowNodeSchema.parse({ ...triggerNode(), config: { kind: 'poll' } })).toThrow();
+    expect(() => workflowNodeSchema.parse({ ...employeeNode(), config: { ...employeeNode().config, employee: { source: 'env', path: 'USER' } } })).toThrow();
+    expect(() => workflowNodeSchema.parse({ ...waitNode(), config: { mode: 'cron', cron: '* * * * *' } })).toThrow();
+    expect(() => workflowNodeSchema.parse({ ...endNode(), config: { result: 'cancelled' } })).toThrow();
+  });
+});
+
+describe('UTF-8 byte and collection limits', () => {
+  it.each([
+    [255 * KiB, true],
+    [256 * KiB, true],
+    [257 * KiB, false],
+  ])('enforces the %i-byte definition boundary', (bytes, accepted) => {
+    const result = workflowDefinitionSchema.safeParse(definitionAtBytes(bytes));
+    expect(result.success).toBe(accepted);
+    if (!accepted) expect(result.error?.message).toMatch(/256 KiB/);
+  });
+
+  it('counts definition JSON in UTF-8 bytes for multibyte content', () => {
+    expect(workflowDefinitionSchema.safeParse(definitionAtBytes(256 * KiB, 'é')).success).toBe(true);
+    expect(workflowDefinitionSchema.safeParse(definitionAtBytes(256 * KiB + 1, 'é')).success).toBe(false);
+  });
+
+  it('enforces the 32 KiB prompt boundary in UTF-8 bytes', () => {
+    expect(workflowNodeSchema.safeParse(employeeNode('work', 'x'.repeat(32 * KiB))).success).toBe(true);
+    const oversized = workflowNodeSchema.safeParse(employeeNode('work', 'x'.repeat(32 * KiB + 1)));
+    expect(oversized.success).toBe(false);
+    if (!oversized.success) expect(oversized.error.message).toMatch(/32 KiB/);
+    expect(workflowNodeSchema.safeParse(employeeNode('work', 'é'.repeat(16 * KiB))).success).toBe(true);
+    expect(workflowNodeSchema.safeParse(employeeNode('work', `${'é'.repeat(16 * KiB)}x`)).success).toBe(false);
+  });
+
+  it.each([[99, true], [100, true], [101, false]])('enforces the %i-node boundary', (count, accepted) => {
+    const nodes = Array.from({ length: count }, (_, index) => employeeNode(`node_${index}`));
+    expect(workflowDefinitionSchema.safeParse(definition({ nodes, edges: [] })).success).toBe(accepted);
+  });
+
+  it.each([[299, true], [300, true], [301, false]])('enforces the %i-edge boundary', (count, accepted) => {
+    const edges = Array.from({ length: count }, (_, index) => edge(`edge-${index}`));
+    expect(workflowDefinitionSchema.safeParse(definition({ edges })).success).toBe(accepted);
+  });
+
+  it('enforces ten Condition cases and ten predicates per case', () => {
+    const node = conditionNode();
+    node.config.cases = Array.from({ length: 10 }, (_, index) => ({ port: `case_${index}`, label: `Case ${index}`, all: [] }));
+    expect(workflowNodeSchema.safeParse(node).success).toBe(true);
+    node.config.cases.push({ port: 'case_10', label: 'Case 10', all: [] });
+    expect(workflowNodeSchema.safeParse(node).success).toBe(false);
+
+    const predicate: ConditionPredicate = { left: { source: 'input', path: 'value' }, operator: 'exists' };
+    const predicates = conditionNode();
+    predicates.config.cases[0]!.all = Array.from({ length: 10 }, () => predicate);
+    expect(workflowNodeSchema.safeParse(predicates).success).toBe(true);
+    predicates.config.cases[0]!.all.push(predicate);
+    expect(workflowNodeSchema.safeParse(predicates).success).toBe(false);
+  });
+});
+
+describe('identifiers, labels, events, and paths', () => {
+  it('reserves the Event transport identity while leaving neighboring Workflow IDs valid', () => {
+    expect(workflowIdSchema.safeParse('events').success).toBe(false);
+    expect(workflowDefinitionSchema.safeParse(definition({ id: 'events' })).success).toBe(false);
+    for (const id of ['event', 'events-v2', 'event-flow']) {
+      expect(workflowIdSchema.safeParse(id).success, id).toBe(true);
+      expect(workflowDefinitionSchema.safeParse(definition({ id })).success, id).toBe(true);
+    }
+  });
+
+  it('enforces workflow, node, edge, title, and node-name boundaries', () => {
+    expect(workflowDefinitionSchema.safeParse(definition({ id: `a${'b'.repeat(63)}`, title: 't'.repeat(120) })).success).toBe(true);
+    for (const id of [`a${'b'.repeat(64)}`, '1workflow', 'Workflow', 'work_flow']) {
+      expect(workflowDefinitionSchema.safeParse(definition({ id })).success, id).toBe(false);
+    }
+    expectDefinitionRejected(definition({ title: '' }));
+    expectDefinitionRejected(definition({ title: 't'.repeat(121) }));
+
+    expect(workflowNodeSchema.safeParse(employeeNode(`a${'b'.repeat(63)}`)).success).toBe(true);
+    for (const id of [`a${'b'.repeat(64)}`, '1node', 'Node', 'node.dot']) {
+      expect(workflowNodeSchema.safeParse({ ...employeeNode(), id }).success, id).toBe(false);
+    }
+    expect(workflowNodeSchema.safeParse({ ...employeeNode(), name: 'n'.repeat(80) }).success).toBe(true);
+    expect(workflowNodeSchema.safeParse({ ...employeeNode(), name: '' }).success).toBe(false);
+    expect(workflowNodeSchema.safeParse({ ...employeeNode(), name: 'n'.repeat(81) }).success).toBe(false);
+
+    expect(workflowDefinitionSchema.safeParse(definition({ edges: [{ ...edge(), id: 'e'.repeat(128) }] })).success).toBe(true);
+    expectDefinitionRejected(definition({ edges: [{ ...edge(), id: '' }] }));
+    expectDefinitionRejected(definition({ edges: [{ ...edge(), id: 'e'.repeat(129) }] }));
+  });
+
+  it('enforces event-name length and grammar', () => {
+    const event = (eventName: string) => triggerNode({ kind: 'event', eventName });
+    expect(workflowNodeSchema.safeParse(event(`E${'a'.repeat(79)}`)).success).toBe(true);
+    for (const name of [`E${'a'.repeat(80)}`, '1event', 'release ready', 'release/ready', '']) {
+      expect(workflowNodeSchema.safeParse(event(name)).success, name).toBe(false);
+    }
+  });
+
+  it('enforces relative paths, 256 characters, and 16 safe identifier segments', () => {
+    const withPath = (path: string) => ({
+      ...employeeNode(),
+      config: { ...employeeNode().config, employee: { source: 'input', path } },
+    });
+    expect(workflowNodeSchema.safeParse(withPath('a'.repeat(256))).success).toBe(true);
+    expect(workflowNodeSchema.safeParse(withPath('a'.repeat(257))).success).toBe(false);
+    expect(workflowNodeSchema.safeParse(withPath(Array.from({ length: 16 }, (_, i) => `s${i}`).join('.'))).success).toBe(true);
+    expect(workflowNodeSchema.safeParse(withPath(Array.from({ length: 17 }, (_, i) => `s${i}`).join('.'))).success).toBe(false);
+    for (const path of ['', '.value', 'value.', 'a..b', '$.value', 'items[0]', 'input.reviewer', 'trigger.payload', 'run.id', 'nodes.work']) {
+      expect(workflowNodeSchema.safeParse(withPath(path)).success, path).toBe(false);
+    }
+    for (const dangerous of ['__proto__', 'prototype', 'constructor', 'safe.__proto__.value']) {
+      expect(workflowNodeSchema.safeParse(withPath(dangerous)).success, dangerous).toBe(false);
+    }
+  });
+});
+
+describe('schema-level cross-field invariants', () => {
+  it('rejects duplicate node IDs, edge IDs, and workflow input keys', () => {
+    expectDefinitionRejected(definition({ nodes: [employeeNode('same'), employeeNode('same')], edges: [] }), /duplicate node ID/i);
+    expectDefinitionRejected(definition({ edges: [edge('same'), edge('same')] }), /duplicate edge ID/i);
+    const inputs: WorkflowInputField[] = [
+      { key: 'topic', label: 'Topic', type: 'string', required: true },
+      { key: 'topic', label: 'Other topic', type: 'string', required: false },
+    ];
+    expectDefinitionRejected(definition({ inputs }), /duplicate input key/i);
+  });
+
+  it('rejects enabled retired definitions', () => {
+    expectDefinitionRejected(definition({ enabled: true, retiredAt: '2026-07-20T00:00:00.000Z' }), /retired.*enabled/i);
+    expect(workflowDefinitionSchema.safeParse(definition({ enabled: false, retiredAt: '2026-07-20T00:00:00.000Z' })).success).toBe(true);
+  });
+
+  it('requires locally unique nonempty Condition case and default ports', () => {
+    const duplicate = conditionNode();
+    duplicate.config.cases.push({ port: 'matched', label: 'Again', all: [] });
+    expect(() => workflowNodeSchema.parse(duplicate)).toThrow(/duplicate condition port/i);
+    const collidingDefault = conditionNode();
+    collidingDefault.config.defaultPort = 'matched';
+    expect(() => workflowNodeSchema.parse(collidingDefault)).toThrow(/default port/i);
+    for (const mutate of [
+      (node: ConditionNode) => { node.config.cases[0]!.port = ''; },
+      (node: ConditionNode) => { node.config.defaultPort = ''; },
+    ]) {
+      const value = conditionNode();
+      mutate(value);
+      expect(workflowNodeSchema.safeParse(value).success).toBe(false);
+    }
+  });
+
+  it('locks target ports to input while leaving authored source ports structurally unbounded', () => {
+    expect(workflowDefinitionSchema.safeParse(definition({ edges: [{ ...edge(), from: { nodeId: 'start', port: 'p'.repeat(512) } }] })).success).toBe(true);
+    expectDefinitionRejected(definition({ edges: [{ ...edge(), from: { nodeId: 'start', port: '' } }] }));
+    expectDefinitionRejected(definition({ edges: [{ ...edge(), to: { nodeId: 'work', port: 'target' as 'input' } }] }));
+
+    const condition = conditionNode();
+    condition.config.cases[0]!.port = 'c'.repeat(512);
+    condition.config.defaultPort = 'd'.repeat(512);
+    expect(workflowNodeSchema.safeParse(condition).success).toBe(true);
+  });
+
+  it('validates finite UI point shapes without checking graph correspondence', () => {
+    expect(workflowDefinitionSchema.safeParse(definition({ ui: { positions: { absent: { x: -1.5, y: 2.25 } } } })).success).toBe(true);
+    expectDefinitionRejected(definition({ ui: { positions: { start: { x: Number.NaN, y: 0 } } } }));
+    expectDefinitionRejected(definition({ ui: { positions: { start: { x: 0 } as { x: number; y: number } } } }));
+  });
+
+  it('carries a manual layout marker and rejects any other provenance value', () => {
+    const marked = definition({ ui: { positions: { start: { x: 0, y: 0 } }, layout: 'manual' } });
+    expect(workflowDefinitionSchema.parse(marked).ui).toEqual({ positions: { start: { x: 0, y: 0 } }, layout: 'manual' });
+    expectDefinitionRejected(definition({ ui: { positions: {}, layout: 'auto' as 'manual' } }));
+  });
+
+  it('requires UI position keys to use node ID grammar', () => {
+    for (const key of ['node_1', 'node-2']) {
+      expect(workflowDefinitionSchema.safeParse(definition({ ui: { positions: { [key]: { x: 0, y: 0 } } } })).success, key).toBe(true);
+    }
+    for (const key of ['Node', 'node.dot', 'node[0]', '__proto__', 'prototype', 'constructor']) {
+      const positions = ownDataRecord(key, { x: 0, y: 0 });
+      expect(workflowDefinitionSchema.safeParse(definition({ ui: { positions: positions as any } })).success, key).toBe(false);
+    }
+  });
+});
+
+describe('draft versus persisted definition', () => {
+  it('accepts empty and structurally incomplete drafts', () => {
+    expect(workflowDraftSchema.parse({ nodes: [], edges: [] })).toEqual({ nodes: [], edges: [] });
+    expect(workflowDraftSchema.safeParse(draft({ nodes: [employeeNode()], edges: [] })).success).toBe(true);
+  });
+
+  it('keeps persisted metadata out of drafts and requires it on definitions', () => {
+    expect(workflowDraftSchema.safeParse(definition()).success).toBe(false);
+    expect(workflowDefinitionSchema.safeParse(draft()).success).toBe(false);
+    expect(workflowDefinitionSchema.safeParse(definition({ nodes: [], edges: [] })).success).toBe(true);
+  });
+
+  it('retains structural and product safety bounds for drafts', () => {
+    expect(workflowDraftSchema.safeParse(draft({ nodes: Array.from({ length: 101 }, (_, i) => employeeNode(`node_${i}`)), edges: [] })).success).toBe(false);
+    expect(workflowDraftSchema.safeParse(draft({ nodes: [{ ...employeeNode(), id: 'bad.id' }], edges: [] })).success).toBe(false);
+    expect(workflowDraftSchema.safeParse({ ...draft(), extra: true }).success).toBe(false);
+  });
+});
+
+describe('trap-free Proxy rejection', () => {
+  it.each(schemaSeams)('rejects a nonthrowing benign Proxy at the %s seam', (_name, schema, fixture) => {
+    expectCanonicalRejected(schema, new Proxy(fixture(), {}));
+  });
+
+  it.each(hostileProxyFactories)('rejects a hostile %s Proxy at every exported seam', (_name, proxy) => {
+    for (const [, schema, fixture] of schemaSeams) expectCanonicalRejected(schema, proxy(fixture()));
+  });
+
+  it.each([
+    ['ownKeys mutation', ownKeysMutationProxy],
+    ['data mutation after observation', dataMutationProxy],
+    ['prototype mutation', prototypeMutationProxy],
+  ])('rejects a stateful Proxy with %s at every exported seam', (_name, proxy) => {
+    for (const [, schema, fixture] of schemaSeams) expectCanonicalRejected(schema, proxy(fixture()));
+  });
+
+  it('rejects an array Proxy that changes its keys and length during inspection', () => {
+    expectCanonicalRejected(jsonValueSchema, arrayMutationProxy());
+  });
+});
+
+describe('safe canonical JSON containers', () => {
+  it('accepts plain and null-prototype records', () => {
+    const plain = { values: [null, true, 1, 'ok'], 'arbitrary.key': 'data' };
+    const nullPrototype = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(nullPrototype, 'value', { value: plain, enumerable: true, configurable: true, writable: true });
+
+    expect(jsonValueSchema.safeParse(plain).success).toBe(true);
+    expect(jsonValueSchema.safeParse(nullPrototype).success).toBe(true);
+    expect(workflowDefinitionSchema.safeParse(definition({ nodes: [fixedJsonNode(nullPrototype)], edges: [] })).success).toBe(true);
+  });
+
+  it('rejects cycles, class instances, array subclasses, and non-JSON values', () => {
+    class RecordClass { value = true; }
+    class ArraySubclass extends Array<unknown> {}
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    const arrayWithExtra: unknown[] & { extra?: boolean } = [1];
+    arrayWithExtra.extra = true;
+    const symbolKey = ownDataRecord(Symbol('extra'), true);
+    const invalidValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      undefined,
+      1n,
+      Symbol('value'),
+      () => true,
+      new Date(),
+      new Map(),
+      new RecordClass(),
+      new ArraySubclass(1, 2),
+      cycle,
+      arrayWithExtra,
+      symbolKey,
+    ];
+
+    for (const value of invalidValues) {
+      expectSafeRejected(jsonValueSchema, value);
+      expectSafeRejected(workflowDefinitionSchema, definition({ nodes: [fixedJsonNode(value)], edges: [] }));
+    }
+  });
+
+  it('rejects dangerous own JSON keys without narrowing other arbitrary keys', () => {
+    expect(jsonValueSchema.safeParse({ 'dotted.key': true, 'bracket[key]': false, '0': null }).success).toBe(true);
+    for (const key of ['__proto__', 'prototype', 'constructor']) {
+      const value = ownDataRecord(key, true);
+      expectSafeRejected(jsonValueSchema, value);
+      expectSafeRejected(workflowDefinitionSchema, definition({ nodes: [fixedJsonNode(value)], edges: [] }));
+    }
+  });
+
+  it.each([true, false])('rejects %s enumerable getters without invoking them', (enumerable) => {
+    let getterCalls = 0;
+    const value: Record<string, unknown> = {};
+    Object.defineProperty(value, 'secret', {
+      enumerable,
+      get() {
+        getterCalls += 1;
+        return 'unsafe';
+      },
+    });
+    expectSafeRejected(jsonValueSchema, value);
+    expectSafeRejected(workflowDefinitionSchema, definition({ nodes: [fixedJsonNode(value)], edges: [] }));
+
+    const hostileDefinition = definition();
+    Object.defineProperty(hostileDefinition, 'description', {
+      enumerable,
+      get() {
+        getterCalls += 1;
+        return 'unsafe';
+      },
+    });
+    expectSafeRejected(workflowDefinitionSchema, hostileDefinition);
+    expect(getterCalls).toBe(0);
+  });
+});
+
+describe('JSON capacity below the definition byte cap', () => {
+  it.each([31, 32, 33, 64, 512])('accepts depth %i', (depth) => {
+    let deep: JsonValue = 'leaf';
+    for (let index = 0; index < depth; index += 1) deep = { next: deep };
+    const deepDefinition = definition({ nodes: [fixedJsonNode(deep)], edges: [] });
+
+    expect(Buffer.byteLength(JSON.stringify(deepDefinition), 'utf8')).toBeLessThan(256 * KiB);
+    expect(jsonValueSchema.safeParse(deep).success).toBe(true);
+    expect(workflowDefinitionSchema.safeParse(deepDefinition).success).toBe(true);
+  });
+
+  it.each([9_999, 10_000, 10_001])('accepts %i values', (count) => {
+    const many: JsonValue = Array.from({ length: count }, () => 0);
+    const manyDefinition = definition({ nodes: [fixedJsonNode(many)], edges: [] });
+
+    expect(Buffer.byteLength(JSON.stringify(manyDefinition), 'utf8')).toBeLessThan(256 * KiB);
+    expect(jsonValueSchema.safeParse(many).success).toBe(true);
+    expect(workflowDefinitionSchema.safeParse(manyDefinition).success).toBe(true);
+  });
+});
+
+describe('canonical node output type', () => {
+  it('exports the locked JSON and node-output shapes', () => {
+    const primitive: JsonPrimitive = null;
+    const json: JsonValue = { primitive, list: [true, 1, 'value'] };
+    const output: WorkflowNodeOutput = { text: 'Done.', fields: { result: json }, employeeId: 'worker', sessionId: 'session-1' };
+    expect(output).toMatchObject({ text: 'Done.', employeeId: 'worker' });
+    expectTypeOf(output.fields).toEqualTypeOf<Record<string, JsonValue>>();
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/node-dispatch-override.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/node-dispatch-override.test.ts
@@ -1,0 +1,174 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Employee, ModelRegistry } from '../../shared/types.js';
+import type { EmployeeNode, WorkflowDefinition, WorkflowNode } from '../model.js';
+import { resolveDispatch, type DispatchResolutionDeps } from '../node-dispatch.js';
+import { openWorkflowDatabase } from '../repository-migrations.js';
+import { WorkflowRepository } from '../repository.js';
+import type { WorkflowRunDetail } from '../runtime.js';
+
+/**
+ * ICI-733: a Todo bound to a workflow run can redirect the NEXT attempt onto
+ * another engine or model. The point is recovery — a run whose attempts keep
+ * dying on one engine has to be movable without editing the workflow — so the
+ * Todo's word beats both the node's own config and the employee's default.
+ */
+
+const WORKER: Employee = {
+  name: 'worker', displayName: 'Worker', department: 'platform', rank: 'employee',
+  engine: 'codex', model: 'gpt-5.6-sol', persona: 'works',
+} as unknown as Employee;
+
+const MODELS: ModelRegistry = {
+  codex: {
+    available: true, defaultModel: 'gpt-5.6-sol',
+    models: [{ id: 'gpt-5.6-sol', supportsEffort: true, effortLevels: ['low', 'high'] }, { id: 'gpt-5.5', supportsEffort: false, effortLevels: [] }],
+  },
+  claude: {
+    available: true, defaultModel: 'opus',
+    models: [{ id: 'opus', supportsEffort: false, effortLevels: [] }, { id: 'sonnet', supportsEffort: false, effortLevels: [] }],
+  },
+} as unknown as ModelRegistry;
+
+function nodes(config: Partial<EmployeeNode['config']> = {}): WorkflowNode[] {
+  return [
+    { id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } },
+    { id: 'work', type: 'employee', name: 'Work', config: {
+      employee: { source: 'fixed', value: 'worker' }, prompt: 'Do the work.', ...config } },
+    { id: 'finish', type: 'end', name: 'Finish', config: { result: 'success' } },
+  ];
+}
+
+function definition(config?: Partial<EmployeeNode['config']>): WorkflowDefinition {
+  return {
+    schemaVersion: 1, id: 'flow', title: 'Flow', revision: 1, enabled: false, nodes: nodes(config),
+    edges: [
+      { id: 'a', from: { nodeId: 'start', port: 'success' }, to: { nodeId: 'work', port: 'input' } },
+      { id: 'b', from: { nodeId: 'work', port: 'success' }, to: { nodeId: 'finish', port: 'input' } },
+    ],
+    createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+function run(todoId?: string, config?: Partial<EmployeeNode['config']>): WorkflowRunDetail {
+  return {
+    id: 'run-1', workflowId: 'flow', workflowTitle: 'Flow', definitionRevision: 1, definition: definition(config),
+    input: {}, trigger: { nodeId: 'start', kind: 'manual', payload: {}, ...(todoId ? { todoId } : {}) },
+    status: 'running', revision: 1, startedAt: '2026-08-01T00:00:00.000Z',
+    nodeRuns: [], approvals: [], childRuns: [], attempts: [],
+  } as unknown as WorkflowRunDetail;
+}
+
+function employeeNode(config?: Partial<EmployeeNode['config']>): EmployeeNode {
+  return nodes(config).find((item) => item.id === 'work') as EmployeeNode;
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'jinn-node-dispatch-'));
+  process.env.JINN_HOME = root;
+  database = openWorkflowDatabase();
+  repository = new WorkflowRepository(database);
+});
+
+afterEach(() => {
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function deps(override?: { engine: string | null; model: string | null }): DispatchResolutionDeps {
+  return {
+    employees: () => new Map([['worker', WORKER]]),
+    models: () => MODELS,
+    repository,
+    executor: { resumableEngineSession: () => null } as unknown as DispatchResolutionDeps['executor'],
+    ...(override ? { todoDispatch: { read: () => override } } : {}),
+  };
+}
+
+describe('resolveDispatch and the bound Todo', () => {
+  it('uses the employee default when the Todo says nothing', () => {
+    expect(resolveDispatch(run('JIN-1'), employeeNode(), deps())).toMatchObject({ engine: 'codex', model: 'gpt-5.6-sol' });
+  });
+
+  it("takes the Todo's engine and model over the node's own", () => {
+    const config = { engine: { source: 'fixed' as const, value: 'codex' }, model: { source: 'fixed' as const, value: 'gpt-5.5' } };
+    const resolved = resolveDispatch(run('JIN-1', config), employeeNode(config), deps({ engine: 'claude', model: 'sonnet' }));
+    expect(resolved).toMatchObject({ engine: 'claude', model: 'sonnet' });
+  });
+
+  it("takes the Todo's engine over the employee default too", () => {
+    expect(resolveDispatch(run('JIN-1'), employeeNode(), deps({ engine: 'claude', model: 'opus' })))
+      .toMatchObject({ engine: 'claude', model: 'opus' });
+  });
+
+  it("resolves the new engine's default model when the Todo names an engine and no model", () => {
+    const config = { model: { source: 'fixed' as const, value: 'gpt-5.5' } };
+    const resolved = resolveDispatch(run('JIN-1', config), employeeNode(config), deps({ engine: 'claude', model: null }));
+    // gpt-5.5 belongs to codex; carrying it onto claude would fail the registry
+    // check, so the pinned engine's default is what the attempt gets.
+    expect(resolved).toMatchObject({ engine: 'claude', model: 'opus' });
+  });
+
+  it("drops the employee's effort when the Todo moves the attempt to another engine", () => {
+    const worker = { ...WORKER, effortLevel: 'high' } as Employee;
+    const withEffort = { ...deps({ engine: 'claude', model: 'opus' }), employees: () => new Map([['worker', worker]]) };
+    // `high` is a codex effort level; claude's opus supports none, so keeping it
+    // would fail the attempt over a default nobody asked for.
+    expect(resolveDispatch(run('JIN-1'), employeeNode(), withEffort).effort).toBeUndefined();
+  });
+
+  it('ignores an override on a run that is not bound to a Todo', () => {
+    expect(resolveDispatch(run(undefined), employeeNode(), deps({ engine: 'claude', model: 'opus' })))
+      .toMatchObject({ engine: 'codex', model: 'gpt-5.6-sol' });
+  });
+
+  it('still refuses an engine the registry does not have available', () => {
+    const unavailable = { ...deps({ engine: 'grok', model: null }) };
+    expect(() => resolveDispatch(run('JIN-1'), employeeNode(), unavailable)).toThrow(/not available/);
+  });
+});
+
+/** PLA-202: a model id belongs to exactly one provider, so no engine rewrite may
+ *  leave one on an attempt bound for a different engine. dispatchTarget already
+ *  resolves the stand-in's own default; this holds it there. */
+describe('resolveDispatch and the chain substitution', () => {
+  /** A run whose only attempt on this node died on codex, the way an engine out
+   *  of allowance settles one. */
+  function afterCodexLimit(): WorkflowRunDetail {
+    const detail = run('JIN-1');
+    detail.attempts = [{
+      nodeId: 'work', attempt: 1, error: { code: 'workflow-step-failed', message: 'Codex usage limit reached' },
+      resolvedConfig: { employeeId: 'worker', engine: 'codex', model: 'gpt-5.6-sol' },
+    }] as unknown as WorkflowRunDetail['attempts'];
+    return detail;
+  }
+
+  const chained: DispatchResolutionDeps = { ...deps(), engineFallback: { chainFor: (engine) => (engine === 'codex' ? ['claude'] : []) } };
+
+  it('runs the stand-in on a model it serves, never the model the limited engine was on', () => {
+    const resolved = resolveDispatch(afterCodexLimit(), employeeNode(), chained);
+
+    expect(resolved.engine).toBe('claude');
+    expect(resolved.model).toBe('opus');
+    expect(MODELS.claude.models.map((model) => model.id)).toContain(resolved.model);
+  });
+
+  it('drops a node pin that belongs to the limited engine rather than carrying it over', () => {
+    const config = { model: { source: 'fixed' as const, value: 'gpt-5.5' } };
+    const detail = afterCodexLimit();
+    detail.definition = definition(config);
+
+    const resolved = resolveDispatch(detail, employeeNode(config), chained);
+
+    expect(resolved.engine).toBe('claude');
+    expect(resolved.model).not.toBe('gpt-5.5');
+    expect(MODELS.claude.models.map((model) => model.id)).toContain(resolved.model);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/node-mutex.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/node-mutex.test.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { workflowNodeSchema } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+const KEY = "shared-resource";
+
+class Executor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}` };
+  }
+  async stopAttempt(): Promise<void> { /* nothing to stop in this harness */ }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+  private async emit(command: WorkflowAttemptCommand, event: Partial<WorkflowAttemptCompletion>): Promise<void> {
+    const completion = {
+      sessionId: `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`,
+      owner: command.owner, terminalVersion: 1, turn: 1, outcome: "succeeded",
+      completedAt: "2026-08-05T12:05:00.000Z", ...event,
+    } as WorkflowAttemptCompletion;
+    await Promise.all([...this.listeners].map((listener) => listener(completion)));
+  }
+  async settle(command: WorkflowAttemptCommand, fields: Record<string, JsonValue> = {}): Promise<void> {
+    await this.emit(command, { finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\`` });
+  }
+  async fail(command: WorkflowAttemptCommand): Promise<void> {
+    await this.emit(command, { outcome: "failed", error: "The phase reported failure." });
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: Executor;
+let service: WorkflowService;
+
+function buildService(): WorkflowService {
+  return new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => "2026-08-05T12:00:00.000Z",
+  });
+}
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function save(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = service.createDefinition({ id, title: id });
+  const saved = service.saveDefinition({ ...created, nodes, edges }, created.revision);
+  return service.setEnabled({ id, enabled: true, expectedRevision: saved.revision });
+}
+
+/** One employee node between a manual trigger and a success End. `mutex` absent leaves
+ *  it exactly as any other Workflow authors it, which is what the untouched case needs. */
+function guardedWorkflow(id: string, mutex?: string): WorkflowDefinition {
+  return save(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "work", type: "employee", name: "Work", config: {
+      employee: { source: "fixed", value: "worker" }, prompt: "Do the guarded work.",
+      retry: { attempts: 1, delaySeconds: 0, backoff: "fixed" },
+      ...(mutex ? { mutex } : {}),
+    } },
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+  ], [edge("start-work", "start", "success", "work"), edge("work-finish", "work", "success", "finish")]);
+}
+
+/** A woken run advances through a fired-and-forgotten promise, so the dispatch it
+ *  makes lands a few ticks after the holder settles rather than inside that call. */
+async function woken(): Promise<void> {
+  for (let tick = 0; tick < 10; tick += 1) await new Promise((resolve) => setImmediate(resolve));
+}
+
+function workNode(workflowId: string, runId: string) {
+  return service.getRun(workflowId, runId)!.nodeRuns.find((node) => node.nodeId === "work")!;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-node-mutex-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => "2026-08-05T12:00:00.000Z");
+  executor = new Executor();
+  service = buildService();
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("mutex as an authored value", () => {
+  const node = (mutex: unknown) => ({
+    id: "work", type: "employee", name: "Work",
+    config: { employee: { source: "fixed", value: "worker" }, prompt: "Do the guarded work.", mutex },
+  });
+
+  it("accepts a key on an employee node", () => {
+    for (const mutex of ["shared-resource", "a", "k".repeat(60)]) {
+      expect(workflowNodeSchema.parse(node(mutex))).toEqual(node(mutex));
+    }
+  });
+
+  it("rejects a key outside the authored bounds", () => {
+    for (const mutex of ["", "k".repeat(61), 4, null]) {
+      expect(workflowNodeSchema.safeParse(node(mutex)).success).toBe(false);
+    }
+  });
+});
+
+describe("nodes sharing a mutex key", () => {
+  async function twoRuns(): Promise<{ holder: string; waiter: string }> {
+    guardedWorkflow("guarded-flow", KEY);
+    const holder = await service.startManual({ workflowId: "guarded-flow", input: {} });
+    const waiter = await service.startManual({ workflowId: "guarded-flow", input: {} });
+    return { holder: holder.id, waiter: waiter.id };
+  }
+
+  it("dispatches one and leaves the other standing off", async () => {
+    const { holder, waiter } = await twoRuns();
+
+    expect(executor.commands).toHaveLength(1);
+    expect(executor.commands[0]!.owner.runId).toBe(holder);
+    expect(workNode("guarded-flow", waiter).status).toBe("pending");
+    expect(service.getRun("guarded-flow", waiter)!.attempts).toEqual([]);
+  });
+
+  it("records the key it wants and who is holding it", async () => {
+    const { holder, waiter } = await twoRuns();
+
+    expect(workNode("guarded-flow", waiter).resolvedConfig).toMatchObject({
+      mutexKey: KEY, mutexHeldBy: `${holder}:work`,
+    });
+  });
+
+  it("wakes the waiter when the holder succeeds, with no external poke", async () => {
+    const { waiter } = await twoRuns();
+
+    await executor.settle(executor.commands[0]!);
+    await woken();
+
+    expect(executor.commands).toHaveLength(2);
+    expect(executor.commands[1]!.owner.runId).toBe(waiter);
+    expect(workNode("guarded-flow", waiter).status).toBe("running");
+  });
+
+  it("frees the key when the holder fails, because a failure is not a claim", async () => {
+    const { holder, waiter } = await twoRuns();
+
+    await executor.fail(executor.commands[0]!);
+    await woken();
+
+    expect(service.getRun("guarded-flow", holder)!.status).toBe("failed");
+    expect(executor.commands).toHaveLength(2);
+    expect(executor.commands[1]!.owner.runId).toBe(waiter);
+  });
+
+  it("keeps no lock a rebuilt service could inherit", async () => {
+    guardedWorkflow("guarded-flow", KEY);
+    const holder = await service.startManual({ workflowId: "guarded-flow", input: {} });
+    await executor.settle(executor.commands[0]!);
+    expect(service.getRun("guarded-flow", holder.id)!.status).toBe("completed");
+
+    service.dispose();
+    service = buildService();
+    const next = await service.startManual({ workflowId: "guarded-flow", input: {} });
+
+    expect(executor.commands).toHaveLength(2);
+    expect(executor.commands[1]!.owner.runId).toBe(next.id);
+    expect(workNode("guarded-flow", next.id).status).toBe("running");
+  });
+
+  it("leaves a node that authors no key dispatching while another holds one", async () => {
+    guardedWorkflow("guarded-flow", KEY);
+    guardedWorkflow("open-flow");
+    await service.startManual({ workflowId: "guarded-flow", input: {} });
+
+    const open = await service.startManual({ workflowId: "open-flow", input: {} });
+
+    expect(executor.commands).toHaveLength(2);
+    expect(executor.commands[1]!.owner.runId).toBe(open.id);
+    expect(workNode("open-flow", open.id).status).toBe("running");
+    expect(workNode("open-flow", open.id).resolvedConfig).not.toHaveProperty("mutexKey");
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/output-attachment-fields.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/output-attachment-fields.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowOutputSchema } from '../model.js';
+import { parseWorkflowOutput, validateSubmittedFields, WorkflowOutputError } from '../output.js';
+
+function outputSchema(
+  fields: WorkflowOutputSchema['fields'] = {},
+  allowAdditionalFields = false,
+): WorkflowOutputSchema {
+  return { fields, allowAdditionalFields };
+}
+
+function block(json: string, eol = '\n', closingEol = ''): string {
+  return `\`\`\`jinn-output${eol}${json}${eol}\`\`\`${closingEol}`;
+}
+
+function expectCode(run: () => unknown, code: WorkflowOutputError['code']): WorkflowOutputError {
+  let thrown: unknown;
+  try {
+    run();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkflowOutputError);
+  expect(thrown).toMatchObject({ name: 'WorkflowOutputError', code });
+  return thrown as WorkflowOutputError;
+}
+
+describe('attachment field types', () => {
+  const REF = 'attachment:PLA-135:wia_ab12cd34ef56:image/png';
+  const schema = outputSchema({
+    shot: { type: 'attachment', required: true },
+    extras: { type: 'attachment[]', required: true },
+  });
+
+  it('accepts a well-formed ref and a list of them', () => {
+    const output = parseWorkflowOutput(block(`{"shot":"${REF}","extras":["${REF}","${REF}"]}`), schema);
+    expect(output.fields).toEqual({ shot: REF, extras: [REF, REF] });
+  });
+
+  it('accepts an empty attachment list', () => {
+    expect(parseWorkflowOutput(block(`{"shot":"${REF}","extras":[]}`), schema).fields).toEqual({ shot: REF, extras: [] });
+  });
+
+  it.each([
+    ['a bare filename', '"screenshot.png"'],
+    ['an absolute path', '"/var/tmp/shot.png"'],
+    ['a parent-directory hop', '"attachment:PLA-135:wia_ab12cd34ef56:../../etc/passwd"'],
+    ['a ref with trailing prose', `"${REF} looks good"`],
+    ['a plain string array', '["a"]'],
+    ['a number', '3'],
+  ])('rejects %s, naming the field and the ref shape', (_label, json) => {
+    const error = expectCode(() => parseWorkflowOutput(block(`{"shot":${json},"extras":[]}`), schema), 'type-mismatch');
+    expect(error.message).toContain('Output field "shot" does not match declared type "attachment".');
+    expect(error.message).toContain('attachment:<TODO-ID>:<attachment-id>:<mime>');
+  });
+
+  it('rejects a list holding one bad ref', () => {
+    const error = expectCode(
+      () => parseWorkflowOutput(block(`{"shot":"${REF}","extras":["${REF}","nope.png"]}`), schema),
+      'type-mismatch',
+    );
+    expect(error.message).toContain('Output field "extras" does not match declared type "attachment[]".');
+  });
+
+  it('does not let an attachment type slip through the string[] check', () => {
+    const single = outputSchema({ shot: { type: 'attachment', required: true } });
+    expectCode(() => parseWorkflowOutput(block('{"shot":["a"]}'), single), 'type-mismatch');
+  });
+
+  it('leaves the existing types alone', () => {
+    const mixed = outputSchema({ shot: { type: 'attachment', required: true }, tags: { type: 'string[]', required: true } });
+    expect(parseWorkflowOutput(block(`{"shot":"${REF}","tags":["${REF}","plain"]}`), mixed).fields)
+      .toEqual({ shot: REF, tags: [REF, 'plain'] });
+  });
+
+  it('persists the ref string itself, with no bytes alongside it', () => {
+    const fields = validateSubmittedFields({ shot: REF, extras: [REF] }, schema);
+    expect(JSON.parse(JSON.stringify(fields))).toEqual({ shot: REF, extras: [REF] });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/output.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/output.test.ts
@@ -1,0 +1,348 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import type { WorkflowOutputSchema } from '../model.js';
+import { parseWorkflowOutput, validateSubmittedFields, WorkflowOutputError } from '../output.js';
+
+const LIMIT = 262_144;
+
+function outputSchema(
+  fields: WorkflowOutputSchema['fields'] = {},
+  allowAdditionalFields = false,
+): WorkflowOutputSchema {
+  return { fields, allowAdditionalFields };
+}
+
+function block(json: string, eol = '\n', closingEol = ''): string {
+  return `\`\`\`jinn-output${eol}${json}${eol}\`\`\`${closingEol}`;
+}
+
+function rawObjectAtBytes(bytes: number, unit = 'x'): string {
+  const prefix = '{"value":"';
+  const suffix = '"}';
+  const fixedBytes = Buffer.byteLength(prefix + suffix + '\n', 'utf8');
+  const unitBytes = Buffer.byteLength(unit, 'utf8');
+  const remaining = bytes - fixedBytes;
+  if (remaining < 0) throw new Error('byte fixture is too small');
+  const raw = `${prefix}${unit.repeat(Math.floor(remaining / unitBytes))}${'x'.repeat(remaining % unitBytes)}${suffix}\n`;
+  expect(Buffer.byteLength(raw, 'utf8')).toBe(bytes);
+  return raw;
+}
+
+function rawBlock(raw: string): string {
+  return `\`\`\`jinn-output\n${raw}\`\`\``;
+}
+
+function expectCode(run: () => unknown, code: WorkflowOutputError['code']): WorkflowOutputError {
+  let thrown: unknown;
+  try {
+    run();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkflowOutputError);
+  expect(thrown).toMatchObject({ name: 'WorkflowOutputError', code });
+  return thrown as WorkflowOutputError;
+}
+
+describe('prose and fenced-block extraction', () => {
+  it('returns prose unchanged with no schema or an optional-only schema', () => {
+    expect(parseWorkflowOutput('Plain response.')).toEqual({ text: 'Plain response.', fields: {} });
+    expect(parseWorkflowOutput('Plain response.', outputSchema({ note: { type: 'string', required: false } })))
+      .toEqual({ text: 'Plain response.', fields: {} });
+  });
+
+  it('reports a missing required field when no block is present', () => {
+    const error = expectCode(
+      () => parseWorkflowOutput('Plain response.', outputSchema({ result: { type: 'string', required: true } })),
+      'missing-field',
+    );
+    expect(error.message).toBe('Required output field "result" is missing.');
+  });
+
+  it.each(['\n', '\r\n'])('extracts start, middle, end, and block-only responses with %j', (eol) => {
+    const json = '{"result":"ok"}';
+    const expectedFields = { result: 'ok' };
+    expect(parseWorkflowOutput(`${block(json, eol, eol)}after`)).toEqual({ text: 'after', fields: expectedFields });
+    expect(parseWorkflowOutput(`before${eol}${block(json, eol, eol)}after`)).toEqual({
+      text: `before${eol}after`,
+      fields: expectedFields,
+    });
+    expect(parseWorkflowOutput(`before${eol}${block(json, eol)}`)).toEqual({ text: `before${eol}`, fields: expectedFields });
+    expect(parseWorkflowOutput(block(json, eol))).toEqual({ text: '', fields: expectedFields });
+  });
+
+  it('preserves all unrelated prose, Unicode, whitespace, and other fences byte-for-byte', () => {
+    const prefix = 'α  \n```json\n{"kept":true}\n```\n\n';
+    const suffix = '  ω\t';
+    const input = `${prefix}${block('{"result":"✓"}', '\n', '\n')}${suffix}`;
+    expect(parseWorkflowOutput(input)).toEqual({ text: prefix + suffix, fields: { result: '✓' } });
+  });
+
+  it.each([
+    'inline ```jinn-output\n{"x":1}\n``` text',
+    '```json\n{"x":1}\n```',
+    '```JINN-OUTPUT\n{"x":1}\n```',
+    '``` jinn-output\n{"x":1}\n```',
+    '````jinn-output\n{"x":1}\n````',
+    '```jinn-output suffix\n{"x":1}\n```',
+    ' ```jinn-output\n{"x":1}\n```',
+    '\t```jinn-output\n{"x":1}\n```',
+    '```jinn_output\n{"x":1}\n```',
+    'ordinary `backticks` and ``` markers',
+  ])('leaves nonmatching fence syntax as prose: %j', (text) => {
+    expect(parseWorkflowOutput(text)).toEqual({ text, fields: {} });
+  });
+
+  it('accepts only horizontal whitespace after exact opener and closer markers', () => {
+    const input = 'before\n```jinn-output \t\n{"x":1}\n```\t \nafter';
+    expect(parseWorkflowOutput(input)).toEqual({ text: 'before\nafter', fields: { x: 1 } });
+  });
+});
+
+describe('syntax and JSON failure priority', () => {
+  it.each([
+    `${block('{bad')}\n${block('{"ok":true}')}`,
+    '```jinn-output\n{"first":true}\n```jinn-output\n{"second":true}\n```',
+    '```jinn-output\n{}\n```\n```jinn-output\n{}\n```\n```jinn-output',
+  ])('reports multiple recognized openers before inspecting payloads', (text) => {
+    expectCode(() => parseWorkflowOutput(text), 'multiple-blocks');
+  });
+
+  it.each([
+    '```jinn-output',
+    '```jinn-output\n{"x":1}',
+    '```jinn-output\r\n{"x":1}\r\n````',
+    '```jinn-output\n{"x":1}\n ```',
+  ])('reports an opener without a valid later closing line as invalid shape', (text) => {
+    expectCode(() => parseWorkflowOutput(text), 'invalid-shape');
+  });
+
+  it.each(['{', '{"x":1,}', '// comment\n{"x":1}', 'undefined'])('rejects malformed JSON without repair: %j', (json) => {
+    expectCode(() => parseWorkflowOutput(block(json)), 'invalid-json');
+  });
+
+  it.each(['null', '[]', '[1]', 'true', 'false', '1', '"value"'])('rejects non-object JSON: %s', (json) => {
+    expectCode(() => parseWorkflowOutput(block(json)), 'invalid-shape');
+  });
+
+  it('uses native JSON duplicate-key last-value semantics', () => {
+    expect(parseWorkflowOutput(block('{"result":"first","result":"last"}')))
+      .toEqual({ text: '', fields: { result: 'last' } });
+  });
+});
+
+describe('raw payload byte limit', () => {
+  it.each([262_143, LIMIT])('accepts a valid object at exactly %i raw UTF-8 bytes', (bytes) => {
+    const raw = rawObjectAtBytes(bytes);
+    expect(parseWorkflowOutput(rawBlock(raw)).fields.value).toHaveLength(bytes - 13);
+  });
+
+  it('rejects 262145 raw bytes before JSON parsing', () => {
+    const raw = `${'!'.repeat(LIMIT)}\n`;
+    expect(Buffer.byteLength(raw, 'utf8')).toBe(LIMIT + 1);
+    expectCode(() => parseWorkflowOutput(rawBlock(raw)), 'too-large');
+  });
+
+  it('counts multibyte payloads in UTF-8 at the exact boundary', () => {
+    const exact = rawObjectAtBytes(LIMIT, 'é');
+    expect(parseWorkflowOutput(rawBlock(exact)).fields.value).toEqual(expect.any(String));
+    const oversized = `${exact.slice(0, -1)}x\n`;
+    expect(Buffer.byteLength(oversized, 'utf8')).toBe(LIMIT + 1);
+    expectCode(() => parseWorkflowOutput(rawBlock(oversized)), 'too-large');
+  });
+
+  it('does not cap prose outside the structured block', () => {
+    const prose = `α${'x'.repeat(LIMIT + 1)}ω`;
+    expect(parseWorkflowOutput(prose)).toEqual({ text: prose, fields: {} });
+  });
+});
+
+describe('declared output fields', () => {
+  const everyType = outputSchema({
+    title: { type: 'string', required: true },
+    score: { type: 'number', required: true },
+    approved: { type: 'boolean', required: true },
+    tags: { type: 'string[]', required: true },
+    note: { type: 'string', required: false },
+  });
+
+  it('accepts every exact field type and an absent optional field', () => {
+    const output = parseWorkflowOutput(block('{"title":"done","score":1.5,"approved":false,"tags":["a","b"]}'), everyType);
+    expect(output).toEqual({
+      text: '',
+      fields: { title: 'done', score: 1.5, approved: false, tags: ['a', 'b'] },
+    });
+  });
+
+  it.each([
+    ['title', '{"title":1,"score":1,"approved":true,"tags":[]}'],
+    ['score', '{"title":"x","score":"1","approved":true,"tags":[]}'],
+    ['approved', '{"title":"x","score":1,"approved":1,"tags":[]}'],
+    ['tags', '{"title":"x","score":1,"approved":true,"tags":"a"}'],
+    ['tags', '{"title":"x","score":1,"approved":true,"tags":["a",1]}'],
+  ])('rejects an exact type mismatch for %s without coercion', (field, json) => {
+    const error = expectCode(() => parseWorkflowOutput(block(json), everyType), 'type-mismatch');
+    expect(error.message).toBe(`Output field "${field}" does not match declared type "${
+      field === 'title' ? 'string' : field === 'score' ? 'number' : field === 'approved' ? 'boolean' : 'string[]'
+    }".`);
+  });
+
+  it('accepts an empty primitive-string array', () => {
+    const schema = outputSchema({ tags: { type: 'string[]', required: true } });
+    expect(parseWorkflowOutput(block('{"tags":[]}'), schema).fields).toEqual({ tags: [] });
+  });
+
+  it('rejects extras when closed and preserves detached nested JSON when open', () => {
+    const fields = { result: { type: 'string', required: true } } as const;
+    expectCode(() => parseWorkflowOutput(block('{"result":"ok","extra":{"items":[null,true,2]}}'), outputSchema(fields)), 'invalid-shape');
+    expect(parseWorkflowOutput(
+      block('{"result":"ok","extra":{"items":[null,true,2]}}'),
+      outputSchema(fields, true),
+    ).fields).toEqual({ result: 'ok', extra: { items: [null, true, 2] } });
+  });
+
+  it('applies deterministic missing, type, then extra-field priority', () => {
+    const schema = outputSchema({
+      first: { type: 'string', required: true },
+      second: { type: 'boolean', required: true },
+    });
+    expectCode(() => parseWorkflowOutput(block('{"second":1,"extra":true}'), schema), 'missing-field');
+    expectCode(() => parseWorkflowOutput(block('{"first":"ok","second":1,"extra":true}'), schema), 'type-mismatch');
+    expectCode(() => parseWorkflowOutput(block('{"first":"ok","second":true,"extra":true}'), schema), 'invalid-shape');
+  });
+});
+
+describe('submitted output field boundary', () => {
+  it('normalizes undefined to empty fields when no schema is declared', () => {
+    expect(validateSubmittedFields(undefined)).toEqual({});
+  });
+
+  it('rejects undefined when a declared required field is missing', () => {
+    const error = expectCode(
+      () => validateSubmittedFields(undefined, outputSchema({ result: { type: 'string', required: true } })),
+      'missing-field',
+    );
+    expect(error.message).toContain('"result"');
+  });
+
+  it('rejects the wrong field type with the field name and declared type', () => {
+    const error = expectCode(
+      () => validateSubmittedFields({ score: 'high' }, outputSchema({ score: { type: 'number', required: true } })),
+      'type-mismatch',
+    );
+    expect(error.message).toContain('"score"');
+    expect(error.message).toContain('number');
+  });
+
+  it('rejects an extra field when additional fields are disabled', () => {
+    const error = expectCode(
+      () => validateSubmittedFields(
+        { result: 'ok', extra: true },
+        outputSchema({ result: { type: 'string', required: true } }),
+      ),
+      'invalid-shape',
+    );
+    expect(error.message).toContain('"extra"');
+  });
+});
+
+describe('safe object handling', () => {
+  it.each(['__proto__', 'prototype', 'constructor'])('rejects dangerous top-level key %s before required-field checks', (key) => {
+    const schema = outputSchema({ result: { type: 'string', required: true } }, true);
+    expectCode(() => parseWorkflowOutput(block(`{"${key}":true}`), schema), 'invalid-shape');
+    expect((Object.prototype as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it.each(['__proto__', 'prototype', 'constructor'])('rejects dangerous nested key %s', (key) => {
+    expectCode(() => parseWorkflowOutput(block(`{"safe":{"${key}":true}}`)), 'invalid-shape');
+  });
+
+  it('returns detached safe fields without mutating the schema', () => {
+    const schema = outputSchema({ result: { type: 'string', required: true, description: 'A result.' } }, true);
+    const snapshot = structuredClone(schema);
+    const first = parseWorkflowOutput(block('{"result":"ok","nested":{"value":1}}'), schema);
+    const second = parseWorkflowOutput(block('{"result":"ok","nested":{"value":1}}'), schema);
+    (first.fields.nested as Record<string, unknown>).value = 2;
+    expect(second.fields).toEqual({ result: 'ok', nested: { value: 1 } });
+    expect(schema).toEqual(snapshot);
+    expect(Object.getPrototypeOf(second.fields)).toBeNull();
+    expect(Object.getPrototypeOf(second.fields.nested as object)).toBeNull();
+  });
+
+  it('parses Unicode, JSON newlines, and escaped fence-like string content without recursion', () => {
+    const json = JSON.stringify({ message: 'Привет\n```jinn-output\n{"nested":true}\n```\n世界' });
+    expect(parseWorkflowOutput(block(json))).toEqual({
+      text: '',
+      fields: { message: 'Привет\n```jinn-output\n{"nested":true}\n```\n世界' },
+    });
+  });
+});
+
+describe('hostile runtime misuse', () => {
+  it.each([null, undefined, 1, true, {}, [], new String('text')])('rejects a nonstring finalText without stringification', (value) => {
+    expectCode(() => parseWorkflowOutput(value as string), 'invalid-shape');
+  });
+
+  it('does not invoke finalText coercion or Proxy traps', () => {
+    let calls = 0;
+    const hostile = new Proxy({}, {
+      get() { calls += 1; throw new Error('get trap'); },
+      getOwnPropertyDescriptor() { calls += 1; throw new Error('descriptor trap'); },
+      ownKeys() { calls += 1; throw new Error('keys trap'); },
+    });
+    expectCode(() => parseWorkflowOutput(hostile as string), 'invalid-shape');
+    expect(calls).toBe(0);
+  });
+
+  it('rejects hostile schema Proxies without invoking traps', () => {
+    let calls = 0;
+    const hostile = new Proxy({}, {
+      get() { calls += 1; throw new Error('get trap'); },
+      getPrototypeOf() { calls += 1; throw new Error('prototype trap'); },
+      ownKeys() { calls += 1; throw new Error('keys trap'); },
+    });
+    expectCode(() => parseWorkflowOutput(block('{}'), hostile as WorkflowOutputSchema), 'invalid-shape');
+    expect(calls).toBe(0);
+  });
+
+  it('rejects schema accessors and coercion hooks without invoking them', () => {
+    let calls = 0;
+    const accessor: Record<string, unknown> = { allowAdditionalFields: false };
+    Object.defineProperty(accessor, 'fields', { enumerable: true, get() { calls += 1; throw new Error('getter'); } });
+    const coercion = outputSchema();
+    Object.defineProperty(coercion, Symbol.toPrimitive, { get() { calls += 1; throw new Error('coercion'); } });
+    expectCode(() => parseWorkflowOutput(block('{}'), accessor as WorkflowOutputSchema), 'invalid-shape');
+    expectCode(() => parseWorkflowOutput(block('{}'), coercion), 'invalid-shape');
+    expect(calls).toBe(0);
+  });
+
+  it.each([
+    null,
+    {},
+    { fields: {}, allowAdditionalFields: 'yes' },
+    { fields: { 'bad.key': { type: 'string', required: true } }, allowAdditionalFields: false },
+    { fields: { ok: { type: 'object', required: true } }, allowAdditionalFields: false },
+    { fields: { ok: { type: 'string', required: true, extra: true } }, allowAdditionalFields: false },
+    { fields: {}, allowAdditionalFields: false, extra: true },
+  ])('maps invalid runtime schema shapes to WorkflowOutputError', (schema) => {
+    expectCode(() => parseWorkflowOutput(block('{}'), schema as unknown as WorkflowOutputSchema), 'invalid-shape');
+  });
+});
+
+describe('error class contract', () => {
+  it('exposes all six stable codes with safe deterministic messages', () => {
+    const required = outputSchema({ result: { type: 'string', required: true } });
+    const cases: Array<[WorkflowOutputError['code'], () => unknown]> = [
+      ['multiple-blocks', () => parseWorkflowOutput(`${block('{}')}\n${block('{}')}`)],
+      ['invalid-json', () => parseWorkflowOutput(block('{'))],
+      ['invalid-shape', () => parseWorkflowOutput(block('null'))],
+      ['missing-field', () => parseWorkflowOutput(block('{}'), required)],
+      ['type-mismatch', () => parseWorkflowOutput(block('{"result":1}'), required)],
+      ['too-large', () => parseWorkflowOutput(rawBlock(`${'x'.repeat(LIMIT)}\n`))],
+    ];
+    for (const [code, run] of cases) {
+      const error = expectCode(run, code);
+      expect(error.message).not.toMatch(/[{}\[\]]|undefined|null|x{8}/);
+    }
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/recovery-gate.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/recovery-gate.test.ts
@@ -1,0 +1,193 @@
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+type MigrationModule = typeof import('../repository-migrations.js');
+type PathsModule = typeof import('../../shared/paths.js');
+
+const PHYSICAL_V1_SQL = `
+CREATE TABLE workflow_schema (version INTEGER NOT NULL);
+CREATE TABLE workflow_definitions (
+  id TEXT PRIMARY KEY, title TEXT NOT NULL, revision INTEGER NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 0, retired_at TEXT, definition_json TEXT NOT NULL,
+  created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE workflow_runs (
+  id TEXT PRIMARY KEY, workflow_id TEXT NOT NULL REFERENCES workflow_definitions(id),
+  workflow_title TEXT NOT NULL, definition_revision INTEGER NOT NULL, definition_json TEXT NOT NULL,
+  input_json TEXT NOT NULL, trigger_json TEXT NOT NULL, status TEXT NOT NULL, revision INTEGER NOT NULL,
+  idempotency_key TEXT, invocation_session_id TEXT, cancel_requested_at TEXT,
+  started_at TEXT NOT NULL, ended_at TEXT, error_json TEXT, UNIQUE(workflow_id, idempotency_key)
+);
+CREATE TABLE workflow_node_runs (
+  run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE, node_id TEXT NOT NULL,
+  node_type TEXT NOT NULL, status TEXT NOT NULL, activated INTEGER NOT NULL DEFAULT 0,
+  resolved_config_json TEXT, input_json TEXT, output_json TEXT, error_json TEXT,
+  resume_at TEXT, started_at TEXT, ended_at TEXT, PRIMARY KEY(run_id, node_id)
+);
+CREATE TABLE workflow_attempts (
+  run_id TEXT NOT NULL, node_id TEXT NOT NULL, attempt INTEGER NOT NULL, session_id TEXT,
+  status TEXT NOT NULL, resolved_config_json TEXT NOT NULL, input_json TEXT NOT NULL,
+  output_json TEXT, error_json TEXT, started_at TEXT NOT NULL, ended_at TEXT,
+  PRIMARY KEY(run_id, node_id, attempt),
+  FOREIGN KEY(run_id, node_id) REFERENCES workflow_node_runs(run_id, node_id) ON DELETE CASCADE
+);
+CREATE TABLE workflow_approvals (
+  run_id TEXT NOT NULL, node_id TEXT NOT NULL, status TEXT NOT NULL, requested_at TEXT NOT NULL,
+  approver_ref TEXT, decided_at TEXT, decided_by TEXT, decision TEXT, reason TEXT,
+  PRIMARY KEY(run_id, node_id),
+  FOREIGN KEY(run_id, node_id) REFERENCES workflow_node_runs(run_id, node_id) ON DELETE CASCADE
+);
+CREATE INDEX workflow_runs_by_workflow_started ON workflow_runs(workflow_id, started_at DESC, id DESC);
+CREATE INDEX workflow_runs_by_status_started ON workflow_runs(status, started_at DESC, id DESC);
+CREATE INDEX workflow_attempts_by_session ON workflow_attempts(session_id);
+CREATE INDEX workflow_approvals_pending ON workflow_approvals(status, requested_at);
+CREATE INDEX workflow_node_runs_due ON workflow_node_runs(status, resume_at);
+INSERT INTO workflow_schema VALUES (1);
+INSERT INTO workflow_definitions
+  (id, title, revision, definition_json, created_at, updated_at)
+  VALUES ('physical-v1', 'Fixture', 1, '{}', '2026-07-21T00:00:00.000Z', '2026-07-21T00:00:00.000Z');
+`;
+
+let suiteRoot: string;
+let previousJinnHome: string | undefined;
+let migrations: MigrationModule;
+let paths: PathsModule;
+
+const SYMLINK_ERROR = 'Workflow database default store must not contain symbolic links.';
+
+beforeAll(async () => {
+  suiteRoot = mkdtempSync(join(tmpdir(), 'jinn-workflow-recovery-'));
+  previousJinnHome = process.env.JINN_HOME;
+  process.env.JINN_HOME = suiteRoot;
+  vi.resetModules();
+  paths = await import('../../shared/paths.js');
+  migrations = await import('../repository-migrations.js');
+});
+
+afterAll(() => {
+  if (previousJinnHome === undefined) delete process.env.JINN_HOME;
+  else process.env.JINN_HOME = previousJinnHome;
+  rmSync(suiteRoot, { recursive: true, force: true });
+});
+
+function resetDefaultStore(): void {
+  rmSync(paths.WORKFLOWS_DIR, { recursive: true, force: true });
+}
+
+function expectDefaultOpenToFailClosed(): void {
+  let db: Database.Database | undefined;
+  expect(() => {
+    try {
+      db = migrations.openWorkflowDatabase();
+    } finally {
+      db?.close();
+    }
+  }).toThrowError(SYMLINK_ERROR);
+}
+
+describe('workflow recovery gate', () => {
+  it('opens a handcrafted physical v1 database through the public opener', () => {
+    const file = join(suiteRoot, 'physical-v1', 'workflows.db');
+    mkdirSync(dirname(file), { recursive: true });
+    const raw = new Database(file);
+    raw.exec(PHYSICAL_V1_SQL);
+    raw.close();
+
+    const db = migrations.openWorkflowDatabase(file);
+    try {
+      expect(db.prepare('SELECT version FROM workflow_schema').pluck().get())
+        .toBe(migrations.WORKFLOW_DB_SCHEMA_VERSION);
+      expect(db.prepare('SELECT title FROM workflow_definitions WHERE id = ?').pluck().get('physical-v1'))
+        .toBe('Fixture');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('enforces owner-only modes for the exact default database store on POSIX', () => {
+    if (process.platform === 'win32') return;
+    mkdirSync(paths.WORKFLOWS_DIR, { recursive: true, mode: 0o755 });
+    chmodSync(paths.WORKFLOWS_DIR, 0o755);
+    const previousUmask = process.umask(0);
+    let db: Database.Database | undefined;
+    try {
+      db = migrations.openWorkflowDatabase(paths.WORKFLOWS_DB_PATH);
+      for (const file of [paths.WORKFLOWS_DB_PATH, `${paths.WORKFLOWS_DB_PATH}-wal`, `${paths.WORKFLOWS_DB_PATH}-shm`]) {
+        expect(existsSync(file)).toBe(true);
+        expectPosixMode(statSync(file), 0o600);
+      }
+      expectPosixMode(statSync(paths.WORKFLOWS_DIR), 0o700);
+    } finally {
+      db?.close();
+      process.umask(previousUmask);
+    }
+  });
+
+  it('rejects a symlinked default directory without touching its caller-owned target', () => {
+    if (process.platform === 'win32') return;
+    resetDefaultStore();
+    const target = join(suiteRoot, 'caller-directory');
+    const sentinel = join(target, 'sentinel.txt');
+    mkdirSync(target, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    writeFileSync(sentinel, 'caller-owned-directory');
+    const before = readFileSync(sentinel);
+    symlinkSync(target, paths.WORKFLOWS_DIR, 'dir');
+
+    expectDefaultOpenToFailClosed();
+
+    expectPosixMode(statSync(target), 0o755);
+    expect(readFileSync(sentinel)).toEqual(before);
+  });
+
+  it('rejects a symlinked default database without touching its caller-owned target', () => {
+    if (process.platform === 'win32') return;
+    resetDefaultStore();
+    mkdirSync(paths.WORKFLOWS_DIR, { mode: 0o700 });
+    const target = join(suiteRoot, 'caller-database');
+    writeFileSync(target, 'caller-owned-database');
+    chmodSync(target, 0o644);
+    const before = readFileSync(target);
+    symlinkSync(target, paths.WORKFLOWS_DB_PATH);
+
+    expectDefaultOpenToFailClosed();
+
+    expectPosixMode(statSync(target), 0o644);
+    expect(readFileSync(target)).toEqual(before);
+  });
+
+  it.each(['-wal', '-shm'])('rejects a planted %s symlink before SQLite can follow it', (suffix) => {
+    if (process.platform === 'win32') return;
+    resetDefaultStore();
+    mkdirSync(paths.WORKFLOWS_DIR, { mode: 0o700 });
+    const raw = new Database(paths.WORKFLOWS_DB_PATH);
+    raw.close();
+    chmodSync(paths.WORKFLOWS_DB_PATH, 0o600);
+    const databaseBefore = readFileSync(paths.WORKFLOWS_DB_PATH);
+    const target = join(suiteRoot, `caller-sidecar${suffix}`);
+    writeFileSync(target, `caller-owned${suffix}`);
+    chmodSync(target, 0o644);
+    const targetBefore = readFileSync(target);
+    symlinkSync(target, `${paths.WORKFLOWS_DB_PATH}${suffix}`);
+
+    expectDefaultOpenToFailClosed();
+
+    expect(readFileSync(paths.WORKFLOWS_DB_PATH)).toEqual(databaseBefore);
+    expectPosixMode(statSync(target), 0o644);
+    expect(readFileSync(target)).toEqual(targetBefore);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/reminder-ladder.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/reminder-ladder.test.ts
@@ -1,0 +1,469 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { WorkflowDefinition, WorkflowOutputSchema } from "../model.js";
+import { WorkflowOutputError } from "../output.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository, WorkflowRepositoryError } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+const employee: Employee = {
+  name: "worker",
+  displayName: "Worker",
+  department: "operations",
+  rank: "employee",
+  engine: "test-engine",
+  model: "test-model",
+  effortLevel: "high",
+  persona: "Complete the workflow step.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine",
+    available: true,
+    defaultModel: "test-model",
+    effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  readonly reminders: Array<{ sessionId: string; text: string }> = [];
+  readonly states = new Map<string, { idle: boolean; runningChildren: number }>();
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+  private readonly turns = new Map<string, number>();
+  private readonly receipts = new Map<string, WorkflowAttemptCompletion>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    const sessionId = this.sessionId(command);
+    this.states.set(sessionId, { idle: true, runningChildren: 0 });
+    return { sessionId };
+  }
+  async stopAttempt(): Promise<void> {}
+  async remind(input: { sessionId: string; text: string }): Promise<void> {
+    this.reminders.push(input);
+  }
+  attemptState(sessionId: string): { idle: boolean; runningChildren: number } | null {
+    return this.states.get(sessionId) ?? null;
+  }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(sessionId: string): WorkflowAttemptCompletion | null {
+    return this.receipts.get(sessionId) ?? null;
+  }
+  async turnEnd(finalText = "The work is done.", outcome: WorkflowAttemptCompletion["outcome"] = "succeeded"): Promise<void> {
+    const command = this.commands.at(-1)!;
+    const sessionId = this.sessionId(command);
+    const turn = (this.turns.get(sessionId) ?? 0) + 1;
+    this.turns.set(sessionId, turn);
+    const event: WorkflowAttemptCompletion = {
+      sessionId,
+      owner: command.owner,
+      turn,
+      terminalVersion: 1,
+      outcome,
+      ...(outcome === "succeeded" ? { finalText } : { error: finalText }),
+      completedAt: now,
+    };
+    this.receipts.set(sessionId, event);
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+  sessionId(command = this.commands.at(-1)!): string {
+    return `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let service: WorkflowService;
+let now: string;
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function saveDefinition(input: {
+  id: string;
+  output?: WorkflowOutputSchema;
+  retries?: number;
+  errorRoute?: boolean;
+  timeoutMinutes?: number;
+}): WorkflowDefinition {
+  const created = repository.createDefinition({ id: input.id, title: input.id });
+  const nodes: WorkflowDefinition["nodes"] = [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    {
+      id: "work",
+      type: "employee",
+      name: "Work",
+      config: {
+        employee: { source: "fixed", value: "worker" },
+        prompt: "Complete the work.",
+        ...(input.output ? { output: input.output } : {}),
+        retry: { attempts: input.retries ?? 1, delaySeconds: 0, backoff: "fixed" },
+        ...(input.timeoutMinutes ? { timeoutMinutes: input.timeoutMinutes } : {}),
+      },
+    },
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ...(input.errorRoute
+      ? [{ id: "handled", type: "end" as const, name: "Handled", config: { result: "success" as const } }]
+      : []),
+  ];
+  const edges = [
+    edge("start-work", "start", "success", "work"),
+    edge("work-finish", "work", "success", "finish"),
+    ...(input.errorRoute ? [edge("work-error", "work", "error", "handled")] : []),
+  ];
+  const saved = repository.saveDefinition({ ...created, nodes, edges }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+async function start(input: Parameters<typeof saveDefinition>[0]) {
+  const definition = saveDefinition(input);
+  const run = await service.startManual({ workflowId: definition.id, input: {} });
+  return { definition, run, sessionId: executor.sessionId() };
+}
+
+async function recover(at: string): Promise<void> {
+  now = at;
+  await service.recover(now);
+}
+
+function rebuildService(): void {
+  service.dispose();
+  service = new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => now,
+  });
+}
+
+async function sendThreeReminders(): Promise<void> {
+  await executor.turnEnd();
+  await recover("2026-07-21T10:05:00.000Z");
+  await executor.turnEnd();
+  await recover("2026-07-21T10:20:00.000Z");
+  await executor.turnEnd();
+  await recover("2026-07-21T10:50:00.000Z");
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-reminder-ladder-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  now = "2026-07-21T10:00:00.000Z";
+  repository = new WorkflowRepository(database, () => now);
+  executor = new FakeExecutor();
+  service = new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => now,
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("workflow explicit completion and reminder ladder", () => {
+  it("schedules the first reminder five minutes after a tool-less turn end", async () => {
+    const { definition, run } = await start({ id: "first-rung" });
+    await executor.turnEnd();
+
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      status: "running",
+      remindersSent: 0,
+      nextReminderAt: "2026-07-21T10:05:00.000Z",
+    });
+  });
+
+  it("escalates through 5/15/30 minute rungs and adds the extension instruction to the third", async () => {
+    const { definition, run } = await start({ id: "three-rungs" });
+    await executor.turnEnd();
+    await recover("2026-07-21T10:05:00.000Z");
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      remindersSent: 1,
+    });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt).toBeUndefined();
+    await executor.turnEnd();
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt)
+      .toBe("2026-07-21T10:20:00.000Z");
+    await recover("2026-07-21T10:20:00.000Z");
+    await executor.turnEnd();
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt)
+      .toBe("2026-07-21T10:50:00.000Z");
+    await recover("2026-07-21T10:50:00.000Z");
+
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({ remindersSent: 3 });
+    expect(executor.reminders).toHaveLength(3);
+    expect(executor.reminders[2]?.text).toContain("final reminder");
+    expect(executor.reminders[2]?.text).toContain("workflow_extend_deadline");
+  });
+
+  it("ignores the persisted prior turn after a reminder is delivered but before its turn runs", async () => {
+    const { definition, run } = await start({ id: "restart-before-reminder-turn" });
+    await executor.turnEnd();
+    await recover("2026-07-21T10:05:00.000Z");
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      status: "running",
+      remindersSent: 1,
+      lastProcessedTurn: 1,
+    });
+
+    rebuildService();
+    const recovered = await service.recover(now);
+
+    expect(recovered.resumedRuns).toBe(0);
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      status: "running",
+      remindersSent: 1,
+      lastProcessedTurn: 1,
+    });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt).toBeUndefined();
+  });
+
+  it("ignores duplicate stale receipts after a reminder rung is consumed", async () => {
+    const { definition, run } = await start({ id: "duplicate-stale-receipt" });
+    await executor.turnEnd();
+    await recover("2026-07-21T10:05:00.000Z");
+    rebuildService();
+    const revision = service.getRun(definition.id, run.id)!.revision;
+
+    expect(await service.recover(now)).toMatchObject({ resumedRuns: 0 });
+    expect(await service.recover(now)).toMatchObject({ resumedRuns: 0 });
+    expect(service.getRun(definition.id, run.id)).toMatchObject({ revision });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      remindersSent: 1,
+      lastProcessedTurn: 1,
+    });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt).toBeUndefined();
+  });
+
+  it("defers busy and child-active sessions five minutes without consuming a rung", async () => {
+    const { definition, run, sessionId } = await start({ id: "deferred-rung" });
+    await executor.turnEnd();
+    executor.states.set(sessionId, { idle: false, runningChildren: 0 });
+    await recover("2026-07-21T10:05:00.000Z");
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      remindersSent: 0,
+      nextReminderAt: "2026-07-21T10:10:00.000Z",
+    });
+    executor.states.set(sessionId, { idle: true, runningChildren: 1 });
+    await recover("2026-07-21T10:10:00.000Z");
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      remindersSent: 0,
+      nextReminderAt: "2026-07-21T10:15:00.000Z",
+    });
+    expect(executor.reminders).toEqual([]);
+  });
+
+  it("fails with workflow-no-output after rung three and routes the error port", async () => {
+    const { definition, run } = await start({ id: "no-output-route", errorRoute: true });
+    await sendThreeReminders();
+    await executor.turnEnd();
+
+    const detail = service.getRun(definition.id, run.id)!;
+    expect(detail.attempts[0]).toMatchObject({
+      status: "failed",
+      error: { code: "workflow-no-output", retryable: true },
+    });
+    expect(detail.nodeRuns.find((node) => node.nodeId === "handled")?.status).toBe("completed");
+    expect(detail.status).toBe("completed");
+  });
+
+  it("does not fail after rung three while delegated children are active", async () => {
+    const { definition, run, sessionId } = await start({ id: "children-after-final" });
+    await sendThreeReminders();
+    executor.states.set(sessionId, { idle: true, runningChildren: 1 });
+    await executor.turnEnd();
+
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      status: "running",
+      remindersSent: 3,
+    });
+  });
+
+  it("submits validated success, advances, and rejects a second submission", async () => {
+    const output: WorkflowOutputSchema = {
+      fields: { result: { type: "string", required: true } },
+      allowAdditionalFields: false,
+    };
+    const { definition, run, sessionId } = await start({ id: "submit-success", output });
+    await expect(service.submitAttemptOutput({
+      sessionId,
+      fields: { result: 42 },
+      summary: "Wrong.",
+    })).rejects.toBeInstanceOf(WorkflowOutputError);
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.status).toBe("running");
+
+    const completed = await service.submitAttemptOutput({
+      sessionId,
+      fields: { result: "done" },
+      summary: "Finished.",
+    });
+    expect(completed).toMatchObject({ status: "completed" });
+    expect(completed.attempts[0]?.output).toMatchObject({
+      text: "Finished.",
+      fields: { result: "done" },
+      sessionId,
+    });
+    await expect(service.submitAttemptOutput({ sessionId, fields: { result: "again" } }))
+      .rejects.toMatchObject({ code: "already-submitted" } satisfies Partial<WorkflowRepositoryError>);
+  });
+
+  it("routes an explicitly submitted failure through the error port", async () => {
+    const { definition, run, sessionId } = await start({ id: "submit-failure", errorRoute: true });
+    const detail = await service.submitAttemptOutput({
+      sessionId,
+      outcome: "failure",
+      summary: "Could not verify.",
+    });
+
+    expect(detail.attempts[0]).toMatchObject({
+      status: "failed",
+      error: { code: "workflow-submitted-failure", message: "Could not verify." },
+    });
+    expect(detail.nodeRuns.find((node) => node.nodeId === "handled")?.status).toBe("completed");
+    expect(service.getRun(definition.id, run.id)).toEqual(detail);
+  });
+
+  it("rejects a duplicate explicit failure without replacing the first settlement", async () => {
+    const { definition, run, sessionId } = await start({ id: "double-failure" });
+    await service.submitAttemptOutput({ sessionId, outcome: "failure", summary: "First failure." });
+
+    await expect(service.submitAttemptOutput({ sessionId, outcome: "failure", summary: "Second failure." }))
+      .rejects.toMatchObject({ code: "already-submitted" } satisfies Partial<WorkflowRepositoryError>);
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      status: "failed",
+      error: { code: "workflow-submitted-failure", message: "First failure." },
+    });
+  });
+
+  it("does not let a concurrent deadline extension resurrect a settled attempt", async () => {
+    const { definition, run, sessionId } = await start({ id: "settle-extend-conflict" });
+
+    const [settlement, extension] = await Promise.allSettled([
+      service.submitAttemptOutput({ sessionId, summary: "Finished." }),
+      service.extendAttemptDeadline({ sessionId, reason: "Too late." }),
+    ]);
+
+    expect(settlement.status).toBe("fulfilled");
+    expect(extension).toMatchObject({
+      status: "rejected",
+      reason: { code: "already-submitted" },
+    });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      status: "completed",
+      extensions: 0,
+    });
+  });
+
+  it("rejects submission after failure, timeout, and cancellation", async () => {
+    const failed = await start({ id: "submit-after-failure" });
+    await service.submitAttemptOutput({ sessionId: failed.sessionId, outcome: "failure" });
+    await expect(service.submitAttemptOutput({ sessionId: failed.sessionId }))
+      .rejects.toMatchObject({ code: "already-submitted" } satisfies Partial<WorkflowRepositoryError>);
+
+    const timedOut = await start({ id: "submit-after-timeout", timeoutMinutes: 1 });
+    now = "2026-07-21T10:01:00.000Z";
+    await service.recover(now);
+    expect(service.getRun(timedOut.definition.id, timedOut.run.id)?.attempts[0]?.status).toBe("timed-out");
+    await expect(service.submitAttemptOutput({ sessionId: timedOut.sessionId }))
+      .rejects.toMatchObject({ code: "already-submitted" } satisfies Partial<WorkflowRepositoryError>);
+
+    const cancelled = await start({ id: "submit-after-cancel" });
+    await service.cancelRun({
+      workflowId: cancelled.definition.id,
+      runId: cancelled.run.id,
+      reason: "Cancelled for test.",
+    });
+    await expect(service.submitAttemptOutput({ sessionId: cancelled.sessionId }))
+      .rejects.toMatchObject({ code: "already-submitted" } satisfies Partial<WorkflowRepositoryError>);
+  });
+
+  it("scopes submission to the calling live workflow session", async () => {
+    const first = await start({ id: "submission-owner-a" });
+    const second = await start({ id: "submission-owner-b" });
+
+    await service.submitAttemptOutput({ sessionId: second.sessionId, summary: "Second is done." });
+
+    expect(service.getRun(first.definition.id, first.run.id)?.attempts[0]?.status).toBe("running");
+    expect(service.getRun(second.definition.id, second.run.id)?.attempts[0]).toMatchObject({
+      status: "completed",
+      sessionId: second.sessionId,
+      output: { text: "Second is done." },
+    });
+  });
+
+  it("resets the ladder on extension, records the reason, and starts a fresh five-minute cycle", async () => {
+    const { definition, run, sessionId } = await start({ id: "extend-deadline" });
+    await executor.turnEnd();
+    await recover("2026-07-21T10:05:00.000Z");
+    await service.extendAttemptDeadline({ sessionId, reason: "Waiting for a reviewer." });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]).toMatchObject({
+      remindersSent: 0,
+      extensions: 1,
+      lastExtensionReason: "Waiting for a reviewer.",
+    });
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt).toBeUndefined();
+
+    await executor.turnEnd();
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.nextReminderAt)
+      .toBe("2026-07-21T10:10:00.000Z");
+  });
+
+  it("settles a valid fenced block and carries an invalid block error into the next reminder", async () => {
+    const output: WorkflowOutputSchema = {
+      fields: { score: { type: "number", required: true } },
+      allowAdditionalFields: false,
+    };
+    const valid = await start({ id: "valid-fallback", output });
+    await executor.turnEnd("Done.\n```jinn-output\n{\"score\":9}\n```");
+    expect(service.getRun(valid.definition.id, valid.run.id)?.attempts[0]).toMatchObject({ status: "completed" });
+
+    const invalid = await start({ id: "invalid-fallback", output });
+    await executor.turnEnd("Done.\n```jinn-output\n{\"score\":\"high\"}\n```");
+    expect(service.getRun(invalid.definition.id, invalid.run.id)?.attempts[0]).toMatchObject({
+      status: "running",
+      pendingOutputError: expect.stringContaining('"score"'),
+      nextReminderAt: "2026-07-21T10:05:00.000Z",
+    });
+    await recover("2026-07-21T10:05:00.000Z");
+    expect(executor.reminders.at(-1)?.text).toContain("Your previous output block was invalid:");
+    expect(executor.reminders.at(-1)?.text).toContain('"score"');
+    expect(service.getRun(invalid.definition.id, invalid.run.id)?.attempts[0]?.pendingOutputError).toBeUndefined();
+  });
+
+  it("keeps the first tool submission when the same turn later ends with a fenced block", async () => {
+    const output: WorkflowOutputSchema = {
+      fields: { result: { type: "string", required: true } },
+      allowAdditionalFields: false,
+    };
+    const { definition, run, sessionId } = await start({ id: "tool-before-block", output });
+    await service.submitAttemptOutput({ sessionId, fields: { result: "tool" } });
+    await executor.turnEnd("```jinn-output\n{\"result\":\"block\"}\n```");
+
+    expect(service.getRun(definition.id, run.id)?.attempts[0]?.output?.fields).toEqual({ result: "tool" });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/repository-definitions.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/repository-definitions.test.ts
@@ -1,0 +1,675 @@
+import { Buffer } from 'node:buffer';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import type { WorkflowDefinition, WorkflowId } from '../model.js';
+import {
+  WorkflowRepository,
+  WorkflowRepositoryError,
+  type CreateWorkflowInput,
+  type CursorPage,
+  type DefinitionListQuery,
+  type WorkflowDefinitionSummary,
+} from '../repository.js';
+import { openWorkflowDatabase } from '../repository-migrations.js';
+import { WorkflowService } from '../service.js';
+
+let root: string;
+let db: Database.Database;
+let repository: WorkflowRepository;
+let now: string;
+let clockCalls: number;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'jinn-workflow-definitions-'));
+  db = openWorkflowDatabase(join(root, 'workflows.db'));
+  now = '2026-07-21T00:00:00.000Z';
+  clockCalls = 0;
+  repository = new WorkflowRepository(db, () => {
+    clockCalls += 1;
+    return now;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+function create(id: string, title = id): WorkflowDefinition {
+  return repository.createDefinition({ id, title });
+}
+
+function expectRepositoryError(action: () => unknown, code: WorkflowRepositoryError['code']): WorkflowRepositoryError {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkflowRepositoryError);
+  expect(thrown).toMatchObject({ name: 'WorkflowRepositoryError', code });
+  return thrown as WorkflowRepositoryError;
+}
+
+function encodeCursor(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function encodeCursorJson(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Record<string, unknown>;
+}
+
+function repositoryOutcome(action: () => unknown): string {
+  try {
+    action();
+    return 'accepted';
+  } catch (error) {
+    if (error instanceof WorkflowRepositoryError) return error.code;
+    return error instanceof Error ? error.name : typeof error;
+  }
+}
+
+function adversarialEnvelopes(id: string): { values: unknown[]; calls: () => number } {
+  let calls = 0;
+  const valid = { id, title: 'Title' };
+  const symbol = { ...valid, [Symbol('extra')]: true };
+  const hidden = { id };
+  Object.defineProperty(hidden, 'title', { value: 'Title', enumerable: false });
+  const accessor = { id };
+  Object.defineProperty(accessor, 'title', { enumerable: true, get() { calls += 1; return 'Title'; } });
+  const proxy = new Proxy(valid, { get() { calls += 1; throw new Error('trap'); }, ownKeys() { calls += 1; throw new Error('trap'); } });
+  const revoked = Proxy.revocable(valid, {});
+  revoked.revoke();
+  const cycle: Record<string, unknown> = { ...valid };
+  cycle.self = cycle;
+  class Envelope { id = `${valid.id}-class`; title = valid.title; }
+  return {
+    values: [null, [], {}, { id }, { ...valid, extra: true }, symbol, hidden, accessor,
+      proxy, revoked.proxy, cycle, new Envelope(), { ...valid, id: 1 }, { ...valid, title: 1 }, { ...valid, description: 1 }],
+    calls: () => calls,
+  };
+}
+
+function adversarialQueries(): { values: unknown[]; calls: () => number } {
+  let calls = 0;
+  const accessor = {};
+  Object.defineProperty(accessor, 'limit', { enumerable: true, get() { calls += 1; return 1; } });
+  const hidden = {};
+  Object.defineProperty(hidden, 'limit', { value: 1, enumerable: false });
+  const proxy = new Proxy({ limit: 1 }, { get() { calls += 1; throw new Error('trap'); } });
+  const statefulTarget = { limit: 1 };
+  const stateful = new Proxy(statefulTarget, { ownKeys() { calls += 1; statefulTarget.limit += 1; return ['limit']; } });
+  const revoked = Proxy.revocable({ limit: 1 }, {});
+  revoked.revoke();
+  const cycle: Record<string, unknown> = {};
+  cycle.self = cycle;
+  class Query { limit = 1; }
+  return {
+    values: [accessor, proxy, stateful, revoked.proxy, { limit: 1, [Symbol('extra')]: true }, hidden,
+      [], new Query(), cycle, true, 1, 'Invalid ID', 1n, null, undefined, { extra: true }],
+    calls: () => calls,
+  };
+}
+
+function summary(definition: WorkflowDefinition): WorkflowDefinitionSummary {
+  return {
+    id: definition.id,
+    title: definition.title,
+    description: definition.description ?? null,
+    revision: definition.revision,
+    enabled: definition.enabled,
+    retiredAt: definition.retiredAt ?? null,
+    createdAt: definition.createdAt,
+    updatedAt: definition.updatedAt,
+  };
+}
+
+function storedDefinitions(): string {
+  return JSON.stringify(db.prepare('SELECT * FROM workflow_definitions ORDER BY id').all());
+}
+
+describe('WorkflowRepository public definition contract', () => {
+  it('exports the locked Task13 service and workflow identity surface', () => {
+    expectTypeOf<WorkflowId>().toEqualTypeOf<WorkflowDefinition['id']>();
+    const methods = Object.getOwnPropertyNames(WorkflowService.prototype);
+    for (const method of [
+      'listDefinitions', 'createDefinition', 'getDefinition', 'saveDefinition', 'duplicateDefinition',
+      'setRetired', 'setEnabled', 'startManual', 'fireEvent', 'getRun', 'listRuns',
+      'getAttemptTranscript', 'cancelRun', 'rerun', 'recover',
+    ]) expect(methods).toContain(method);
+  });
+  it('exposes the exact Task 10 method and page shapes', () => {
+    expectTypeOf(repository.createDefinition).parameter(0).toEqualTypeOf<CreateWorkflowInput>();
+    expectTypeOf(repository.listDefinitions).parameter(0).toEqualTypeOf<DefinitionListQuery>();
+    expectTypeOf(repository.listDefinitions).returns.toEqualTypeOf<CursorPage<WorkflowDefinitionSummary>>();
+    expectTypeOf(repository.getDefinition).returns.toEqualTypeOf<WorkflowDefinition | null>();
+  });
+
+  it('exposes every locked repository error code including the Task 11 reservation', () => {
+    expectTypeOf<WorkflowRepositoryError['code']>().toEqualTypeOf<
+      'not-found' | 'id-conflict' | 'revision-conflict' | 'idempotency-conflict'
+      | 'retired' | 'bad-cursor' | 'bad-input' | 'corrupt-record' | 'already-submitted'
+    >();
+  });
+});
+
+describe('public ID validation', () => {
+  it('rejects invalid IDs before prepared statements and preserves duplicate priority', () => {
+    const adversarial = adversarialQueries();
+    const invalidIds = [...adversarial.values, '', 'Invalid', '1workflow', 'under_score', `a${'b'.repeat(64)}`];
+    const methods: Array<[string, (id: unknown) => unknown]> = [
+      ['get', (id) => repository.getDefinition(id as string)],
+      ['enable', (id) => repository.setEnabled(id as string, true, 1)],
+      ['retire', (id) => repository.setRetired(id as string, true, 1, now)],
+      ['duplicate', (id) => repository.duplicateDefinition(id as string, { id: 'copy', title: 'Copy' })],
+    ];
+    const prepare = vi.spyOn(db, 'prepare');
+    const priority = expectRepositoryError(
+      () => repository.duplicateDefinition(adversarial.values[1] as string, { id: 'Invalid', title: 'Copy' }),
+      'bad-input',
+    );
+    expect(priority.message).toBe('Workflow definition is invalid.');
+    expect(adversarial.calls()).toBe(0);
+    expect(methods.flatMap(([name, method]) => invalidIds.map((id) => [name, repositoryOutcome(() => method(id))])))
+      .toEqual(methods.flatMap(([name]) => invalidIds.map(() => [name, 'bad-input'])));
+    expect(adversarial.calls()).toBe(0);
+    expect(prepare).not.toHaveBeenCalled();
+  });
+});
+
+describe('validation before immediate transactions', () => {
+  it('rejects deterministic write inputs before contention while preserving real SQLITE_BUSY', () => {
+    const saveSource = create('lock-save');
+    const enableSource = create('lock-enable');
+    const retireSource = create('lock-retire');
+    const duplicateSource = create('lock-duplicate');
+    const before = storedDefinitions();
+    const canonicalNow = now;
+    const adversarial = adversarialQueries();
+    const cases: Array<[string, unknown, WorkflowRepositoryError['code'], () => unknown]> = [
+      ['create target', canonicalNow, 'bad-input', () => repository.createDefinition({ id: 'Invalid', title: 'Title' })],
+      ['duplicate target', canonicalNow, 'bad-input', () => repository.duplicateDefinition(duplicateSource.id, { id: 'Invalid', title: 'Copy' })],
+      ['duplicate source accessor', canonicalNow, 'bad-input', () => repository.duplicateDefinition(adversarial.values[0] as string, { id: 'copy-a', title: 'Copy' })],
+      ['duplicate source proxy', canonicalNow, 'bad-input', () => repository.duplicateDefinition(adversarial.values[1] as string, { id: 'copy-b', title: 'Copy' })],
+      ['save definition', canonicalNow, 'bad-input', () => repository.saveDefinition({ ...saveSource, title: '' }, 1)],
+      ['save revision', canonicalNow, 'revision-conflict', () => repository.saveDefinition(saveSource, 1.5)],
+      ['enable id', canonicalNow, 'bad-input', () => repository.setEnabled('Invalid', true, 1)],
+      ['enable state', canonicalNow, 'bad-input', () => repository.setEnabled(enableSource.id, 'yes' as unknown as boolean, 1)],
+      ['enable revision', canonicalNow, 'revision-conflict', () => repository.setEnabled(enableSource.id, true, 1.5)],
+      ['retire id', canonicalNow, 'bad-input', () => repository.setRetired('Invalid', true, 1, canonicalNow)],
+      ['retire revision', canonicalNow, 'revision-conflict', () => repository.setRetired(retireSource.id, true, 1.5, canonicalNow)],
+      ['retire at', canonicalNow, 'bad-input', () => repository.setRetired(retireSource.id, true, 1, 1 as unknown as string)],
+      ['create clock', '2026-07-21T00:00:00Z', 'bad-input', () => create('lock-clock-create')],
+      ['duplicate clock', 1, 'bad-input', () => repository.duplicateDefinition(duplicateSource.id, { id: 'lock-clock-copy', title: 'Copy' })],
+      ['save clock', 'not-an-instant', 'bad-input', () => repository.saveDefinition(saveSource, 1)],
+      ['enable clock', '2026-07-21T00:00:00.000+00:00', 'bad-input', () => repository.setEnabled(enableSource.id, true, 1)],
+      ['retire clock', null, 'bad-input', () => repository.setRetired(retireSource.id, true, 1, canonicalNow)],
+    ];
+    const blocker = openWorkflowDatabase(join(root, 'workflows.db'));
+    db.pragma('busy_timeout = 0');
+    blocker.exec('BEGIN IMMEDIATE');
+    const prepare = vi.spyOn(db, 'prepare');
+    let contention: unknown;
+    let prepareCalls = 0;
+    let results: Array<[string, string]> = [];
+    try {
+      results = cases.map(([name, stamp, , action]) => {
+        now = stamp as string;
+        return [name, repositoryOutcome(action)];
+      });
+      now = canonicalNow;
+      try { create('valid-under-lock'); } catch (error) { contention = error; }
+    } finally {
+      prepareCalls = prepare.mock.calls.length;
+      prepare.mockRestore();
+      blocker.exec('ROLLBACK');
+      blocker.close();
+    }
+    expect(results).toEqual(cases.map(([name, , code]) => [name, code]));
+    expect(adversarial.calls()).toBe(0);
+    expect(prepareCalls).toBe(0);
+    expect(contention).toMatchObject({ name: 'SqliteError', code: 'SQLITE_BUSY' });
+    expect(contention).not.toBeInstanceOf(WorkflowRepositoryError);
+    expect(storedDefinitions()).toBe(before);
+
+    now = canonicalNow;
+    const callsBeforeCrud = clockCalls;
+    const created = create('after-lock');
+    const saved = repository.saveDefinition({ ...created, title: 'Saved' }, 1);
+    const enabled = repository.setEnabled(saved.id, true, saved.revision);
+    const copy = repository.duplicateDefinition(enabled.id, { id: 'after-lock-copy', title: 'Copy' });
+    const retired = repository.setRetired(enabled.id, true, enabled.revision, canonicalNow);
+    expect({ saved: saved.revision, enabled: enabled.enabled, copy: copy.revision,
+      retired: retired.retiredAt, read: repository.getDefinition(copy.id)?.id })
+      .toEqual({ saved: 2, enabled: true, copy: 1, retired: canonicalNow, read: copy.id });
+    expect(clockCalls - callsBeforeCrud).toBe(5);
+  });
+});
+
+describe('createDefinition and getDefinition', () => {
+  it('uses the caller ID and one transaction-clock value for canonical disabled defaults', () => {
+    const created = repository.createDefinition({
+      id: 'content-pipeline',
+      title: 'Content pipeline',
+      description: 'Prepare and review content.',
+    });
+
+    expect(created).toEqual({
+      schemaVersion: 1,
+      id: 'content-pipeline',
+      title: 'Content pipeline',
+      description: 'Prepare and review content.',
+      revision: 1,
+      enabled: false,
+      nodes: [],
+      edges: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(created).not.toHaveProperty('retiredAt');
+    expect(clockCalls).toBe(1);
+    expect(repository.getDefinition(created.id)).toEqual(created);
+    expect(repository.getDefinition('missing-workflow')).toBeNull();
+
+    const row = db.prepare('SELECT retired_at, definition_json FROM workflow_definitions WHERE id = ?')
+      .get(created.id) as { retired_at: string | null; definition_json: string };
+    expect(row.retired_at).toBeNull();
+    expect(JSON.parse(row.definition_json)).not.toHaveProperty('retiredAt');
+  });
+
+  it('rejects duplicate IDs without replacing the stable original', () => {
+    const original = create('stable-id', 'Original');
+    expectRepositoryError(
+      () => repository.createDefinition({ id: 'stable-id', title: 'Replacement' }),
+      'id-conflict',
+    );
+    expect(repository.getDefinition('stable-id')).toEqual(original);
+  });
+
+  it.each([
+    [{ id: '', title: 'Title' }, 'invalid ID'],
+    [{ id: 'Invalid', title: 'Title' }, 'invalid ID grammar'],
+    [{ id: 'valid-id', title: '' }, 'empty title'],
+    [{ id: 'valid-id', title: 'x'.repeat(121) }, 'long title'],
+  ])('rejects bad create input: %s (%s)', (input) => {
+    expectRepositoryError(() => repository.createDefinition(input), 'bad-input');
+  });
+
+  it('rejects the reserved Event identity at create, save, and duplicate boundaries', () => {
+    const source = create('event-source');
+
+    expectRepositoryError(() => repository.createDefinition({ id: 'events', title: 'Reserved' }), 'bad-input');
+    expectRepositoryError(() => repository.saveDefinition({ ...source, id: 'events' }, source.revision), 'bad-input');
+    expectRepositoryError(() => repository.duplicateDefinition(source.id, { id: 'events', title: 'Reserved' }), 'bad-input');
+    expect(db.prepare("SELECT COUNT(*) FROM workflow_definitions WHERE id = 'events'").pluck().get()).toBe(0);
+    expect(repository.getDefinition(source.id)).toEqual(source);
+  });
+
+  it('normalizes exact safe envelopes without mutation and rejects hostile envelopes', () => {
+    const input = Object.assign(Object.create(null), { id: 'null-prototype', title: 'Null prototype' }) as CreateWorkflowInput;
+    repository.createDefinition(input);
+    expect(input).toEqual({ id: 'null-prototype', title: 'Null prototype' });
+    expect(Object.getPrototypeOf(input)).toBeNull();
+
+    const adversarial = adversarialEnvelopes('invalid-create');
+    expect(adversarial.values.map((value) => repositoryOutcome(
+      () => repository.createDefinition(value as CreateWorkflowInput),
+    ))).toEqual(adversarial.values.map(() => 'bad-input'));
+    expect(adversarial.calls()).toBe(0);
+  });
+});
+
+describe('canonical definition persistence', () => {
+  it('roundtrips the exact canonical graph JSON', () => {
+    const created = create('review-flow', 'Review flow');
+    now = '2026-07-21T01:00:00.000Z';
+    const changed: WorkflowDefinition = {
+      ...created,
+      description: 'Review a prepared artifact.',
+      inputs: [{ key: 'topic', label: 'Topic', type: 'string', required: true, default: 'release' }],
+      nodes: [
+        { id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } },
+        {
+          id: 'review', type: 'employee', name: 'Review',
+          config: {
+            employee: { source: 'input', path: 'reviewer' },
+            prompt: 'Review {{ input.topic }}.',
+            output: { fields: { approved: { type: 'boolean', required: true } }, allowAdditionalFields: false },
+          },
+        },
+      ],
+      edges: [{ id: 'start-review', from: { nodeId: 'start', port: 'success' }, to: { nodeId: 'review', port: 'input' } }],
+      ui: { positions: { start: { x: 0, y: 0 }, review: { x: 180, y: 0 } } },
+    };
+
+    const saved = repository.saveDefinition(changed, 1);
+    expect(saved).toEqual({ ...changed, revision: 2, updatedAt: now });
+    expect(repository.getDefinition(created.id)).toEqual(saved);
+
+    const json = db.prepare('SELECT definition_json FROM workflow_definitions WHERE id = ?')
+      .pluck().get(created.id) as string;
+    expect(JSON.parse(json)).toEqual(saved);
+  });
+
+  it('rejects invalid canonical definitions without changing the row', () => {
+    const created = create('valid-workflow');
+    const invalid = { ...created, title: '' } as WorkflowDefinition;
+    expectRepositoryError(() => repository.saveDefinition(invalid, 1), 'bad-input');
+    expect(repository.getDefinition(created.id)).toEqual(created);
+  });
+
+  it('reports which field failed the schema instead of a bare "definition is invalid"', () => {
+    const created = create('schema-detail');
+    const invalid = { ...created, nodes: [{ id: 'start', type: 'trigger', name: '', config: { kind: 'manual' } }] } as WorkflowDefinition;
+
+    let thrown: unknown;
+    try { repository.saveDefinition(invalid, 1); } catch (error) { thrown = error; }
+
+    expect(thrown).toBeInstanceOf(WorkflowRepositoryError);
+    expect((thrown as WorkflowRepositoryError).issues).toEqual([
+      expect.objectContaining({ code: 'schema', path: 'nodes.0.name' }),
+    ]);
+  });
+
+  it('fails every definition read that encounters corrupt JSON', () => {
+    create('corrupt-get');
+    db.prepare("UPDATE workflow_definitions SET definition_json = '{' WHERE id = 'corrupt-get'").run();
+    expectRepositoryError(() => repository.getDefinition('corrupt-get'), 'corrupt-record');
+
+    create('corrupt-list');
+    expectRepositoryError(() => repository.listDefinitions({}), 'corrupt-record');
+    expectRepositoryError(
+      () => repository.duplicateDefinition('corrupt-get', { id: 'copy', title: 'Copy' }),
+      'corrupt-record',
+    );
+  });
+});
+
+describe('optimistic revision mutations', () => {
+  it('increments exactly once for save and rejects stale expected revisions', () => {
+    const created = create('revisioned', 'Revision one');
+    now = '2026-07-21T01:00:00.000Z';
+    const saved = repository.saveDefinition({ ...created, title: 'Revision two' }, 1);
+    expect(saved).toMatchObject({ revision: 2, title: 'Revision two', updatedAt: now });
+    expectRepositoryError(
+      () => repository.saveDefinition({ ...saved, title: 'Stale write' }, 1),
+      'revision-conflict',
+    );
+    expect(repository.getDefinition(created.id)).toEqual(saved);
+  });
+
+  it('persists a canvas-only move without spending a revision, and still versions the next graph edit', () => {
+    const created = create('dragged', 'Dragged');
+    const graph = repository.saveDefinition({
+      ...created,
+      nodes: [{ id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } }],
+      ui: { positions: { start: { x: 0, y: 0 } } },
+    } as WorkflowDefinition, 1);
+    expect(graph.revision).toBe(2);
+
+    now = '2026-07-21T02:00:00.000Z';
+    const dragged = repository.saveDefinition({ ...graph, ui: { positions: { start: { x: 320, y: 96 } }, layout: 'manual' } }, 2);
+    expect(dragged).toMatchObject({ revision: 2, updatedAt: now, ui: { positions: { start: { x: 320, y: 96 } }, layout: 'manual' } });
+    expect(repository.getDefinition(created.id)).toEqual(dragged);
+
+    const renamed = repository.saveDefinition({ ...dragged, title: 'Renamed' }, 2);
+    expect(renamed).toMatchObject({ revision: 3, title: 'Renamed' });
+  });
+
+  it('rejects invalid repository clocks before every write and roundtrips emitted cursors', () => {
+    const saved = create('clock-save');
+    const enabled = create('clock-enable');
+    const retired = create('clock-retire');
+    const duplicated = create('clock-duplicate');
+    const cases: Array<[unknown, () => unknown]> = [
+      ['2026-07-21T00:00:00Z', () => create('clock-create')],
+      ['not-an-instant', () => repository.saveDefinition({ ...saved, title: 'Changed' }, saved.revision)],
+      [1, () => repository.setEnabled(enabled.id, true, enabled.revision)],
+      ['2026-07-21T00:00:00Z', () => repository.setRetired(
+        retired.id, true, retired.revision, '2026-07-21T00:30:00.000Z',
+      )],
+      ['not-an-instant', () => repository.duplicateDefinition(duplicated.id, { id: 'clock-copy', title: 'Copy' })],
+    ];
+    const results = cases.map(([stamp, action]) => {
+      const before = storedDefinitions();
+      now = stamp as string;
+      return { outcome: repositoryOutcome(action), unchanged: storedDefinitions() === before };
+    });
+    expect(results).toEqual(cases.map(() => ({ outcome: 'bad-input', unchanged: true })));
+
+    now = '2026-07-21T01:00:00.000Z';
+    create('clock-cursor-a');
+    create('clock-cursor-b');
+    const first = repository.listDefinitions({ limit: 1 });
+    expect(repository.listDefinitions({ limit: 1, cursor: first.nextCursor! }).items).toHaveLength(1);
+  });
+
+  it('increments exactly once per enable transition', () => {
+    const created = create('enable-flow');
+    now = '2026-07-21T02:00:00.000Z';
+    const enabled = repository.setEnabled(created.id, true, 1);
+    expect(enabled).toMatchObject({ enabled: true, revision: 2, updatedAt: now });
+    now = '2026-07-21T03:00:00.000Z';
+    const disabled = repository.setEnabled(created.id, false, 2);
+    expect(disabled).toMatchObject({ enabled: false, revision: 3, updatedAt: now });
+    expectRepositoryError(() => repository.setEnabled(created.id, true, 2), 'revision-conflict');
+  });
+
+  it('retires once, disables the definition, and rejects later mutations', () => {
+    const created = create('retire-flow');
+    const enabled = repository.setEnabled(created.id, true, 1);
+    now = '2026-07-21T04:00:00.000Z';
+    const retiredAt = '2026-07-21T03:30:00.000Z';
+    const retired = repository.setRetired(created.id, true, enabled.revision, retiredAt);
+
+    expect(retired).toMatchObject({ enabled: false, retiredAt, revision: 3, updatedAt: now });
+    expect(db.prepare('SELECT retired_at FROM workflow_definitions WHERE id = ?').pluck().get(created.id)).toBe(retiredAt);
+    expectRepositoryError(() => repository.setEnabled(created.id, true, retired.revision), 'retired');
+    expectRepositoryError(() => repository.saveDefinition({ ...retired, title: 'Changed' }, retired.revision), 'retired');
+    expectRepositoryError(() => repository.setRetired(created.id, true, retired.revision, retiredAt), 'retired');
+  });
+
+  it('distinguishes missing rows from revision conflicts', () => {
+    expectRepositoryError(() => repository.setEnabled('missing', true, 1), 'not-found');
+    expectRepositoryError(() => repository.setRetired('missing', true, 1, now), 'not-found');
+    const absent: WorkflowDefinition = {
+      schemaVersion: 1, id: 'missing', title: 'Missing', revision: 1, enabled: false,
+      nodes: [], edges: [], createdAt: now, updatedAt: now,
+    };
+    expectRepositoryError(() => repository.saveDefinition(absent, 1), 'not-found');
+  });
+});
+
+describe('duplicateDefinition', () => {
+  it('copies authored content while resetting identity, lifecycle, revision, and timestamps', () => {
+    const source = create('source-flow', 'Source');
+    const saved = repository.saveDefinition({ ...source, description: 'Source description' }, 1);
+    repository.setEnabled(source.id, true, saved.revision);
+    now = '2026-07-21T05:00:00.000Z';
+    const callsBeforeDuplicate = clockCalls;
+
+    const copy = repository.duplicateDefinition(source.id, { id: 'copied-flow', title: 'Copied flow' });
+    expect(copy).toEqual({
+      ...saved,
+      id: 'copied-flow',
+      title: 'Copied flow',
+      revision: 1,
+      enabled: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(copy).not.toHaveProperty('retiredAt');
+    expect(clockCalls - callsBeforeDuplicate).toBe(1);
+    expect(repository.getDefinition(source.id)).toMatchObject({ enabled: true, revision: 3 });
+  });
+
+  it('validates duplicate targets before source lookup without leaking source existence', () => {
+    const invalidTargets = [
+      { id: 'Invalid', title: 'Copy' },
+      { id: 'copy', title: '' },
+      { id: 'copy', title: 'x'.repeat(121) },
+    ];
+    expect(invalidTargets.map((input) => repositoryOutcome(
+      () => repository.duplicateDefinition('missing', input),
+    ))).toEqual(invalidTargets.map(() => 'bad-input'));
+    expectRepositoryError(
+      () => repository.duplicateDefinition('missing', { id: 'copy', title: 'Copy' }),
+      'not-found',
+    );
+    create('existing');
+    expect(invalidTargets.map((input) => repositoryOutcome(
+      () => repository.duplicateDefinition('existing', input),
+    ))).toEqual(invalidTargets.map(() => 'bad-input'));
+    expectRepositoryError(
+      () => repository.duplicateDefinition('existing', { id: 'existing', title: 'Copy' }),
+      'id-conflict',
+    );
+  });
+
+  it('normalizes exact duplicate envelopes and rejects every hostile envelope', () => {
+    create('duplicate-source');
+    const input = Object.assign(Object.create(null), { id: 'null-prototype-copy', title: 'Copy' });
+    repository.duplicateDefinition('duplicate-source', input);
+    expect(input).toEqual({ id: 'null-prototype-copy', title: 'Copy' });
+    expect(Object.getPrototypeOf(input)).toBeNull();
+
+    const adversarial = adversarialEnvelopes('invalid-copy');
+    const values = [...adversarial.values, { id: 'description-copy', title: 'Copy', description: 'extra' }];
+    expect(values.map((value) => repositoryOutcome(
+      () => repository.duplicateDefinition('duplicate-source', value as { id: string; title: string }),
+    ))).toEqual(values.map(() => 'bad-input'));
+    expect(adversarial.calls()).toBe(0);
+  });
+});
+
+describe('listDefinitions pagination and filters', () => {
+  it('defaults to 50, accepts 100, and rejects all invalid limits', () => {
+    for (let index = 0; index < 105; index += 1) {
+      now = new Date(Date.UTC(2026, 6, 21, 6, index)).toISOString();
+      create(`workflow-${String(index).padStart(3, '0')}`);
+    }
+    expect(repository.listDefinitions({}).items).toHaveLength(50);
+    expect(repository.listDefinitions({ limit: 100 }).items).toHaveLength(100);
+    for (const limit of [0, -1, 1.5, 101, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expectRepositoryError(() => repository.listDefinitions({ limit }), 'bad-input');
+    }
+  });
+
+  it('uses stable updatedAt DESC and id DESC keyset pagination', () => {
+    now = '2026-07-21T07:00:00.000Z';
+    const first = create('alpha');
+    const beta = create('beta');
+    now = '2026-07-21T08:00:00.000Z';
+    const gamma = create('gamma');
+
+    const pageOne = repository.listDefinitions({ limit: 2 });
+    expect(pageOne.items).toEqual([summary(gamma), summary(beta)]);
+    expect(pageOne.nextCursor).not.toBeNull();
+    now = '2026-07-21T09:00:00.000Z';
+    create('newer-after-cursor');
+    const pageTwo = repository.listDefinitions({ limit: 2, cursor: pageOne.nextCursor! });
+    expect(pageTwo).toEqual({ items: [summary(first)], nextCursor: null });
+  });
+
+  it('filters enabled state and retired state with locked omitted behavior', () => {
+    create('disabled');
+    const active = create('active');
+    const retiredSource = create('retired-source');
+    const retiredEnabledSource = create('retired-enabled-source');
+    repository.setEnabled(active.id, true, active.revision);
+    repository.setRetired(retiredSource.id, true, retiredSource.revision, '2026-07-21T10:00:00.000Z');
+    const enabled = repository.setEnabled(retiredEnabledSource.id, true, retiredEnabledSource.revision);
+    repository.setRetired(enabled.id, true, enabled.revision, '2026-07-21T10:00:00.000Z');
+
+    expect(repository.listDefinitions({}).items.map((item) => item.id).sort()).toEqual(['active', 'disabled']);
+    expect(repository.listDefinitions({ retired: false }).items.map((item) => item.id).sort()).toEqual(['active', 'disabled']);
+    expect(repository.listDefinitions({ enabled: true }).items.map((item) => item.id)).toEqual(['active']);
+    expect(repository.listDefinitions({ enabled: false }).items.map((item) => item.id)).toEqual(['disabled']);
+    expect(repository.listDefinitions({ retired: true }).items.map((item) => item.id).sort())
+      .toEqual(['retired-enabled-source', 'retired-source']);
+    expect(repository.listDefinitions({ retired: true, enabled: true }).items).toEqual([]);
+  });
+});
+
+describe('listDefinitions validation', () => {
+  it('normalizes exact null-prototype queries without mutation', () => {
+    create('alpha');
+    create('beta');
+    const cursor = repository.listDefinitions({ limit: 1 }).nextCursor!;
+    const query = Object.assign(Object.create(null), { cursor, limit: 1, enabled: false, retired: false });
+    expect(repository.listDefinitions(query).items.map((item) => item.id)).toEqual(['alpha']);
+    expect({ ...query }).toEqual({ cursor, limit: 1, enabled: false, retired: false });
+    expect(Object.getPrototypeOf(query)).toBeNull();
+    expect(repository.listDefinitions({}).items).toHaveLength(2);
+  });
+
+  it('rejects hostile query envelopes without traps or prepared statements', () => {
+    const adversarial = adversarialQueries();
+    const prepare = vi.spyOn(db, 'prepare');
+    expect(adversarial.values.map((query) => repositoryOutcome(
+      () => repository.listDefinitions(query as DefinitionListQuery),
+    ))).toEqual(adversarial.values.map(() => 'bad-input'));
+    expect(adversarial.calls()).toBe(0);
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed, wrong-endpoint, and unknown-version cursors', () => {
+    create('alpha');
+    create('beta');
+    for (const cursor of [null, 1, true, {}, []]) {
+      expectRepositoryError(() => repository.listDefinitions({ cursor } as unknown as DefinitionListQuery), 'bad-cursor');
+    }
+    const valid = repository.listDefinitions({ limit: 1 }).nextCursor!;
+    const decoded = decodeCursor(valid);
+    for (const cursor of [
+      '', 'not-base64!', `${valid}!`, encodeCursor(null), encodeCursor({}),
+      encodeCursor({ ...decoded, endpoint: 'workflow-runs' }),
+      encodeCursor({ ...decoded, version: 2 }),
+      encodeCursor({ ...decoded, updatedAt: 1 }),
+      encodeCursor({ ...decoded, id: null }),
+    ]) {
+      expectRepositoryError(() => repository.listDefinitions({ cursor }), 'bad-cursor');
+    }
+  });
+
+  it('rejects noncanonical cursor JSON and invalid tuple values', () => {
+    create('alpha');
+    create('beta');
+    const valid = repository.listDefinitions({ limit: 1 }).nextCursor!;
+    const decoded = decodeCursor(valid);
+    const canonicalJson = Buffer.from(valid, 'base64url').toString('utf8');
+    const idJson = JSON.stringify(decoded.id);
+    const invalid = [
+      encodeCursorJson(JSON.stringify({ id: decoded.id, updatedAt: decoded.updatedAt, endpoint: decoded.endpoint, version: decoded.version })),
+      encodeCursorJson(`${canonicalJson} `),
+      encodeCursorJson(canonicalJson.replace(`"id":${idJson}`, `"id":${idJson},"id":${idJson}`)),
+      encodeCursor({ ...decoded, extra: true }), `${valid}=`,
+      ...['', 'not-an-instant', '2026-07-21T00:00:00Z', '2026-07-21T00:00:00.000+00:00',
+        '2026-02-30T00:00:00.000Z'].map((updatedAt) => encodeCursor({ ...decoded, updatedAt })),
+      ...['', 'Invalid ID', 'Invalid', '1workflow', 'under_score', `a${'b'.repeat(64)}`]
+        .map((id) => encodeCursor({ ...decoded, id })),
+    ];
+    expect(invalid.map((cursor) => repositoryOutcome(
+      () => repository.listDefinitions({ cursor }),
+    ))).toEqual(invalid.map(() => 'bad-cursor'));
+  });
+
+  it('rejects non-boolean filters as bad input', () => {
+    expectRepositoryError(
+      () => repository.listDefinitions({ enabled: 'true' } as unknown as DefinitionListQuery),
+      'bad-input',
+    );
+    expectRepositoryError(
+      () => repository.listDefinitions({ retired: 1 } as unknown as DefinitionListQuery),
+      'bad-input',
+    );
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/repository-migrations.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/repository-migrations.test.ts
@@ -1,0 +1,691 @@
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
+import { createHash } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+type MigrationModule = typeof import('../repository-migrations.js');
+type PathsModule = typeof import('../../shared/paths.js');
+
+interface TableColumn {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+interface ForeignKey {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
+interface IndexColumn {
+  name: string | null;
+  desc: number;
+  key: number;
+}
+
+let suiteRoot: string;
+let previousJinnHome: string | undefined;
+let migrations: MigrationModule;
+let paths: PathsModule;
+
+beforeAll(async () => {
+  suiteRoot = mkdtempSync(join(tmpdir(), 'jinn-workflow-database-'));
+  previousJinnHome = process.env.JINN_HOME;
+  process.env.JINN_HOME = suiteRoot;
+  paths = await import('../../shared/paths.js');
+  migrations = await import('../repository-migrations.js');
+});
+
+afterAll(() => {
+  if (previousJinnHome === undefined) delete process.env.JINN_HOME;
+  else process.env.JINN_HOME = previousJinnHome;
+  rmSync(suiteRoot, { recursive: true, force: true });
+});
+
+function databasePath(name: string): string {
+  return join(suiteRoot, name, 'workflows.db');
+}
+
+function withWorkflowDatabase<T>(file: string | undefined, run: (db: Database.Database) => T): T {
+  const db = migrations.openWorkflowDatabase(file);
+  try {
+    return run(db);
+  } finally {
+    db.close();
+  }
+}
+
+function withRawDatabase<T>(file: string, run: (db: Database.Database) => T): T {
+  mkdirSync(dirname(file), { recursive: true });
+  const db = new Database(file);
+  try {
+    return run(db);
+  } finally {
+    db.close();
+  }
+}
+
+function tableNames(db: Database.Database): string[] {
+  return db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+    .pluck().all() as string[];
+}
+
+function domainTableNames(db: Database.Database): string[] {
+  return tableNames(db).filter((name) => name !== 'workflow_schema' && name !== 'marker');
+}
+
+function tableInfo(db: Database.Database, table: string): TableColumn[] {
+  return db.pragma(`table_info(${table})`) as TableColumn[];
+}
+
+function column(name: string, type: string, notnull: number, dflt: string | null, pk: number): Omit<TableColumn, 'cid'> {
+  return { name, type, notnull, dflt_value: dflt, pk };
+}
+
+function expectedColumns(columns: Array<Omit<TableColumn, 'cid'>>): TableColumn[] {
+  return columns.map((entry, cid) => ({ cid, ...entry }));
+}
+
+function foreignKeys(db: Database.Database, table: string): Array<Omit<ForeignKey, 'id'>> {
+  return (db.pragma(`foreign_key_list(${table})`) as ForeignKey[])
+    .map(({ id: _id, ...entry }) => entry);
+}
+
+function namedIndexes(db: Database.Database): string[] {
+  return db.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+    .pluck().all() as string[];
+}
+
+function indexColumns(db: Database.Database, index: string): Array<{ name: string; desc: number }> {
+  return (db.pragma(`index_xinfo(${index})`) as IndexColumn[])
+    .filter((entry) => entry.key === 1)
+    .map((entry) => ({ name: entry.name!, desc: entry.desc }));
+}
+
+function schemaSql(db: Database.Database): string[] {
+  return db.prepare("SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type, name").pluck().all() as string[];
+}
+
+function databaseSnapshot(file: string): string {
+  return withRawDatabase(file, (db) => JSON.stringify({
+    schema: db.prepare("SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY type, name").all(),
+    versions: tableNames(db).some((name) => name.toLowerCase() === 'workflow_schema') ? db.prepare('SELECT * FROM workflow_schema').all() : [],
+    definitions: tableNames(db).some((name) => name.toLowerCase() === 'workflow_definitions')
+      ? db.prepare('SELECT * FROM workflow_definitions ORDER BY id').all() : [],
+  }));
+}
+
+function rejectedDatabaseSnapshot(file: string): object {
+  const bytes = readFileSync(file);
+  const db = new Database(file, { readonly: true, fileMustExist: true });
+  let inspected: object;
+  try {
+    const names = tableNames(db);
+    inspected = {
+      schema: db.prepare(
+        'SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY type, name',
+      ).all(),
+      versions: names.includes('workflow_schema') ? db.prepare('SELECT * FROM workflow_schema').all() : [],
+      data: names.includes('marker') ? db.prepare('SELECT * FROM marker ORDER BY rowid').all()
+        : names.includes('workflow_definitions') ? db.prepare('SELECT * FROM workflow_definitions ORDER BY id').all() : [],
+      journalMode: db.pragma('journal_mode', { simple: true }),
+    };
+  } finally {
+    db.close();
+  }
+  return {
+    bytes,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    ...inspected,
+    sidecars: ['-journal', '-wal', '-shm'].map((suffix) => existsSync(`${file}${suffix}`)),
+  };
+}
+
+function expectRejectedWithoutMutation(file: string, error: string): void {
+  const before = rejectedDatabaseSnapshot(file);
+  expect(before).toMatchObject({ journalMode: 'delete', sidecars: [false, false, false] });
+  expect(() => migrations.openWorkflowDatabase(file)).toThrowError(error);
+  expect(rejectedDatabaseSnapshot(file)).toEqual(before);
+  const moved = `${file}.closed`;
+  renameSync(file, moved);
+  renameSync(moved, file);
+}
+
+function expectMalformedWithoutMutation(file: string): void {
+  const before = databaseSnapshot(file);
+  expect(() => migrations.openWorkflowDatabase(file)).toThrowError('Malformed workflow database schema version.');
+  expect(databaseSnapshot(file)).toBe(before);
+}
+
+function currentDatabase(name: string): string {
+  const file = databasePath(name);
+  withWorkflowDatabase(file, (db) => insertDefinition(db, 'sentinel'));
+  return file;
+}
+
+function versionTwoDatabase(name: string): string {
+  const file = currentDatabase(name);
+  withRawDatabase(file, (db) => {
+    const columns = tableInfo(db, 'workflow_attempts').map((entry) => entry.name);
+    if (columns.includes('reminders_sent')) {
+      db.exec(`
+        DROP INDEX workflow_attempts_due_reminder;
+        ALTER TABLE workflow_attempts DROP COLUMN reminders_sent;
+        ALTER TABLE workflow_attempts DROP COLUMN next_reminder_at;
+        ALTER TABLE workflow_attempts DROP COLUMN extensions;
+        ALTER TABLE workflow_attempts DROP COLUMN last_extension_reason;
+        ALTER TABLE workflow_attempts DROP COLUMN pending_output_error;
+        ALTER TABLE workflow_attempts DROP COLUMN last_processed_turn;
+        ALTER TABLE workflow_attempts DROP COLUMN prompt_text;
+        ALTER TABLE workflow_attempts DROP COLUMN stop_nudges_sent;
+        UPDATE workflow_schema SET version = 2;
+      `);
+    }
+  });
+  return file;
+}
+
+function versionOneDatabase(name: string): string {
+  const file = versionTwoDatabase(name);
+  withRawDatabase(file, (db) => db.exec(`
+    DROP INDEX workflow_attempts_retry_key;
+    ALTER TABLE workflow_attempts DROP COLUMN retry_idempotency_key;
+    UPDATE workflow_schema SET version = 1;
+  `));
+  return file;
+}
+
+function uppercaseCurrentDatabase(name: string): string {
+  const source = currentDatabase(`${name}-source`);
+  const ddl = withRawDatabase(source, (db) => (db.prepare(
+    "SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY type = 'table' DESC, name",
+  ).pluck().all() as string[]).join(';\n'));
+  const file = databasePath(name);
+  withRawDatabase(file, (db) => {
+    db.exec(`${ddl.toUpperCase()}; INSERT INTO WORKFLOW_SCHEMA VALUES (${migrations.WORKFLOW_DB_SCHEMA_VERSION})`);
+    insertDefinition(db, 'sentinel');
+  });
+  return file;
+}
+
+function insertDefinition(db: Database.Database, id = 'workflow'): void {
+  db.prepare(`INSERT INTO workflow_definitions
+    (id, title, revision, definition_json, created_at, updated_at)
+    VALUES (?, 'Fixture', 1, '{}', '2026-07-20T00:00:00.000Z', '2026-07-20T00:00:00.000Z')`).run(id);
+}
+
+function insertRun(db: Database.Database, id: string, workflowId = 'workflow', key: string | null = null): void {
+  db.prepare(`INSERT INTO workflow_runs
+    (id, workflow_id, workflow_title, definition_revision, definition_json, input_json,
+     trigger_json, status, revision, idempotency_key, started_at)
+    VALUES (?, ?, 'Fixture', 1, '{}', '{}', '{}', 'running', 1, ?, '2026-07-20T00:00:00.000Z')`)
+    .run(id, workflowId, key);
+}
+
+function insertNode(db: Database.Database, runId: string, nodeId = 'node'): void {
+  db.prepare(`INSERT INTO workflow_node_runs (run_id, node_id, node_type, status)
+    VALUES (?, ?, 'employee', 'running')`).run(runId, nodeId);
+}
+
+const tables = [
+  'workflow_approvals',
+  'workflow_attempts',
+  'workflow_definitions',
+  'workflow_node_runs',
+  'workflow_runs',
+  'workflow_schema',
+];
+
+const indexes = [
+  'workflow_approvals_pending',
+  'workflow_attempts_by_session',
+  'workflow_attempts_due_reminder',
+  'workflow_attempts_retry_key',
+  'workflow_node_runs_due',
+  'workflow_runs_by_status_started',
+  'workflow_runs_by_workflow_started',
+];
+
+const alteredApprovalTable = `
+DROP TABLE workflow_approvals;
+CREATE TABLE workflow_approvals (
+  run_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  requested_at TEXT NOT NULL,
+  approver_ref TEXT,
+  decided_at TEXT,
+  decided_by TEXT,
+  decision TEXT,
+  reason INTEGER,
+  PRIMARY KEY(run_id, node_id),
+  FOREIGN KEY(run_id, node_id) REFERENCES workflow_node_runs(run_id, node_id) ON DELETE RESTRICT
+);`;
+
+const v1SchemaMutations = [
+  ['one missing table', 'DROP TABLE workflow_approvals'],
+  ['one missing named index', 'DROP INDEX workflow_approvals_pending'],
+  ['altered column, default, and foreign key', alteredApprovalTable],
+  ['altered index columns and direction', `DROP INDEX workflow_runs_by_status_started;
+    CREATE INDEX workflow_runs_by_status_started ON workflow_runs(status DESC, ended_at, id ASC)`],
+  ['an extra workflow table', 'CREATE TABLE workflow_extra (value TEXT)'],
+  ['an extra workflow index', 'CREATE INDEX workflow_extra_index ON workflow_definitions(title)'],
+  ['an extra workflow trigger', `CREATE TRIGGER workflow_extra_trigger AFTER UPDATE ON workflow_definitions
+    BEGIN SELECT 1; END`],
+  ['an extra workflow view', 'CREATE VIEW workflow_extra_view AS SELECT id FROM workflow_definitions'],
+] as const;
+
+describe('workflow database paths and connection', () => {
+  it('resolves constants from the isolated JINN_HOME and opens the default path', () => {
+    expect(paths.WORKFLOWS_DIR).toBe(join(suiteRoot, 'workflows'));
+    expect(paths.WORKFLOWS_DB_PATH).toBe(join(suiteRoot, 'workflows', 'workflows.db'));
+    withWorkflowDatabase(undefined, (db) => expect(db.open).toBe(true));
+    expect(existsSync(paths.WORKFLOWS_DB_PATH)).toBe(true);
+  });
+
+  it('leaves an injected caller-owned parent and database modes unchanged', () => {
+    const ownerParent = join(suiteRoot, 'caller-owned');
+    const target = join(ownerParent, 'workflows.db');
+    mkdirSync(ownerParent, { mode: 0o755 });
+    withRawDatabase(target, () => undefined);
+    if (process.platform !== 'win32') {
+      chmodSync(ownerParent, 0o755);
+      chmodSync(target, 0o640);
+    }
+    withWorkflowDatabase(target, (db) => expect(db.open).toBe(true));
+    if (process.platform !== 'win32') {
+      expectPosixMode(statSync(ownerParent), 0o755);
+      expectPosixMode(statSync(target), 0o640);
+    }
+  });
+
+  it('sets pragmas on the first connection and an independent reopen', () => {
+    const file = databasePath('pragmas');
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      withWorkflowDatabase(file, (db) => {
+        expect(db.pragma('busy_timeout', { simple: true })).toBe(5000);
+        expect(db.pragma('journal_mode', { simple: true })).toBe('wal');
+        expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+      });
+    }
+  });
+
+  it('supports repeated close/open and a Unicode absolute path without residue', () => {
+    const file = databasePath('special space — 流程');
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      withWorkflowDatabase(file, (db) => expect(db.open).toBe(true));
+      expect(existsSync(`${file}-wal`)).toBe(false);
+      expect(existsSync(`${file}-shm`)).toBe(false);
+    }
+    const moved = `${file}.moved`;
+    renameSync(file, moved);
+    renameSync(moved, file);
+  });
+});
+
+describe('fresh version 3 schema', () => {
+  it('creates the exact table set and definition/run column shapes', () => {
+    withWorkflowDatabase(databasePath('columns'), (db) => {
+      expect(tableNames(db)).toEqual(tables);
+      expect(tableInfo(db, 'workflow_schema')).toEqual(expectedColumns([
+        column('version', 'INTEGER', 1, null, 0),
+      ]));
+      expect(tableInfo(db, 'workflow_definitions')).toEqual(expectedColumns([
+        column('id', 'TEXT', 0, null, 1), column('title', 'TEXT', 1, null, 0),
+        column('revision', 'INTEGER', 1, null, 0), column('enabled', 'INTEGER', 1, '0', 0),
+        column('retired_at', 'TEXT', 0, null, 0), column('definition_json', 'TEXT', 1, null, 0),
+        column('created_at', 'TEXT', 1, null, 0), column('updated_at', 'TEXT', 1, null, 0),
+      ]));
+      expect(tableInfo(db, 'workflow_runs')).toEqual(expectedColumns([
+        column('id', 'TEXT', 0, null, 1), column('workflow_id', 'TEXT', 1, null, 0),
+        column('workflow_title', 'TEXT', 1, null, 0), column('definition_revision', 'INTEGER', 1, null, 0),
+        column('definition_json', 'TEXT', 1, null, 0), column('input_json', 'TEXT', 1, null, 0),
+        column('trigger_json', 'TEXT', 1, null, 0), column('status', 'TEXT', 1, null, 0),
+        column('revision', 'INTEGER', 1, null, 0), column('idempotency_key', 'TEXT', 0, null, 0),
+        column('invocation_session_id', 'TEXT', 0, null, 0), column('cancel_requested_at', 'TEXT', 0, null, 0),
+        column('started_at', 'TEXT', 1, null, 0), column('ended_at', 'TEXT', 0, null, 0),
+        column('error_json', 'TEXT', 0, null, 0),
+      ]));
+    });
+  });
+
+  it('creates the locked node-run column shape', () => {
+    withWorkflowDatabase(databasePath('node-run-columns'), (db) => {
+      expect(tableInfo(db, 'workflow_node_runs')).toEqual(expectedColumns([
+        column('run_id', 'TEXT', 1, null, 1), column('node_id', 'TEXT', 1, null, 2),
+        column('node_type', 'TEXT', 1, null, 0), column('status', 'TEXT', 1, null, 0),
+        column('activated', 'INTEGER', 1, '0', 0), column('resolved_config_json', 'TEXT', 0, null, 0),
+        column('input_json', 'TEXT', 0, null, 0), column('output_json', 'TEXT', 0, null, 0),
+        column('error_json', 'TEXT', 0, null, 0), column('resume_at', 'TEXT', 0, null, 0),
+        column('started_at', 'TEXT', 0, null, 0), column('ended_at', 'TEXT', 0, null, 0),
+      ]));
+    });
+  });
+
+  it('creates the locked attempt and approval column shapes', () => {
+    withWorkflowDatabase(databasePath('attempt-approval-columns'), (db) => {
+      expect(tableInfo(db, 'workflow_attempts')).toEqual(expectedColumns([
+        column('run_id', 'TEXT', 1, null, 1), column('node_id', 'TEXT', 1, null, 2),
+        column('attempt', 'INTEGER', 1, null, 3), column('session_id', 'TEXT', 0, null, 0),
+        column('status', 'TEXT', 1, null, 0), column('resolved_config_json', 'TEXT', 1, null, 0),
+        column('input_json', 'TEXT', 1, null, 0), column('output_json', 'TEXT', 0, null, 0),
+        column('error_json', 'TEXT', 0, null, 0), column('started_at', 'TEXT', 1, null, 0),
+        column('ended_at', 'TEXT', 0, null, 0), column('retry_idempotency_key', 'TEXT', 0, null, 0),
+        column('reminders_sent', 'INTEGER', 1, '0', 0), column('next_reminder_at', 'TEXT', 0, null, 0),
+        column('extensions', 'INTEGER', 1, '0', 0), column('last_extension_reason', 'TEXT', 0, null, 0),
+        column('pending_output_error', 'TEXT', 0, null, 0),
+        column('last_processed_turn', 'INTEGER', 1, '0', 0), column('prompt_text', 'TEXT', 0, null, 0), column('stop_nudges_sent', 'INTEGER', 1, '0', 0),
+      ]));
+      expect(tableInfo(db, 'workflow_approvals')).toEqual(expectedColumns([
+        column('run_id', 'TEXT', 1, null, 1), column('node_id', 'TEXT', 1, null, 2),
+        column('status', 'TEXT', 1, null, 0), column('requested_at', 'TEXT', 1, null, 0),
+        column('approver_ref', 'TEXT', 0, null, 0), column('decided_at', 'TEXT', 0, null, 0),
+        column('decided_by', 'TEXT', 0, null, 0), column('decision', 'TEXT', 0, null, 0),
+        column('reason', 'TEXT', 0, null, 0),
+      ]));
+    });
+  });
+});
+
+describe('fresh version 3 schema metadata', () => {
+  it('creates exactly the seven named indexes with locked columns and directions', () => {
+    withWorkflowDatabase(databasePath('indexes'), (db) => {
+      expect(namedIndexes(db)).toEqual(indexes);
+      expect(indexColumns(db, 'workflow_runs_by_workflow_started')).toEqual([
+        { name: 'workflow_id', desc: 0 }, { name: 'started_at', desc: 1 }, { name: 'id', desc: 1 },
+      ]);
+      expect(indexColumns(db, 'workflow_runs_by_status_started')).toEqual([
+        { name: 'status', desc: 0 }, { name: 'started_at', desc: 1 }, { name: 'id', desc: 1 },
+      ]);
+      expect(indexColumns(db, 'workflow_attempts_by_session')).toEqual([{ name: 'session_id', desc: 0 }]);
+      expect(indexColumns(db, 'workflow_attempts_due_reminder')).toEqual([
+        { name: 'status', desc: 0 }, { name: 'next_reminder_at', desc: 0 },
+      ]);
+      expect(indexColumns(db, 'workflow_attempts_retry_key')).toEqual([
+        { name: 'run_id', desc: 0 }, { name: 'retry_idempotency_key', desc: 0 },
+      ]);
+      expect(indexColumns(db, 'workflow_approvals_pending')).toEqual([
+        { name: 'status', desc: 0 }, { name: 'requested_at', desc: 0 },
+      ]);
+      expect(indexColumns(db, 'workflow_node_runs_due')).toEqual([
+        { name: 'status', desc: 0 }, { name: 'resume_at', desc: 0 },
+      ]);
+    });
+  });
+
+  it('stores exactly one schema version row equal to the exported version', () => {
+    withWorkflowDatabase(databasePath('version'), (db) => {
+      expect(migrations.WORKFLOW_DB_SCHEMA_VERSION).toBe(4);
+      const inventory = migrations as unknown as Record<string, unknown>;
+      const physicalVersions = Array.from(
+        { length: migrations.WORKFLOW_DB_SCHEMA_VERSION }, (_, index) => index + 1,
+      );
+      expect(inventory.WORKFLOW_DB_PHYSICAL_SCHEMA_VERSIONS).toEqual(physicalVersions);
+      expect(inventory.WORKFLOW_DB_MIGRATION_SOURCE_VERSIONS)
+        .toEqual(physicalVersions.map((version) => version - 1));
+      expect(db.prepare('SELECT version FROM workflow_schema').all()).toEqual([{ version: 4 }]);
+    });
+  });
+
+  it('uses the locked foreign-key shapes', () => {
+    withWorkflowDatabase(databasePath('foreign-key-shapes'), (db) => {
+      expect(foreignKeys(db, 'workflow_runs')).toEqual([
+        { seq: 0, table: 'workflow_definitions', from: 'workflow_id', to: 'id', on_update: 'NO ACTION', on_delete: 'NO ACTION', match: 'NONE' },
+      ]);
+      expect(foreignKeys(db, 'workflow_node_runs')).toEqual([
+        { seq: 0, table: 'workflow_runs', from: 'run_id', to: 'id', on_update: 'NO ACTION', on_delete: 'CASCADE', match: 'NONE' },
+      ]);
+      for (const table of ['workflow_attempts', 'workflow_approvals']) {
+        expect(foreignKeys(db, table)).toEqual([
+          { seq: 0, table: 'workflow_node_runs', from: 'run_id', to: 'run_id', on_update: 'NO ACTION', on_delete: 'CASCADE', match: 'NONE' },
+          { seq: 1, table: 'workflow_node_runs', from: 'node_id', to: 'node_id', on_update: 'NO ACTION', on_delete: 'CASCADE', match: 'NONE' },
+        ]);
+      }
+    });
+  });
+});
+
+describe('migration safety and idempotency', () => {
+  it('upgrades an exact v1 database in place while preserving data and adding retry claims', () => {
+    const file = versionOneDatabase('v1-retry-migration');
+    withWorkflowDatabase(file, (db) => {
+      expect(db.prepare('SELECT version FROM workflow_schema').pluck().get()).toBe(4);
+      expect(tableInfo(db, 'workflow_attempts').map((entry) => entry.name)).toContain('retry_idempotency_key');
+      expect(tableInfo(db, 'workflow_attempts').map((entry) => entry.name)).toEqual(expect.arrayContaining(['reminders_sent', 'stop_nudges_sent']));
+      expect(db.prepare("SELECT title FROM workflow_definitions WHERE id = 'sentinel'").pluck().get()).toBe('Fixture');
+    });
+  });
+
+  it('upgrades an exact v2 database in place while preserving attempts and adding reminder state', () => {
+    const file = versionTwoDatabase('v2-reminder-migration');
+    withRawDatabase(file, (db) => {
+      insertRun(db, 'run', 'sentinel');
+      insertNode(db, 'run');
+      db.prepare(`INSERT INTO workflow_attempts
+        (run_id, node_id, attempt, session_id, status, resolved_config_json, input_json, started_at)
+        VALUES ('run', 'node', 1, 'session-1', 'running', '{}', '{}', '2026-07-20T00:00:00.000Z')`).run();
+    });
+    withWorkflowDatabase(file, (db) => {
+      expect(db.prepare('SELECT version FROM workflow_schema').pluck().get()).toBe(4);
+      expect(db.prepare(`SELECT session_id, reminders_sent, next_reminder_at, extensions,
+        last_extension_reason, pending_output_error, last_processed_turn, prompt_text FROM workflow_attempts`).get()).toEqual({
+        session_id: 'session-1',
+        reminders_sent: 0,
+        next_reminder_at: null,
+        extensions: 0,
+        last_extension_reason: null,
+        pending_output_error: null,
+        last_processed_turn: 0,
+        prompt_text: null,
+      });
+    });
+  });
+
+  it('is idempotent on one connection and reopen while preserving data and schema', () => {
+    const file = databasePath('idempotent');
+    let expectedSchema: string[] = [];
+    withWorkflowDatabase(file, (db) => {
+      insertDefinition(db, 'sentinel');
+      expectedSchema = schemaSql(db);
+      migrations.migrateWorkflowDatabase(db);
+      migrations.migrateWorkflowDatabase(db);
+      expect(schemaSql(db)).toEqual(expectedSchema);
+      expect(db.prepare("SELECT title FROM workflow_definitions WHERE id = 'sentinel'").pluck().get()).toBe('Fixture');
+    });
+    withWorkflowDatabase(file, (db) => {
+      expect(schemaSql(db)).toEqual(expectedSchema);
+      expect(db.prepare("SELECT COUNT(*) FROM workflow_definitions WHERE id = 'sentinel'").pluck().get()).toBe(1);
+    });
+  });
+
+  it('rejects a DELETE-journal future v5 without changing bytes, schema, data, mode, or sidecars', () => {
+    const file = databasePath('future');
+    withRawDatabase(file, (db) => {
+      expect(db.pragma('journal_mode = DELETE', { simple: true })).toBe('delete');
+      db.exec('CREATE TABLE workflow_schema (version INTEGER NOT NULL); INSERT INTO workflow_schema VALUES (5); CREATE TABLE marker (value TEXT)');
+      db.prepare("INSERT INTO marker VALUES ('preserve-me')").run();
+    });
+    expectRejectedWithoutMutation(file, 'Unsupported workflow database schema version.');
+  });
+
+  it('rejects a malformed DELETE-journal v3 without changing bytes, schema, data, mode, or sidecars', () => {
+    const file = currentDatabase('malformed-v1-no-mutation');
+    withRawDatabase(file, (db) => {
+      expect(db.pragma('journal_mode = DELETE', { simple: true })).toBe('delete');
+      db.exec('DROP INDEX workflow_approvals_pending');
+    });
+    expectRejectedWithoutMutation(file, 'Malformed workflow database schema version.');
+  });
+
+  it.each([
+    ['empty', []],
+    ['multiple', [1, 1]],
+    ['non-integer', ['version-one']],
+    ['negative', [-1]],
+  ])('rejects a malformed %s version shape non-destructively', (_label, versions) => {
+    const file = databasePath(`malformed-${_label}`);
+    withRawDatabase(file, (db) => {
+      db.exec('CREATE TABLE workflow_schema (version INTEGER NOT NULL); CREATE TABLE marker (value TEXT)');
+      const insert = db.prepare('INSERT INTO workflow_schema VALUES (?)');
+      for (const version of versions) insert.run(version);
+      db.prepare("INSERT INTO marker VALUES ('preserve-me')").run();
+    });
+    expect(() => migrations.openWorkflowDatabase(file)).toThrowError('Malformed workflow database schema version.');
+    withRawDatabase(file, (db) => {
+      expect(db.prepare('SELECT version, typeof(version) AS type FROM workflow_schema').all()).toHaveLength(versions.length);
+      expect(db.prepare('SELECT value FROM marker').pluck().get()).toBe('preserve-me');
+      expect(domainTableNames(db)).toEqual([]);
+    });
+  });
+
+  it('rolls back a supported 0-to-1 migration fault without enabling WAL', () => {
+    const file = databasePath('rollback');
+    mkdirSync(dirname(file), { recursive: true });
+    const originalExec = Database.prototype.exec;
+    const exec = vi.spyOn(Database.prototype, 'exec').mockImplementation(function (this: Database.Database, sql: string) {
+      if (sql.includes('CREATE TABLE workflow_definitions')) throw new Error('injected migration fault');
+      return originalExec.call(this, sql);
+    });
+    try {
+      expect(() => migrations.openWorkflowDatabase(file)).toThrowError('injected migration fault');
+    } finally {
+      exec.mockRestore();
+    }
+    const snapshot = rejectedDatabaseSnapshot(file);
+    expect(snapshot).toMatchObject({ schema: [], journalMode: 'delete', sidecars: [false, false, false] });
+  });
+});
+
+describe('schema structure classification', () => {
+  it('accepts mixed-case version 0 with whitespace and trailing semicolons and migrates it', () => {
+    const file = databasePath('mixed-case-version-zero');
+    withRawDatabase(file, (db) => db.exec(`
+      cReAtE tAbLe WORKFLOW_SCHEMA (version iNtEgEr nOt nUlL) ;
+      iNsErT iNtO WORKFLOW_SCHEMA vAlUeS (0) ;
+    `));
+    withWorkflowDatabase(file, (db) => {
+      expect(tableNames(db).map((name) => name.toLowerCase()).sort()).toEqual(tables);
+      expect(db.prepare('SELECT version FROM workflow_schema').pluck().get()).toBe(4);
+    });
+  });
+
+  it('accepts complete version 3 with uppercase keywords, types, and identifiers', () => {
+    const file = uppercaseCurrentDatabase('uppercase-current');
+    withWorkflowDatabase(file, (db) => {
+      expect(db.prepare("SELECT definition_json FROM workflow_definitions WHERE id = 'sentinel'").pluck().get()).toBe('{}');
+    });
+  });
+
+  it('does not confuse a similarly named table for the schema table', () => {
+    const file = databasePath('schema-name-suffix');
+    withRawDatabase(file, (db) => db.exec('CREATE TABLE workflow_schema_extra (value TEXT)'));
+    expectMalformedWithoutMutation(file);
+  });
+  it.each([
+    ['extra column', 'ALTER TABLE workflow_approvals ADD COLUMN rogue TEXT'],
+    ['changed default and missing ON DELETE', alteredApprovalTable.replace(' ON DELETE RESTRICT', '')],
+    ['changed index direction and column', v1SchemaMutations[3][1]],
+    ['extra object', 'CREATE TABLE workflow_mixed_extra (value TEXT)'],
+  ])('still rejects mixed-case version 1 with %s', (label, mutation) => {
+    const file = uppercaseCurrentDatabase(`mixed-material-${label.replaceAll(' ', '-')}`);
+    withRawDatabase(file, (db) => db.exec(mutation));
+    expectMalformedWithoutMutation(file);
+  });
+
+  it.each([0, 1, 2, 3])('rejects and preserves an extra-column schema table at version %i', (version) => {
+    const file = databasePath(`extra-schema-column-${version}`);
+    withRawDatabase(file, (db) => db.exec(`
+      CREATE TABLE workflow_schema (version INTEGER NOT NULL, rogue TEXT);
+      INSERT INTO workflow_schema VALUES (${version}, 'preserve-me');
+    `));
+    expectMalformedWithoutMutation(file);
+  });
+
+  it('rejects and preserves a forged version 1 with no domain objects', () => {
+    const file = databasePath('forged-empty-v1');
+    withRawDatabase(file, (db) => db.exec(`
+      CREATE TABLE workflow_schema (version INTEGER NOT NULL);
+      INSERT INTO workflow_schema VALUES (1);
+    `));
+    expectMalformedWithoutMutation(file);
+  });
+
+  it.each(v1SchemaMutations)('rejects and preserves version 3 with %s', (label, mutation) => {
+    const file = currentDatabase(`forged-${label.replaceAll(' ', '-')}`);
+    withRawDatabase(file, (db) => db.exec(mutation));
+    expectMalformedWithoutMutation(file);
+  });
+
+  it('migrates an exact schema-table-only version 0 and accepts the resulting current schema', () => {
+    const file = databasePath('exact-version-zero');
+    withRawDatabase(file, (db) => db.exec(`
+      CREATE TABLE workflow_schema (version INTEGER NOT NULL);
+      INSERT INTO workflow_schema VALUES (0);
+    `));
+    withWorkflowDatabase(file, (db) => {
+      expect(tableNames(db)).toEqual(tables);
+      expect(db.prepare('SELECT version FROM workflow_schema').pluck().all()).toEqual([4]);
+      migrations.migrateWorkflowDatabase(db);
+    });
+  });
+
+  it('accepts an exact current version 3 on independent reopen without changing sentinel data', () => {
+    const file = currentDatabase('exact-current-reopen');
+    const before = databaseSnapshot(file);
+    withWorkflowDatabase(file, (db) => migrations.migrateWorkflowDatabase(db));
+    expect(databaseSnapshot(file)).toBe(before);
+  });
+});
+
+describe('locked constraints', () => {
+  it('rejects a run whose definition does not exist', () => {
+    withWorkflowDatabase(databasePath('foreign-key-rejection'), (db) => {
+      expect(() => insertRun(db, 'orphan', 'missing')).toThrow(/FOREIGN KEY constraint failed/);
+    });
+  });
+
+  it('cascades run deletion through nodes, attempts, and approvals and protects definitions', () => {
+    withWorkflowDatabase(databasePath('cascades'), (db) => {
+      insertDefinition(db);
+      insertRun(db, 'run');
+      insertNode(db, 'run');
+      db.prepare(`INSERT INTO workflow_attempts
+        (run_id, node_id, attempt, status, resolved_config_json, input_json, started_at)
+        VALUES ('run', 'node', 1, 'running', '{}', '{}', '2026-07-20T00:00:00.000Z')`).run();
+      db.prepare(`INSERT INTO workflow_approvals (run_id, node_id, status, requested_at)
+        VALUES ('run', 'node', 'pending', '2026-07-20T00:00:00.000Z')`).run();
+      expect(() => db.prepare("DELETE FROM workflow_definitions WHERE id = 'workflow'").run())
+        .toThrow(/FOREIGN KEY constraint failed/);
+      db.prepare("DELETE FROM workflow_runs WHERE id = 'run'").run();
+      for (const table of ['workflow_node_runs', 'workflow_attempts', 'workflow_approvals']) {
+        expect(db.prepare(`SELECT COUNT(*) FROM ${table}`).pluck().get()).toBe(0);
+      }
+      expect(db.prepare('SELECT COUNT(*) FROM workflow_definitions').pluck().get()).toBe(1);
+    });
+  });
+
+  it('enforces non-null idempotency uniqueness per workflow while allowing multiple NULL keys', () => {
+    withWorkflowDatabase(databasePath('idempotency'), (db) => {
+      insertDefinition(db, 'first');
+      insertDefinition(db, 'second');
+      insertRun(db, 'first-key', 'first', 'same-key');
+      expect(() => insertRun(db, 'duplicate-key', 'first', 'same-key')).toThrow(/UNIQUE constraint failed/);
+      insertRun(db, 'other-workflow-key', 'second', 'same-key');
+      insertRun(db, 'first-null', 'first');
+      insertRun(db, 'second-null', 'first');
+      expect(db.prepare('SELECT COUNT(*) FROM workflow_runs').pluck().get()).toBe(4);
+    });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/repository-runs.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/repository-runs.test.ts
@@ -1,0 +1,899 @@
+import { Buffer } from 'node:buffer';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import * as workflows from '../index.js';
+import type { JsonValue, WorkflowDefinition } from '../model.js';
+import {
+  WorkflowRepository,
+  WorkflowRepositoryError,
+  type CreateRunInput,
+  type CursorPage,
+  type RunListQuery,
+  type WorkflowRunSummary,
+  type WorkflowRunTransaction,
+} from '../repository.js';
+import { openWorkflowDatabase } from '../repository-migrations.js';
+import type {
+  ResolvedEmployeeConfig,
+  WorkflowAttemptRecord,
+  WorkflowNodeRunRecord,
+  WorkflowRunDetail,
+  WorkflowRunRecord,
+} from '../runtime.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const START = '2026-07-21T10:00:00.000Z';
+
+let root: string;
+let db: Database.Database;
+let repository: WorkflowRepository;
+let now: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'jinn-workflow-runs-'));
+  db = openWorkflowDatabase(join(root, 'workflows.db'));
+  now = START;
+  repository = new WorkflowRepository(db, () => now);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+function authoredDefinition(id = 'content-flow', title = 'Content flow'): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title });
+  return repository.saveDefinition({
+    ...created,
+    nodes: [
+      { id: 'start', type: 'trigger', name: 'Start', config: { kind: 'manual' } },
+      { id: 'event-start', type: 'trigger', name: 'Event start', config: { kind: 'event', eventName: 'content.ready' } },
+      { id: 'draft', type: 'employee', name: 'Draft content', config: { employee: { source: 'fixed', value: 'writer' }, prompt: 'Draft the content.' } },
+      { id: 'pause', type: 'wait', name: 'Pause', config: { mode: 'duration', minutes: 5 } },
+      { id: 'approve', type: 'approval', name: 'Approve', config: { description: 'Approve the draft.' } },
+      { id: 'finish', type: 'end', name: 'Finish', config: { result: 'success' } },
+    ],
+    edges: [],
+  }, created.revision);
+}
+
+function calledDefinition(id = 'child-flow'): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: 'Child flow' });
+  return repository.saveDefinition({ ...created,
+    nodes: [
+      { id: 'start', type: 'trigger', name: 'Called', config: { kind: 'workflow-call' } },
+      { id: 'write', type: 'employee', name: 'Write', config: { employee: { source: 'fixed', value: 'writer' }, prompt: 'Write.' } },
+      { id: 'finish', type: 'end', name: 'Finish', config: { result: 'success' } },
+    ],
+    edges: [{ id: 'to-write', from: { nodeId: 'start', port: 'success' }, to: { nodeId: 'write', port: 'input' } },
+      { id: 'finish', from: { nodeId: 'write', port: 'success' }, to: { nodeId: 'finish', port: 'input' } }],
+  }, created.revision);
+}
+
+function createRun(overrides: Partial<CreateRunInput> = {}): WorkflowRunRecord {
+  return repository.createRun({
+    workflowId: 'content-flow',
+    input: { topic: 'release' },
+    trigger: { nodeId: 'start', kind: 'manual', payload: { source: 'operator' } },
+    ...overrides,
+  });
+}
+
+function resolved(employeeId = 'writer'): ResolvedEmployeeConfig {
+  return { employeeId, engine: 'codex', model: 'model-name', effort: 'high', timeoutMinutes: 30,
+    retry: { attempts: 2, delaySeconds: 10, backoff: 'fixed' } };
+}
+
+function expectRepositoryError(action: () => unknown, code: WorkflowRepositoryError['code']): WorkflowRepositoryError {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkflowRepositoryError);
+  expect(thrown).toMatchObject({ name: 'WorkflowRepositoryError', code });
+  return thrown as WorkflowRepositoryError;
+}
+
+function repositoryErrorCode(action: () => unknown): string | null {
+  try {
+    action();
+    return null;
+  } catch (error) {
+    return error instanceof WorkflowRepositoryError ? error.code : `raw:${String(error)}`;
+  }
+}
+
+function tableCounts(): Record<string, number> {
+  const count = (table: string) => (db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count;
+  return {
+    runs: count('workflow_runs'),
+    nodes: count('workflow_node_runs'),
+    attempts: count('workflow_attempts'),
+    approvals: count('workflow_approvals'),
+  };
+}
+
+function decodeCursor(value: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Record<string, unknown>;
+}
+
+describe('WorkflowRepository Task 11 contract', () => {
+  it('exposes the ten run methods and exact public contract shapes', () => {
+    expectTypeOf(repository.createRun).parameter(0).toEqualTypeOf<CreateRunInput>();
+    expectTypeOf(repository.createRun).returns.toEqualTypeOf<WorkflowRunRecord>();
+    expectTypeOf(repository.getRun).returns.toEqualTypeOf<WorkflowRunDetail | null>();
+    expectTypeOf(repository.listRuns).parameter(1).toEqualTypeOf<RunListQuery>();
+    expectTypeOf(repository.listRuns).returns.toEqualTypeOf<CursorPage<WorkflowRunSummary>>();
+    expectTypeOf(repository.findRunByIdempotency).returns.toEqualTypeOf<WorkflowRunRecord | null>();
+    expectTypeOf(repository.mutateRun).parameter(2).toEqualTypeOf<(tx: WorkflowRunTransaction) => unknown>();
+    expectTypeOf(repository.getAttempt).returns.toEqualTypeOf<WorkflowAttemptRecord | null>();
+    expectTypeOf(repository.listAttempts).returns.toEqualTypeOf<WorkflowAttemptRecord[]>();
+    expectTypeOf(repository.findAttemptBySessionId).returns.toEqualTypeOf<WorkflowAttemptRecord | null>();
+    expectTypeOf(repository.listRecoverableRuns).returns.toEqualTypeOf<WorkflowRunRecord[]>();
+    expectTypeOf(repository.listDueWaits).returns.toEqualTypeOf<WorkflowNodeRunRecord[]>();
+    expectTypeOf(repository.listDueReminders).returns.toEqualTypeOf<WorkflowAttemptRecord[]>();
+    expectTypeOf(repository.nextDueReminder).returns.toEqualTypeOf<{
+      runId: string; nodeId: string; attempt: number; nextReminderAt: string;
+    } | null>();
+    expectTypeOf(repository.nextDueTimeout).returns.toEqualTypeOf<string | null>();
+  });
+
+  it('exports one public repository and the same error without exposing helpers', () => {
+    expect(workflows.WorkflowRepository).toBe(WorkflowRepository);
+    expect(workflows.WorkflowRepositoryError).toBe(WorkflowRepositoryError);
+    expect(Object.keys(workflows).filter((name) => name.endsWith('Repository'))).toEqual(['WorkflowRepository']);
+    expect(Object.keys(workflows)).not.toContain('RunRepository');
+
+    const repositorySource = readFileSync(join(HERE, '..', 'repository.ts'), 'utf8');
+    const helpers = ['repository-support.ts', 'repository-runs.ts', 'repository-run-transaction.ts'];
+    for (const helper of helpers) {
+      const source = readFileSync(join(HERE, '..', helper), 'utf8');
+      expect(source).not.toMatch(/BEGIN\s+(?:IMMEDIATE|TRANSACTION)/i);
+      expect(source).not.toContain('.transaction(');
+      expect(repositorySource).toContain(`./${helper.replace(/\.ts$/, '.js')}`);
+    }
+  });
+});
+
+describe('run creation and idempotency', () => {
+  it('lists child runs by caller in item order, with the End output and the session of each round', () => {
+    const parentDefinition = authoredDefinition();
+    const childDefinition = calledDefinition();
+    const parent = repository.createRun({ workflowId: parentDefinition.id, input: {},
+      trigger: { nodeId: 'start', kind: 'manual', payload: {} } });
+    const children = [2, 0, 1, 3].map((itemIndex) => repository.createRun({
+      workflowId: childDefinition.id, input: { topic: `item-${itemIndex}` },
+      trigger: { nodeId: 'start', kind: 'workflow-call', payload: {
+        caller: { workflowId: parent.workflowId, runId: parent.id, nodeId: 'draft' }, itemIndex,
+      } }, idempotencyKey: `${parent.id}:draft:${itemIndex}`,
+    }));
+    // Round 0 is still running and round 1 failed, each with a session on its attempt and nothing in its node
+    // output; round 2 finished and carries one in its output; round 3 finished without ever dispatching.
+    for (const child of children) {
+      const itemIndex = child.trigger.payload.itemIndex as number;
+      repository.mutateRun(child.id, child.revision, (tx) => {
+        tx.setNodeStatus('start', 'completed', { activated: true, startedAt: now, endedAt: now });
+        if (itemIndex < 3) {
+          tx.createAttempt({ nodeId: 'write', resolvedConfig: resolved(), input: {} });
+          tx.settleAttempt('write', 1, { status: 'running', sessionId: `session-${itemIndex}` });
+        }
+        if (itemIndex === 0) return tx.setRunStatus('running', {});
+        if (itemIndex === 1) return tx.setRunStatus('failed', { endedAt: now, error: { code: 'engine-down', message: 'Engine down.', retryable: true } });
+        if (itemIndex === 2) {
+          tx.settleAttempt('write', 1, { status: 'completed', output: { text: '', fields: {} }, endedAt: now });
+          tx.setNodeStatus('write', 'completed', { activated: true, startedAt: now, endedAt: now, output: { text: '', fields: {}, sessionId: 'session-2' } });
+        }
+        tx.setNodeStatus('finish', 'completed', { activated: true, startedAt: now, endedAt: now, output: { text: '', fields: { result: `done-${itemIndex}` } } });
+        tx.setRunStatus('completed', { endedAt: now });
+      });
+    }
+
+    expect(repository.listChildRuns(parent.id, 'draft').map((round) => [round.itemIndex, round.runId,
+      round.workflowId, round.status, round.endOutput?.result, round.sessionId])).toEqual([
+      [0, children[1]!.id, childDefinition.id, 'running', undefined, 'session-0'],
+      [1, children[2]!.id, childDefinition.id, 'failed', undefined, 'session-1'],
+      [2, children[0]!.id, childDefinition.id, 'completed', 'done-2', 'session-2'],
+      [3, children[3]!.id, childDefinition.id, 'completed', 'done-3', undefined],
+    ]);
+  });
+
+  it('freezes the exact definition, input, and trigger and initializes every authored node', () => {
+    const definition = authoredDefinition();
+    const input = Object.assign(Object.create(null), { topic: 'release' }) as Record<string, JsonValue>;
+    const run = repository.createRun({
+      workflowId: definition.id,
+      input,
+      trigger: { nodeId: 'event-start', kind: 'event', fireId: 'fire-1', payload: { ok: true } },
+      idempotencyKey: 'request-1',
+      invocationSessionId: 'caller-1',
+    });
+
+    expect(run).toMatchObject({
+      workflowId: definition.id,
+      workflowTitle: definition.title,
+      definitionRevision: definition.revision,
+      definition,
+      input: { topic: 'release' },
+      trigger: { nodeId: 'event-start', kind: 'event', fireId: 'fire-1', payload: { ok: true } },
+      status: 'pending',
+      revision: 1,
+      idempotencyKey: 'request-1',
+      invocationSessionId: 'caller-1',
+      startedAt: START,
+    });
+    expect(run.id).toMatch(/^run_[0-9a-f-]{36}$/);
+    expect(run).not.toHaveProperty('endedAt');
+    expect(repository.getRun(definition.id, run.id)?.nodeRuns).toEqual(definition.nodes.map((node) => ({
+      runId: run.id,
+      nodeId: node.id,
+      nodeType: node.type,
+      status: 'pending',
+      activated: false,
+    })));
+    expect(input).toEqual({ topic: 'release' });
+
+    now = '2026-07-21T10:05:00.000Z';
+    repository.saveDefinition({ ...definition, title: 'Changed title', nodes: definition.nodes.map((node) => (
+      node.id === 'draft' ? { ...node, name: 'Changed node label' } : node
+    )) }, definition.revision);
+    expect(repository.getRun(definition.id, run.id)).toMatchObject({
+      workflowTitle: 'Content flow',
+      definitionRevision: definition.revision,
+      definition,
+    });
+  });
+
+  it('returns an equivalent idempotent replay without writes and rejects conflicting reuse once', () => {
+    authoredDefinition();
+    const request: CreateRunInput = {
+      workflowId: 'content-flow',
+      input: { topic: 'release' },
+      trigger: { nodeId: 'event-start', kind: 'event', fireId: 'same-fire', payload: { nested: { ok: true } } },
+      idempotencyKey: 'same-request',
+      invocationSessionId: 'caller-1',
+    };
+    const original = repository.createRun(request);
+    const before = tableCounts();
+    now = '2026-07-21T11:00:00.000Z';
+    expect(repository.createRun(request)).toEqual(original);
+    expect(tableCounts()).toEqual(before);
+
+    const conflicts: CreateRunInput[] = [
+      { ...request, input: { topic: 'different' } },
+      { ...request, trigger: { ...request.trigger, payload: { nested: { ok: false } } } },
+      { ...request, invocationSessionId: 'caller-2' },
+    ];
+    for (const conflict of conflicts) {
+      expectRepositoryError(() => repository.createRun(conflict), 'idempotency-conflict');
+    }
+    expect(tableCounts()).toEqual(before);
+    expect(repository.findRunByIdempotency('content-flow', 'same-request')).toEqual(original);
+    expect(repository.findRunByIdempotency('content-flow', 'missing-request')).toBeNull();
+  });
+
+  it('requires the current definition revision for an idempotent replay', () => {
+    const definition = authoredDefinition();
+    const request: CreateRunInput = {
+      workflowId: definition.id, input: {}, idempotencyKey: 'stable-key',
+      trigger: { nodeId: 'start', kind: 'manual', payload: {} },
+    };
+    repository.createRun(request);
+    repository.saveDefinition({ ...definition, title: 'New revision' }, definition.revision);
+    const before = tableCounts();
+    expectRepositoryError(() => repository.createRun(request), 'idempotency-conflict');
+    expect(tableCounts()).toEqual(before);
+  });
+
+  it('fails closed when the current definition is missing or corrupt before replay', () => {
+    const definition = authoredDefinition();
+    const request: CreateRunInput = {
+      workflowId: 'content-flow', input: {}, idempotencyKey: 'stable-key',
+      trigger: { nodeId: 'start', kind: 'manual', payload: {} },
+    };
+    repository.createRun(request);
+    db.prepare("UPDATE workflow_definitions SET definition_json = '{' WHERE id = ?").run('content-flow');
+    expectRepositoryError(() => repository.createRun(request), 'corrupt-record');
+    db.prepare('UPDATE workflow_definitions SET definition_json = ? WHERE id = ?').run(JSON.stringify(definition), 'content-flow');
+    db.pragma('foreign_keys = OFF');
+    db.prepare('DELETE FROM workflow_definitions WHERE id = ?').run('content-flow');
+    db.pragma('foreign_keys = ON');
+    expectRepositoryError(() => repository.createRun(request), 'not-found');
+  });
+});
+
+describe('atomic run mutations', () => {
+  it('persists dispatching attempts with deterministic next numbers and settles them', () => {
+    authoredDefinition();
+    const run = createRun();
+    let first!: WorkflowAttemptRecord;
+    repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setRunStatus('running');
+      tx.setNodeStatus('draft', 'dispatching', {
+        activated: true,
+        resolvedConfig: { employeeId: 'writer' },
+        input: { topic: 'release' },
+        startedAt: START,
+      });
+      first = tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: { topic: 'release' },
+        promptText: 'Draft the release notes.\n\n---\nContract block.' });
+    });
+    expect(first).toMatchObject({
+      runId: run.id, nodeId: 'draft', attempt: 1, status: 'dispatching', startedAt: START,
+      promptText: 'Draft the release notes.\n\n---\nContract block.',
+    });
+    expect(repository.getAttempt(run.id, 'draft', 1)).toEqual(first);
+
+    now = '2026-07-21T10:01:00.000Z';
+    repository.mutateRun(run.id, 2, (tx) => {
+      tx.settleAttempt('draft', 1, { status: 'running', sessionId: 'session-1' });
+    });
+    const running = repository.findAttemptBySessionId('session-1');
+    expect(running).toMatchObject({ status: 'running', sessionId: 'session-1' });
+
+    now = '2026-07-21T10:02:00.000Z';
+    repository.mutateRun(run.id, 3, (tx) => {
+      tx.settleAttempt('draft', 1, {
+        status: 'completed', output: { text: 'Done.', fields: { ok: true } }, endedAt: now,
+      });
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: { topic: 'retry' } });
+    });
+    expect(repository.listAttempts(run.id, 'draft').map(({ attempt, status }) => ({ attempt, status }))).toEqual([
+      { attempt: 1, status: 'completed' },
+      { attempt: 2, status: 'dispatching' },
+    ]);
+    // promptText is optional: the second attempt was created without one.
+    expect(repository.getAttempt(run.id, 'draft', 2)?.promptText).toBeUndefined();
+  });
+
+  it('persists reminder state and reads due attempts in deterministic order', () => {
+    authoredDefinition();
+    const run = createRun();
+    repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setNodeStatus('draft', 'dispatching', { activated: true, startedAt: START });
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    repository.mutateRun(run.id, 2, (tx) => {
+      tx.settleAttempt('draft', 1, { status: 'running', sessionId: 'session-reminder' });
+      tx.setAttemptReminder('draft', 1, {
+        remindersSent: 2,
+        nextReminderAt: '2026-07-21T10:15:00.000Z',
+        extensions: 1,
+        lastExtensionReason: 'Waiting for review.',
+        pendingOutputError: 'Field "score" must be a number.',
+      });
+    });
+
+    expect(repository.getAttempt(run.id, 'draft', 1)).toMatchObject({
+      remindersSent: 2,
+      nextReminderAt: '2026-07-21T10:15:00.000Z',
+      extensions: 1,
+      lastExtensionReason: 'Waiting for review.',
+      pendingOutputError: 'Field "score" must be a number.',
+    });
+    expect(repository.listDueReminders('2026-07-21T10:15:00.000Z', 100)).toEqual([
+      expect.objectContaining({ runId: run.id, nodeId: 'draft', attempt: 1 }),
+    ]);
+    expect(repository.listDueReminders('2026-07-21T10:14:59.999Z', 100)).toEqual([]);
+    expect(repository.nextDueReminder()).toEqual({
+      runId: run.id,
+      nodeId: 'draft',
+      attempt: 1,
+      nextReminderAt: '2026-07-21T10:15:00.000Z',
+    });
+  });
+
+  it('reads the earliest running attempt timeout and ignores attempts without one', () => {
+    const createRunningAttempt = (id: string, startedAt: string, timeoutMinutes?: number) => {
+      now = startedAt;
+      authoredDefinition(id, id);
+      const run = createRun({ workflowId: id });
+      const config = resolved();
+      if (timeoutMinutes === undefined) delete config.timeoutMinutes;
+      else config.timeoutMinutes = timeoutMinutes;
+      repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.setRunStatus('running');
+        tx.setNodeStatus('draft', 'dispatching', { activated: true, startedAt });
+        tx.createAttempt({ nodeId: 'draft', resolvedConfig: config, input: {} });
+      });
+      repository.mutateRun(run.id, 2, (tx) => {
+        tx.settleAttempt('draft', 1, { status: 'running', sessionId: `session-${id}` });
+      });
+      return run;
+    };
+
+    expect(repository.nextDueTimeout()).toBeNull();
+    createRunningAttempt('unbounded-flow', '2026-07-21T10:00:00.000Z');
+    expect(repository.nextDueTimeout()).toBeNull();
+    const later = createRunningAttempt('later-flow', '2026-07-21T10:01:00.000Z', 30);
+    const earlier = createRunningAttempt('earlier-flow', '2026-07-21T10:05:00.000Z', 10);
+    expect(repository.nextDueTimeout()).toBe('2026-07-21T10:15:00.000Z');
+
+    const timeoutError = { code: 'workflow-timeout', message: 'Workflow attempt timed out.', retryable: true };
+    repository.mutateRun(earlier.id, 3, (tx) => {
+      tx.settleAttempt('draft', 1, { status: 'timed-out', error: timeoutError, endedAt: '2026-07-21T10:15:00.000Z' });
+    });
+    expect(repository.nextDueTimeout()).toBe('2026-07-21T10:31:00.000Z');
+    repository.mutateRun(later.id, 3, (tx) => {
+      tx.settleAttempt('draft', 1, { status: 'timed-out', error: timeoutError, endedAt: '2026-07-21T10:31:00.000Z' });
+    });
+    expect(repository.nextDueTimeout()).toBeNull();
+  });
+
+  it('rolls back atomically, bumps once when changed, never bumps a no-op, and rejects stale revisions', () => {
+    authoredDefinition();
+    const run = createRun();
+    const result = repository.mutateRun(run.id, 1, (tx) => {
+      tx.setRunStatus('running');
+      tx.setNodeStatus('start', 'completed', { activated: true, startedAt: START, endedAt: START });
+      tx.setNodeStatus('draft', 'ready', { activated: true });
+      return 'mutated';
+    });
+    expect(result).toBe('mutated');
+    expect(repository.getRun(run.workflowId, run.id)?.revision).toBe(2);
+
+    repository.mutateRun(run.id, 2, (tx) => {
+      tx.setRunStatus('running');
+      tx.setNodeStatus('draft', 'ready', { activated: true });
+    });
+    expect(repository.getRun(run.workflowId, run.id)?.revision).toBe(2);
+    expectRepositoryError(() => repository.mutateRun(run.id, 1, () => undefined), 'revision-conflict');
+
+    const before = repository.getRun(run.workflowId, run.id);
+    expect(() => repository.mutateRun(run.id, 2, (tx) => {
+      tx.setRunStatus('failed', { endedAt: now, error: { code: 'failed', message: 'Failed.', retryable: false } });
+      tx.setNodeStatus('draft', 'failed', {
+        error: { code: 'failed', message: 'Failed.', retryable: false, nodeId: 'draft' }, endedAt: now,
+      });
+      throw new Error('rollback');
+    })).toThrow('rollback');
+    expect(repository.getRun(run.workflowId, run.id)).toEqual(before);
+
+    db.exec(`CREATE TRIGGER reject_node_update BEFORE UPDATE ON workflow_node_runs
+      BEGIN SELECT RAISE(ABORT, 'forced SQL fault'); END`);
+    expect(() => repository.mutateRun(run.id, 2, (tx) => {
+      tx.setRunStatus('failed', { endedAt: START, error: { code: 'failed', message: 'Failed.', retryable: false } });
+      tx.setNodeStatus('draft', 'failed');
+    })).toThrow('forced SQL fault');
+    db.exec('DROP TRIGGER reject_node_update');
+    expect(repository.getRun(run.workflowId, run.id)).toEqual(before);
+  });
+
+  it('persists complete approval audit records', () => {
+    authoredDefinition();
+    const run = createRun();
+    repository.mutateRun(run.id, 1, (tx) => {
+      tx.putApproval({
+        nodeId: 'approve', status: 'approved', requestedAt: START, approverRef: 'operator',
+        decidedAt: START, decidedBy: 'operator', decision: 'approve', reason: 'Reviewed.',
+      });
+    });
+    expect(repository.getRun(run.workflowId, run.id)?.approvals).toEqual([{
+      runId: run.id, nodeId: 'approve', status: 'approved', requestedAt: START, approverRef: 'operator',
+      decidedAt: START, decidedBy: 'operator', decision: 'approve', reason: 'Reviewed.',
+    }]);
+  });
+
+  it('rejects incomplete attempt settlements without changing the run', () => {
+    authoredDefinition();
+    const run = createRun();
+    repository.mutateRun(run.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    const before = repository.getRun(run.workflowId, run.id);
+    expectRepositoryError(() => repository.mutateRun(run.id, 2, (tx) => {
+      tx.settleAttempt('draft', 1, { status: 'completed', endedAt: START } as never);
+    }), 'bad-input');
+    expect(repository.getRun(run.workflowId, run.id)).toEqual(before);
+  });
+
+  it('closes mutation scopes, rejects nesting, and rolls async work back', async () => {
+    authoredDefinition();
+    const run = createRun();
+    let escaped!: WorkflowRunTransaction;
+    expect(repository.mutateRun(run.id, 1, (tx) => {
+      escaped = tx;
+      return { ok: true };
+    })).toEqual({ ok: true });
+    expectRepositoryError(() => escaped.setRunStatus('running'), 'bad-input');
+
+    expectRepositoryError(() => repository.mutateRun(run.id, 1, () => (
+      repository.mutateRun(run.id, 1, () => undefined)
+    )), 'bad-input');
+    expect(() => repository.mutateRun(run.id, 1, () => { throw new Error('callback'); })).toThrow('callback');
+
+    let continuation!: Promise<void>;
+    expectRepositoryError(() => repository.mutateRun(run.id, 1, (tx) => {
+      tx.setRunStatus('running');
+      continuation = (async () => {
+        await Promise.resolve();
+        tx.setRunStatus('failed', { endedAt: START, error: { code: 'late', message: 'Late.', retryable: false } });
+      })();
+      return continuation as never;
+    }), 'bad-input');
+    await expect(continuation).rejects.toMatchObject({ code: 'bad-input' });
+
+    expectRepositoryError(() => repository.mutateRun(run.id, 1, (tx) => {
+      tx.setRunStatus('running');
+      return { then: () => undefined } as never;
+    }), 'bad-input');
+    expect(repository.getRun(run.workflowId, run.id)).toMatchObject({ revision: 1, status: 'pending' });
+    repository.mutateRun(run.id, 1, (tx) => tx.setRunStatus('running'));
+  });
+
+  it('enforces attempt ownership and legal lifecycle transitions', () => {
+    authoredDefinition();
+    const run = createRun();
+    repository.mutateRun(run.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    expectRepositoryError(() => repository.mutateRun(run.id, 2, (tx) => {
+      tx.settleAttempt('draft', 1, {
+        status: 'completed', output: { text: 'Skipped running.', fields: {} }, endedAt: START,
+      });
+    }), 'bad-input');
+    expectRepositoryError(() => repository.mutateRun(run.id, 2, (tx) => {
+      tx.settleAttempt('draft', 1, {
+        status: 'dispatching', error: { code: 'bad', message: 'Bad.', retryable: false }, endedAt: START,
+      } as never);
+    }), 'bad-input');
+
+    repository.mutateRun(run.id, 2, (tx) => tx.settleAttempt('draft', 1, {
+      status: 'running', sessionId: 'owner-session',
+    }));
+    expectRepositoryError(() => repository.mutateRun(run.id, 3, (tx) => {
+      tx.settleAttempt('draft', 1, {
+        status: 'completed', sessionId: 'foreign-session', output: { text: 'Done.', fields: {} }, endedAt: START,
+      });
+    }), 'bad-input');
+    const terminal = { status: 'completed' as const, sessionId: 'owner-session', output: { text: 'Done.', fields: {} }, endedAt: START };
+    repository.mutateRun(run.id, 3, (tx) => tx.settleAttempt('draft', 1, terminal));
+    repository.mutateRun(run.id, 4, (tx) => tx.settleAttempt('draft', 1, terminal));
+    expectRepositoryError(() => repository.mutateRun(run.id, 4, (tx) => {
+      tx.settleAttempt('draft', 1, { status: 'running', sessionId: 'owner-session' });
+    }), 'bad-input');
+
+    repository.mutateRun(run.id, 4, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    repository.mutateRun(run.id, 5, (tx) => tx.settleAttempt('draft', 2, {
+      status: 'failed', error: { code: 'spawn-failed', message: 'Spawn failed.', retryable: true }, endedAt: START,
+    }));
+    expect(repository.getAttempt(run.id, 'draft', 2)).toMatchObject({ status: 'failed' });
+    expect(repository.getAttempt(run.id, 'draft', 2)).not.toHaveProperty('sessionId');
+  });
+
+  it('rejects session ownership claims from another attempt in the same or a different run', () => {
+    authoredDefinition();
+    const first = createRun({ idempotencyKey: 'first-owner' });
+    repository.mutateRun(first.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    repository.mutateRun(first.id, 2, (tx) => tx.settleAttempt('draft', 1, {
+      status: 'running', sessionId: 'shared-session',
+    }));
+    const beforeSameRun = repository.getRun(first.workflowId, first.id);
+    expectRepositoryError(() => repository.mutateRun(first.id, 3, (tx) => tx.settleAttempt('draft', 2, {
+      status: 'running', sessionId: 'shared-session',
+    })), 'bad-input');
+    expect(repository.getRun(first.workflowId, first.id)).toEqual(beforeSameRun);
+
+    const second = createRun({ idempotencyKey: 'second-owner' });
+    repository.mutateRun(second.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    const beforeCrossRun = repository.getRun(second.workflowId, second.id);
+    expectRepositoryError(() => repository.mutateRun(second.id, 2, (tx) => tx.settleAttempt('draft', 1, {
+      status: 'running', sessionId: 'shared-session',
+    })), 'bad-input');
+    expect(repository.getRun(second.workflowId, second.id)).toEqual(beforeCrossRun);
+  });
+
+  it('validates mutation payloads before scoped SQL and preserves stored corruption typing', () => {
+    authoredDefinition();
+    const run = createRun();
+    const invalidActions: Array<(tx: WorkflowRunTransaction) => unknown> = [
+      (tx: WorkflowRunTransaction) => tx.createAttempt({ nodeId: 'draft', resolvedConfig: { employeeId: 'writer' } as never, input: {} }),
+      (tx: WorkflowRunTransaction) => tx.setRunStatus('failed', { endedAt: START, error: { code: 'bad' } as never }),
+      (tx: WorkflowRunTransaction) => tx.setNodeStatus('draft', 'completed', { output: { fields: 1 } as never, endedAt: START }),
+      (tx: WorkflowRunTransaction) => tx.putApproval({ nodeId: 'approve', status: 'approved', requestedAt: START } as never),
+    ];
+    for (const action of invalidActions) {
+      const prepare = vi.spyOn(db, 'prepare');
+      expectRepositoryError(() => repository.mutateRun(run.id, 1, action), 'bad-input');
+      expect(prepare).toHaveBeenCalledTimes(1);
+      prepare.mockRestore();
+    }
+    expect(repository.getRun(run.workflowId, run.id)).toMatchObject({ revision: 1, status: 'pending' });
+    db.prepare("UPDATE workflow_node_runs SET status = 'unknown' WHERE run_id = ? AND node_id = 'draft'").run(run.id);
+    expectRepositoryError(() => repository.mutateRun(run.id, 1, (tx) => tx.setNodeStatus('draft', 'ready')), 'corrupt-record');
+  });
+});
+
+describe('history, recovery, and wait readers', () => {
+  it('lists stable cursor pages with inclusive filters and frozen current/failing projections', () => {
+    const definition = authoredDefinition('content-flow', 'Content Pipeline');
+    const oldest = createRun({ idempotencyKey: 'old', trigger: { nodeId: 'start', kind: 'manual', payload: {} } });
+    repository.mutateRun(oldest.id, 1, (tx) => {
+      tx.setRunStatus('running');
+      tx.setNodeStatus('draft', 'running', { activated: true, resolvedConfig: { employeeId: 'resolved-writer' } });
+    });
+    now = '2026-07-21T11:00:00.000Z';
+    const failed = createRun({ idempotencyKey: 'failed', trigger: { nodeId: 'event-start', kind: 'event', payload: {} } });
+    repository.mutateRun(failed.id, 1, (tx) => {
+      tx.setRunStatus('failed', { endedAt: now, error: { code: 'node-failed', message: 'Failed.', retryable: false } });
+      tx.setNodeStatus('draft', 'failed', {
+        activated: true, resolvedConfig: { employeeId: 'failed-writer' },
+        error: { code: 'node-failed', message: 'Failed.', retryable: false }, endedAt: now,
+      });
+    });
+    now = '2026-07-21T12:00:00.000Z';
+    const newest = createRun({ idempotencyKey: 'new', trigger: { nodeId: 'start', kind: 'manual', payload: {} } });
+
+    const first = repository.listRuns(definition.id, { limit: 2 });
+    expect(first.items.map((item) => item.id)).toEqual([newest.id, failed.id]);
+    expect(decodeCursor(first.nextCursor!)).toEqual({
+      version: 1, endpoint: 'workflow-runs', startedAt: failed.startedAt, id: failed.id,
+    });
+    expect(repository.listRuns(definition.id, { limit: 2, cursor: first.nextCursor! }).items.map((item) => item.id))
+      .toEqual([oldest.id]);
+    expect(repository.listRuns(definition.id, { status: 'failed' }).items[0]?.currentOrFailingNode).toEqual({
+      nodeId: 'draft', label: 'Draft content', employeeId: 'failed-writer', state: 'failing',
+    });
+    expect(repository.listRuns(definition.id, { triggerKind: 'manual', startedFrom: START, startedTo: START }).items[0])
+      .toMatchObject({ id: oldest.id, currentOrFailingNode: {
+        nodeId: 'draft', label: 'Draft content', employeeId: 'resolved-writer', state: 'current',
+      } });
+    expect(repository.listRuns(definition.id, { text: 'pipeline' }).items).toHaveLength(3);
+    expect(repository.listRuns(definition.id, { text: failed.id }).items.map((item) => item.id)).toEqual([failed.id]);
+  });
+
+  it('defaults to 50, accepts 100, and rejects malformed run queries and cursors', () => {
+    authoredDefinition();
+    for (let index = 0; index < 101; index += 1) {
+      now = new Date(Date.UTC(2026, 6, 21, 0, index)).toISOString();
+      createRun({ idempotencyKey: `request-${index}` });
+    }
+    expect(repository.listRuns('content-flow', {}).items).toHaveLength(50);
+    expect(repository.listRuns('content-flow', { limit: 100 }).items).toHaveLength(100);
+    for (const query of [
+      { limit: 0 }, { limit: 101 }, { limit: 1.5 }, { status: 'unknown' }, { triggerKind: 'unknown' },
+      { startedFrom: '2026-07-21T00:00:00Z' }, { startedTo: 'invalid' }, { text: 1 }, { extra: true },
+    ]) {
+      expectRepositoryError(() => repository.listRuns('content-flow', query as RunListQuery), 'bad-input');
+    }
+    const cursor = repository.listRuns('content-flow', { limit: 1 }).nextCursor!;
+    for (const invalid of [
+      '', 'not-base64!', Buffer.from(JSON.stringify({ ...decodeCursor(cursor), endpoint: 'workflow-definitions' })).toString('base64url'),
+    ]) {
+      expectRepositoryError(() => repository.listRuns('content-flow', { cursor: invalid }), 'bad-cursor');
+    }
+  });
+
+  it('validates date ranges before SQL and searches frozen node labels without spoofed employees', () => {
+    authoredDefinition();
+    const run = createRun();
+    const prepare = vi.spyOn(db, 'prepare');
+    expectRepositoryError(() => repository.listRuns('content-flow', {
+      startedFrom: '2026-07-22T00:00:00.000Z', startedTo: START,
+    }), 'bad-input');
+    expect(prepare).not.toHaveBeenCalled();
+    prepare.mockRestore();
+
+    repository.mutateRun(run.id, 1, (tx) => {
+      tx.setNodeStatus('draft', 'ready', { activated: true });
+    });
+    expect(repository.listRuns('content-flow', { text: 'draft content' }).items.map((item) => item.id)).toEqual([run.id]);
+
+    const spoofed = createRun({ idempotencyKey: 'spoofed' });
+    repository.mutateRun(spoofed.id, 1, (tx) => {
+      tx.setNodeStatus('start', 'ready', { activated: true, resolvedConfig: { employeeId: 'spoofed' } });
+    });
+    expect(repository.listRuns('content-flow', { text: spoofed.id }).items[0]?.currentOrFailingNode).toEqual({
+      nodeId: 'start', label: 'Start', employeeId: null, state: 'current',
+    });
+  });
+
+  it('returns recoverable runs and due waits in deterministic order with inclusive deadlines', () => {
+    authoredDefinition();
+    const pending = createRun({ idempotencyKey: 'pending' });
+    now = '2026-07-21T10:01:00.000Z';
+    const waiting = createRun({ idempotencyKey: 'waiting' });
+    repository.mutateRun(waiting.id, 1, (tx) => {
+      tx.setRunStatus('waiting');
+      tx.setNodeStatus('pause', 'waiting', { activated: true, resumeAt: '2026-07-21T10:05:00.000Z' });
+    });
+    now = '2026-07-21T10:02:00.000Z';
+    const completed = createRun({ idempotencyKey: 'completed' });
+    repository.mutateRun(completed.id, 1, (tx) => tx.setRunStatus('completed', { endedAt: now }));
+
+    expect(repository.listRecoverableRuns().map((run) => run.id)).toEqual([pending.id, waiting.id]);
+    expect(repository.listDueWaits('2026-07-21T10:05:00.000Z', 1)).toEqual([
+      expect.objectContaining({ runId: waiting.id, nodeId: 'pause', status: 'waiting' }),
+    ]);
+    expect(repository.listDueWaits('2026-07-21T10:04:59.999Z', 100)).toEqual([]);
+  });
+});
+
+describe('validation and corrupt storage', () => {
+  it('rejects public inputs before the write lock while valid contention remains SQLITE_BUSY', () => {
+    authoredDefinition();
+    const blocker = openWorkflowDatabase(join(root, 'workflows.db'));
+    db.pragma('busy_timeout = 0');
+    blocker.exec('BEGIN IMMEDIATE');
+    try {
+      expectRepositoryError(() => repository.createRun({
+        workflowId: 'Invalid', input: {}, trigger: { nodeId: 'start', kind: 'manual', payload: {} },
+      }), 'bad-input');
+      expectRepositoryError(() => repository.mutateRun('bad id', 1, () => undefined), 'bad-input');
+      expectRepositoryError(() => repository.listDueWaits('not-an-instant', 10), 'bad-input');
+      expect(() => createRun({ idempotencyKey: 'contended' })).toThrow(expect.objectContaining({ code: 'SQLITE_BUSY' }));
+    } finally {
+      blocker.exec('ROLLBACK');
+      blocker.close();
+    }
+  });
+
+  it('rejects proxy callbacks before traps or lock access', () => {
+    authoredDefinition();
+    const run = createRun();
+    const blocker = openWorkflowDatabase(join(root, 'workflows.db'));
+    db.pragma('busy_timeout = 0');
+    blocker.exec('BEGIN IMMEDIATE');
+    let traps = 0;
+    const proxy = new Proxy(() => undefined, {
+      apply: () => { traps += 1; },
+      get: () => { traps += 1; },
+      ownKeys: () => { traps += 1; return []; },
+    });
+    const revoked = Proxy.revocable(() => undefined, {});
+    revoked.revoke();
+    const prepare = vi.spyOn(db, 'prepare');
+    try {
+      for (const callback of [proxy, revoked.proxy, {}]) {
+        expectRepositoryError(() => repository.mutateRun(run.id, 1, callback as never), 'bad-input');
+      }
+      expect(traps).toBe(0);
+      expect(prepare).not.toHaveBeenCalled();
+    } finally {
+      prepare.mockRestore();
+      blocker.exec('ROLLBACK');
+      blocker.close();
+    }
+  });
+
+  it('maps corrupt run, node, attempt, and approval rows to corrupt-record errors', () => {
+    authoredDefinition();
+    const corruptRun = createRun({ idempotencyKey: 'corrupt-run' });
+    db.prepare("UPDATE workflow_runs SET definition_json = '{' WHERE id = ?").run(corruptRun.id);
+    expectRepositoryError(() => repository.getRun('content-flow', corruptRun.id), 'corrupt-record');
+
+    const corruptNode = createRun({ idempotencyKey: 'corrupt-node' });
+    db.prepare("UPDATE workflow_node_runs SET status = 'unknown' WHERE run_id = ? AND node_id = 'draft'").run(corruptNode.id);
+    expectRepositoryError(() => repository.getRun('content-flow', corruptNode.id), 'corrupt-record');
+
+    const corruptActivation = createRun({ idempotencyKey: 'corrupt-activation' });
+    db.prepare("UPDATE workflow_node_runs SET activated = 2 WHERE run_id = ? AND node_id = 'draft'").run(corruptActivation.id);
+    expectRepositoryError(() => repository.getRun('content-flow', corruptActivation.id), 'corrupt-record');
+
+    const corruptAttempt = createRun({ idempotencyKey: 'corrupt-attempt' });
+    repository.mutateRun(corruptAttempt.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    db.prepare("UPDATE workflow_attempts SET resolved_config_json = '{' WHERE run_id = ?").run(corruptAttempt.id);
+    expectRepositoryError(() => repository.listAttempts(corruptAttempt.id, 'draft'), 'corrupt-record');
+
+    const corruptApproval = createRun({ idempotencyKey: 'corrupt-approval' });
+    repository.mutateRun(corruptApproval.id, 1, (tx) => {
+      tx.putApproval({ nodeId: 'approve', status: 'pending', requestedAt: START });
+    });
+    db.prepare("UPDATE workflow_approvals SET status = 'unknown' WHERE run_id = ?").run(corruptApproval.id);
+    expectRepositoryError(() => repository.getRun('content-flow', corruptApproval.id), 'corrupt-record');
+
+    const corruptTrigger = createRun({ idempotencyKey: 'corrupt-trigger' });
+    db.prepare("UPDATE workflow_runs SET trigger_json = '{' WHERE id = ?").run(corruptTrigger.id);
+    expectRepositoryError(() => repository.listRuns('content-flow', { triggerKind: 'manual' }), 'corrupt-record');
+  });
+
+  it('fails closed on foreign history references and corruption hidden by list filters', () => {
+    authoredDefinition();
+    const run = createRun();
+    db.pragma('foreign_keys = OFF');
+    db.prepare(`INSERT INTO workflow_attempts
+      (run_id, node_id, attempt, status, resolved_config_json, input_json, started_at)
+      VALUES (?, 'ghost', 1, 'dispatching', ?, '{}', ?)`)
+      .run(run.id, JSON.stringify(resolved()), START);
+    db.pragma('foreign_keys = ON');
+    expectRepositoryError(() => repository.getRun(run.workflowId, run.id), 'corrupt-record');
+    expectRepositoryError(() => repository.listRuns(run.workflowId, {
+      status: 'completed', text: 'does-not-match', startedFrom: '2026-07-22T00:00:00.000Z',
+    }), 'corrupt-record');
+    db.prepare("DELETE FROM workflow_attempts WHERE run_id = ? AND node_id = 'ghost'").run(run.id);
+    const config = JSON.stringify(resolved());
+    db.prepare(`INSERT INTO workflow_attempts
+      (run_id,node_id,attempt,session_id,status,resolved_config_json,input_json,started_at) VALUES
+      (?,'draft',1,'duplicate-session','running',?,'{}',?),
+      (?,'draft',2,'duplicate-session','running',?,'{}',?)`).run(run.id, config, START, run.id, config, START);
+    expectRepositoryError(() => repository.findAttemptBySessionId('duplicate-session'), 'corrupt-record');
+    expectRepositoryError(() => repository.listRuns(run.workflowId, { text: 'does-not-match' }), 'corrupt-record');
+    db.prepare("DELETE FROM workflow_attempts WHERE run_id = ? AND session_id = 'duplicate-session'").run(run.id);
+
+    const cases = [
+      ["UPDATE workflow_runs SET status = 'unknown' WHERE id = ?", "UPDATE workflow_runs SET status = 'pending' WHERE id = ?"],
+      ["UPDATE workflow_runs SET trigger_json = '{' WHERE id = ?", "UPDATE workflow_runs SET trigger_json = ? WHERE id = ?"],
+      ["UPDATE workflow_node_runs SET status = 'unknown' WHERE run_id = ? AND node_id = 'draft'", "UPDATE workflow_node_runs SET status = 'pending' WHERE run_id = ? AND node_id = 'draft'"],
+    ] as const;
+    for (const [corrupt, repair] of cases) {
+      db.prepare(corrupt).run(run.id);
+      expectRepositoryError(() => repository.listRuns(run.workflowId, {
+        status: 'completed', text: 'does-not-match', startedFrom: '2026-07-22T00:00:00.000Z',
+      }), 'corrupt-record');
+      if (repair.includes('trigger_json = ?')) {
+        db.prepare(repair).run(JSON.stringify(run.trigger), run.id);
+      } else {
+        db.prepare(repair).run(run.id);
+      }
+    }
+  });
+
+  it('treats a completed attempt without a session as corrupt in detail and filtered history', () => {
+    authoredDefinition();
+    const run = createRun();
+    repository.mutateRun(run.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    db.prepare(`UPDATE workflow_attempts SET status='completed', output_json=?, ended_at=?
+      WHERE run_id=? AND node_id='draft' AND attempt=1`).run(JSON.stringify({ text: 'Done.', fields: {} }), START, run.id);
+    expect([
+      repositoryErrorCode(() => repository.getRun(run.workflowId, run.id)),
+      repositoryErrorCode(() => repository.listRuns(run.workflowId, {
+        status: 'cancelled', text: 'not-present', startedFrom: '2026-07-22T00:00:00.000Z',
+      })),
+    ]).toEqual(['corrupt-record', 'corrupt-record']);
+  });
+
+  it('detects exact decoder-invalid semantics independently of list filters', () => {
+    authoredDefinition();
+    const run = createRun();
+    repository.mutateRun(run.id, 1, (tx) => {
+      tx.createAttempt({ nodeId: 'draft', resolvedConfig: resolved(), input: {} });
+    });
+    const hiddenListCode = () => repositoryErrorCode(() => repository.listRuns(run.workflowId, {
+      status: 'cancelled', text: 'not-present', startedFrom: '2026-07-22T00:00:00.000Z',
+    }));
+    const outcomes: string[] = [];
+    const attempt = "WHERE run_id=? AND node_id='draft' AND attempt=1";
+    db.prepare(`UPDATE workflow_attempts SET resolved_config_json='{}' ${attempt}`).run(run.id);
+    outcomes.push(`resolved:${hiddenListCode()}`);
+    db.prepare(`UPDATE workflow_attempts SET resolved_config_json=? ${attempt}`).run(JSON.stringify(resolved()), run.id);
+    for (const stamp of ['not-an-instant', '2026-07-21T10:00:00Z']) {
+      db.prepare(`UPDATE workflow_attempts SET started_at=? ${attempt}`).run(stamp, run.id);
+      outcomes.push(`attempt-time:${hiddenListCode()}`);
+    }
+    db.prepare(`UPDATE workflow_attempts SET started_at=? ${attempt}`).run(START, run.id);
+    db.prepare("UPDATE workflow_node_runs SET output_json='{}' WHERE run_id=? AND node_id='draft'").run(run.id);
+    outcomes.push(`node-output:${hiddenListCode()}`);
+    db.prepare("UPDATE workflow_node_runs SET output_json=NULL WHERE run_id=? AND node_id='draft'").run(run.id);
+    db.prepare("UPDATE workflow_runs SET error_json='{}' WHERE id=?").run(run.id);
+    outcomes.push(`run-error:${hiddenListCode()}`);
+    db.prepare('UPDATE workflow_runs SET error_json=NULL WHERE id=?').run(run.id);
+    for (const stamp of ['not-an-instant', '2026-07-21T10:00:00Z']) {
+      db.prepare('UPDATE workflow_runs SET started_at=? WHERE id=?').run(stamp, run.id);
+      outcomes.push(`run-time:${hiddenListCode()}`);
+    }
+    db.prepare('UPDATE workflow_runs SET started_at=? WHERE id=?').run(START, run.id);
+    db.prepare("UPDATE workflow_runs SET definition_json=json_set(definition_json,'$.schemaVersion',2) WHERE id=?").run(run.id);
+    outcomes.push(`schema:${hiddenListCode()}`);
+    expect(outcomes).toEqual([
+      'resolved:corrupt-record', 'attempt-time:corrupt-record', 'attempt-time:corrupt-record',
+      'node-output:corrupt-record', 'run-error:corrupt-record', 'run-time:corrupt-record',
+      'run-time:corrupt-record', 'schema:corrupt-record',
+    ]);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/restart-redispatch.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/restart-redispatch.test.ts
@@ -1,0 +1,296 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener } from "../../shared/types.js";
+import type { SessionManager } from "../../sessions/manager.js";
+import { resumableEngineSession } from "../../sessions/attempt-continuation.js";
+import type { EmployeeNode, JsonValue, WorkflowDefinition } from "../model.js";
+import { resolveDispatch } from "../node-dispatch.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+/* A gateway restart is not an attempt at the work. Before PLA-154 it was charged
+ * as one: the boot sweep left the interruption unexplained, the runtime read it
+ * as an operator stopping the attempt, and one restart spent the whole default
+ * budget of `attempts: 1` — terminal-failing three live runs at once. */
+
+const sessionHome = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-restart-redispatch-sessions-"));
+process.env.JINN_HOME = sessionHome;
+const RESTART_ERROR = "Interrupted: gateway restarted while workflow attempt was running";
+const employee: Employee = { name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work." };
+const models: ModelRegistry = { "test-engine": { name: "test-engine", available: true, defaultModel: "test-model",
+  effortMechanism: "codex-config", models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }] } };
+
+class RestartExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  readonly sessions = new Map<string, string>();
+  terminalReader?: (sessionId: string) => WorkflowAttemptCompletion | null;
+  onStop?: () => Promise<void>;
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    const sessionId = `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+    this.sessions.set(`${command.owner.nodeId}:${command.owner.attempt}`, sessionId);
+    return { sessionId };
+  }
+  async stopAttempt(): Promise<void> { await this.onStop?.(); }
+  attemptState(): { idle: boolean; runningChildren: number } { return { idle: true, runningChildren: 0 }; }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener); return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(sessionId: string): WorkflowAttemptCompletion | null { return this.terminalReader?.(sessionId) ?? null; }
+  // Delegated to the real implementation: whether the killed session still holds
+  // a usable thread is the whole gate on carrying one forward.
+  resumableEngineSession(sessionId: string, engine: string): string | null { return resumableEngineSession(sessionId, engine); }
+
+  /** The completion a gateway restart leaves behind for the attempt that died with it. */
+  restart(nodeId: string, at: string): Promise<void> {
+    return this.deliver({ ...this.terminalOf(nodeId, at), outcome: "interrupted",
+      interruptionCause: "gateway-restart", error: RESTART_ERROR });
+  }
+  /** An engine turn that reported a transport fault of its own. */
+  fail(nodeId: string, at: string): Promise<void> {
+    return this.deliver({ ...this.terminalOf(nodeId, at), outcome: "failed", error: "Interactive turn failed: server_error" });
+  }
+  succeed(nodeId: string, at: string): Promise<void> {
+    return this.deliver({ ...this.terminalOf(nodeId, at), outcome: "succeeded", finalText: "Done.\n```jinn-output\n{}\n```" });
+  }
+  async deliver(event: WorkflowAttemptCompletion): Promise<void> {
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+  private terminalOf(nodeId: string, at: string): WorkflowAttemptCompletion {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    return { sessionId: this.sessions.get(`${nodeId}:${command.owner.attempt}`)!, owner: command.owner,
+      turn: 1, terminalVersion: 1, outcome: "interrupted", completedAt: at };
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: RestartExecutor;
+let service: WorkflowService;
+let now: Date;
+
+/** trigger → work → end. Omitting `attempts` authors NO retry on the node, so
+ *  the budget is whatever node-dispatch resolves as the default. */
+function definitionWith(id: string, attempts?: number): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({ ...created, nodes: [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "work", type: "employee", name: "work", config: { employee: { source: "fixed", value: "worker" },
+      prompt: "Run work.", timeoutMinutes: 180,
+      ...(attempts === undefined ? {} : { retry: { attempts, delaySeconds: 0, backoff: "fixed" as const } }) } },
+    { id: "done", type: "end", name: "Done", config: { result: "success" } },
+  ], edges: [
+    { id: "start-work", from: { nodeId: "start", port: "success" }, to: { nodeId: "work", port: "input" } },
+    { id: "work-done", from: { nodeId: "work", port: "success" }, to: { nodeId: "done", port: "input" } },
+  ] }, created.revision);
+  return repository.setEnabled(id, true, saved.revision);
+}
+
+function attemptsOf(definition: WorkflowDefinition, runId: string) {
+  return service.getRun(definition.id, runId)!.attempts.map((attempt) => ({ attempt: attempt.attempt, status: attempt.status }));
+}
+
+/**
+ * A phase session and its attempt left `running` by a gateway that died under
+ * them — the state a boot actually finds. `engineSessionId` is the thread that
+ * session still holds; omit it for one that holds nothing resumable.
+ */
+async function orphanRunningAttempt(definition: WorkflowDefinition, engineSessionId?: string):
+Promise<{ runId: string; sessionId: string }> {
+  const registry = await import("../../sessions/registry.js");
+  const created = repository.createRun({ workflowId: definition.id, input: {},
+    trigger: { nodeId: "start", kind: "manual", payload: {} } });
+  const key = `workflow:${definition.id}:${created.id}:work:1`;
+  const session = registry.getOrCreateWorkflowAttemptSession({
+    engine: "test-engine", source: "workflow", sourceRef: key, connector: "workflow", sessionKey: key,
+    employee: "worker", model: "test-model", effortLevel: "high", prompt: "Run work.",
+    workflowProvenance: { kind: "phase", workflowId: definition.id, workflowName: definition.id, runId: created.id,
+      triggerSource: "manual", phase: { nodeId: "work", name: "work", index: 1, round: 1, attempt: 1 } },
+  });
+  registry.updateSession(session.id, { status: "running" });
+  if (engineSessionId) registry.recordEngineSessionId(session.id, "test-engine", engineSessionId);
+  const detail = repository.getRun(definition.id, created.id)!;
+  // Resolved by the real dispatcher, so an unconfigured node carries exactly the
+  // budget node-dispatch gives it rather than one the fixture made up.
+  const config = resolveDispatch(detail, detail.definition.nodes.find((item) => item.id === "work") as EmployeeNode, {
+    repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models,
+  });
+  repository.mutateRun(detail.id, detail.revision, (tx) => {
+    tx.setRunStatus("running");
+    tx.setNodeStatus("start", "completed", { activated: true, startedAt: now.toISOString(), endedAt: now.toISOString() });
+    tx.setNodeStatus("work", "running", { activated: true, input: {}, startedAt: now.toISOString(),
+      resolvedConfig: config as unknown as Record<string, JsonValue> });
+    const attempt = tx.createAttempt({ nodeId: "work", resolvedConfig: config, input: {} });
+    tx.settleAttempt("work", attempt.attempt, { status: "running", sessionId: session.id });
+  });
+  const { WorkflowSessionExecutor: ReceiptReader } = await import("../session-executor.js");
+  const reader = new ReceiptReader({} as SessionManager, (id) => {
+    const stored = registry.getSession(id);
+    return stored ? { session: stored } : null;
+  });
+  executor.terminalReader = (id) => reader.readTerminalCompletion(id);
+  return { runId: created.id, sessionId: session.id };
+}
+
+/** Kill everything the old gateway was running, the way a boot does, then boot. */
+async function reboot(): Promise<void> {
+  const registry = await import("../../sessions/registry.js");
+  registry.recoverStaleWorkflowAttemptSessions();
+  await service.recover(now.toISOString());
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-restart-redispatch-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  now = new Date("2026-08-19T16:01:00.000Z");
+  repository = new WorkflowRepository(database, () => now.toISOString());
+  executor = new RestartExecutor();
+  service = new WorkflowService({ repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString() });
+});
+afterEach(() => { service.dispose(); database.close(); fs.rmSync(root, { recursive: true, force: true }); });
+afterAll(async () => {
+  (await import("../../shared/db.js")).__closeDbForTest();
+  fs.rmSync(sessionHome, { recursive: true, force: true });
+});
+
+describe("Replacing a workflow attempt a gateway restart killed", () => {
+  it("re-dispatches an attempt with NO retry budget left, and the run completes", async () => {
+    const definition = definitionWith("default-budget");
+    const { runId, sessionId } = await orphanRunningAttempt(definition, "engine-thread-1");
+
+    now = new Date("2026-08-19T16:05:00.000Z");
+    await reboot();
+
+    expect(service.getRun(definition.id, runId)!.attempts[0]!.resolvedConfig.retry)
+      .toEqual({ attempts: 1, delaySeconds: 0, backoff: "fixed" });
+    expect(service.getRun(definition.id, runId)!.status).not.toBe("failed");
+    expect(attemptsOf(definition, runId)).toEqual([
+      { attempt: 1, status: "cancelled" }, { attempt: 2, status: "running" },
+    ]);
+    expect(service.getRun(definition.id, runId)!.attempts[0]!.error)
+      .toMatchObject({ code: "workflow-attempt-restart-interrupted", message: RESTART_ERROR });
+    // The replacement picks up the thread the killed session still held.
+    expect(executor.commands.at(-1)).toMatchObject({ owner: { nodeId: "work", attempt: 2 },
+      continueFrom: { engine: "test-engine", engineSessionId: "engine-thread-1", sourceSessionId: sessionId } });
+
+    await executor.succeed("work", now.toISOString());
+    expect(service.getRun(definition.id, runId)!.status).toBe("completed");
+  });
+
+  it("dispatches the replacement cold when the killed session held no usable thread", async () => {
+    const definition = definitionWith("cold-replacement");
+    const { runId } = await orphanRunningAttempt(definition);
+
+    now = new Date("2026-08-19T16:05:00.000Z");
+    await reboot();
+
+    expect(executor.commands.at(-1)).toMatchObject({ owner: { nodeId: "work", attempt: 2 } });
+    expect(executor.commands.at(-1)!.continueFrom).toBeUndefined();
+    expect(attemptsOf(definition, runId)).toEqual([
+      { attempt: 1, status: "cancelled" }, { attempt: 2, status: "running" },
+    ]);
+  });
+
+  it("leaves the retry budget whole, so a genuine fault after the restart still retries", async () => {
+    const definition = definitionWith("budget-intact", 2);
+    const { runId } = await orphanRunningAttempt(definition);
+
+    now = new Date("2026-08-19T16:05:00.000Z");
+    await reboot();
+    expect(attemptsOf(definition, runId)).toHaveLength(2);
+
+    // The restart spent nothing, so this transport fault is the FIRST call on the
+    // two-attempt budget and still earns its own retry.
+    await executor.fail("work", now.toISOString());
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition, runId)).toEqual([
+      { attempt: 1, status: "cancelled" }, { attempt: 2, status: "failed" }, { attempt: 3, status: "running" },
+    ]);
+    expect(service.getRun(definition.id, runId)!.status).not.toBe("failed");
+  });
+
+  it("replays one terminal completion and one boot into exactly one replacement", async () => {
+    const definition = definitionWith("idempotent");
+    const { runId, sessionId } = await orphanRunningAttempt(definition);
+
+    now = new Date("2026-08-19T16:05:00.000Z");
+    const registry = await import("../../sessions/registry.js");
+    registry.recoverStaleWorkflowAttemptSessions();
+    const completion = executor.terminalReader!(sessionId)!;
+    await service.recover(now.toISOString());
+    // The same boot state read twice, and the same terminal event delivered
+    // again: neither may open a second replacement.
+    await service.recover(now.toISOString());
+    await executor.deliver(completion);
+
+    expect(attemptsOf(definition, runId)).toEqual([
+      { attempt: 1, status: "cancelled" }, { attempt: 2, status: "running" },
+    ]);
+  });
+
+  it("stops re-dispatching at the cap and fails the run truthfully", async () => {
+    const definition = definitionWith("restart-storm");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+
+    for (let boot = 0; boot < 6; boot += 1) {
+      if (service.getRun(definition.id, run.id)!.status === "failed") break;
+      await executor.restart("work", now.toISOString());
+    }
+
+    const stormed = service.getRun(definition.id, run.id)!;
+    expect(stormed.status).toBe("failed");
+    expect(stormed.error).toMatchObject({ code: "workflow-attempt-restart-exhausted", retryable: false });
+    expect(stormed.error!.message).toContain("4 gateway restarts");
+    // Every one of them was interrupted rather than judged, so they settle the
+    // way an interrupted attempt always has; the RUN is what fails.
+    expect(attemptsOf(definition, run.id).map((attempt) => attempt.status))
+      .toEqual(["cancelled", "cancelled", "cancelled", "cancelled"]);
+  });
+
+  it("settles the RUN, not just the attempt, when the gateway died inside the cancel", async () => {
+    const definition = definitionWith("cancel-crash-window");
+    const { runId } = await orphanRunningAttempt(definition);
+    // The window cancelRun opens: `cancelRequestedAt` is durable on the run row,
+    // and the gateway dies before the drain that would have settled it.
+    const detail = repository.getRun(definition.id, runId)!;
+    repository.mutateRun(detail.id, detail.revision, (tx) => tx.setRunStatus("running", { cancelRequestedAt: now.toISOString() }));
+
+    now = new Date("2026-08-19T16:05:00.000Z");
+    await reboot();
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("cancelled");
+    expect(attemptsOf(definition, runId)).toEqual([{ attempt: 1, status: "cancelled" }]);
+    expect(executor.commands).toHaveLength(0);
+
+    // And a second boot has nothing left to repair.
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition, runId)).toEqual([{ attempt: 1, status: "cancelled" }]);
+    expect(service.getRun(definition.id, runId)!.status).toBe("cancelled");
+  });
+
+  it("settles cancelled, never a replacement, when the run was cancelled first", async () => {
+    const definition = definitionWith("cancel-wins");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    // The restart lands mid-cancel, after `cancelRequestedAt` is durable: the
+    // operator's decision owns the attempt, not the gateway that died on it.
+    executor.onStop = () => executor.restart("work", now.toISOString());
+
+    const cancelled = await service.cancelRun({ workflowId: definition.id, runId: run.id, reason: "stop" });
+
+    expect(cancelled.status).toBe("cancelled");
+    expect(attemptsOf(definition, run.id)).toEqual([{ attempt: 1, status: "cancelled" }]);
+    expect(executor.commands.map((command) => command.owner.attempt)).toEqual([1]);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/retry-boundary.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/retry-boundary.test.ts
@@ -1,0 +1,294 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import { isTransportFailure, workflowError } from "../failure.js";
+import type { WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+/* A node's retry budget exists for attempts that never landed. Spending it on an
+ * employee that ran and reported failure pays twice for a verdict already
+ * reached — and once re-ran a phase that had deliberately refused to proceed,
+ * which then implemented and parked a merge gate for work already on main. */
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete the task.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  failStarts = 0;
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    if (this.failStarts > 0) { this.failStarts -= 1; throw new Error("engine spawn refused"); }
+    this.commands.push(command);
+    return { sessionId: `session:${command.owner.nodeId}:${command.owner.attempt}` };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null { return null; }
+  // No session registry behind these fixtures, so nothing is ever resumable and
+  // every replacement here dispatches cold.
+  resumableEngineSession(): string | null { return null; }
+  attemptState(): { idle: boolean; runningChildren: number } { return { idle: true, runningChildren: 0 }; }
+
+  /** An engine turn that reported an error — the one path whose only account of
+   *  itself is its message. */
+  async failTurn(nodeId: string, error: string): Promise<void> {
+    await this.emit(nodeId, { outcome: "failed", error });
+  }
+  /** An attempt killed under the runtime with no cause on the row — a legacy
+   *  interruption, which the classifier reads as an operator stopping it. */
+  async interrupt(nodeId: string, error: string): Promise<void> {
+    await this.emit(nodeId, { outcome: "interrupted", error });
+  }
+  /** An attempt the operator stopped; the session manager forces this cause. */
+  async stop(nodeId: string): Promise<void> {
+    await this.emit(nodeId, { outcome: "interrupted", interruptionCause: "attempt-stop", error: "Interrupted: stopped" });
+  }
+  /** An attempt killed by a gateway restart, named as such by the boot sweep. */
+  async restart(nodeId: string): Promise<void> {
+    await this.emit(nodeId, { outcome: "interrupted", interruptionCause: "gateway-restart",
+      error: "Interrupted: gateway restarted while workflow attempt was running" });
+  }
+  private async emit(nodeId: string,
+    outcome: Pick<WorkflowAttemptCompletion, "outcome" | "error" | "interruptionCause">): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    const event: WorkflowAttemptCompletion = {
+      sessionId: `session:${nodeId}:${command.owner.attempt}`, owner: command.owner,
+      terminalVersion: 1, turn: 1, completedAt: new Date("2026-07-30T10:00:00.000Z").toISOString(), ...outcome,
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let service: WorkflowService;
+const now = new Date("2026-07-30T10:00:00.000Z");
+
+function worker(id: string): WorkflowNode {
+  return {
+    id, type: "employee", name: id, config: {
+      employee: { source: "fixed", value: "worker" }, prompt: `Run ${id}.`,
+      retry: { attempts: 2, delaySeconds: 0, backoff: "fixed" },
+      output: { fields: {}, allowAdditionalFields: true },
+    },
+  };
+}
+
+/** trigger → work → end, `work` carrying a two-attempt retry budget. */
+function definitionWith(id: string): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({
+    ...created,
+    inputs: [],
+    nodes: [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      worker("work"),
+      { id: "done", type: "end", name: "Done", config: { result: "success" } },
+    ],
+    edges: [
+      { id: "start-work", from: { nodeId: "start", port: "success" }, to: { nodeId: "work", port: "input" } },
+      { id: "work-done", from: { nodeId: "work", port: "success" }, to: { nodeId: "done", port: "input" } },
+    ],
+  }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+function attemptsOf(workflowId: string, runId: string) {
+  return service.getRun(workflowId, runId)!.attempts.map((attempt) => attempt.attempt);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-retry-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  executor = new FakeExecutor();
+  service = new WorkflowService({
+    repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("isTransportFailure — the message-matched half of the boundary", () => {
+  it("accepts provider fault codes, 5xx in status context, and socket faults", () => {
+    expect(isTransportFailure("Interactive turn failed: server_error")).toBe(true);
+    expect(isTransportFailure("api_error")).toBe(true);
+    expect(isTransportFailure("overloaded_error: please retry")).toBe(true);
+    expect(isTransportFailure("HTTP 503 from upstream")).toBe(true);
+    expect(isTransportFailure("status: 502")).toBe(true);
+    expect(isTransportFailure("Bad Gateway")).toBe(true);
+    expect(isTransportFailure("connect ECONNRESET 1.2.3.4:443")).toBe(true);
+    expect(isTransportFailure("socket hang up")).toBe(true);
+    expect(isTransportFailure("fetch failed")).toBe(true);
+  });
+
+  it("refuses faults a retry cannot fix, and rate limits the manager already owns", () => {
+    expect(isTransportFailure("Interactive turn failed: rate_limit")).toBe(false);
+    expect(isTransportFailure("Interactive turn failed: billing_error")).toBe(false);
+    expect(isTransportFailure("Interactive turn failed: invalid_request")).toBe(false);
+    expect(isTransportFailure("Interactive turn failed: permission_error")).toBe(false);
+  });
+
+  it("refuses anything unrecognised — the default is deny, because guessing spends money", () => {
+    expect(isTransportFailure("the tests did not pass")).toBe(false);
+    expect(isTransportFailure("")).toBe(false);
+    // A bare number is not a status code. Matching one would retry a real failure
+    // whose summary happened to mention a count.
+    expect(isTransportFailure("503 files changed")).toBe(false);
+  });
+});
+
+describe("workflowError — a model id we got wrong is not a verdict on the work", () => {
+  // The live break: a tab-joined composite reached `--model`, the CLI refused it, and
+  // the attempt died `retryable: false` with its work already committed.
+  it("retries an engine that refused the model id it was handed", () => {
+    expect(workflowError(new Error("invalid model selection"), "build").retryable).toBe(true);
+  });
+
+  it("still refuses a verdict the employee actually reached", () => {
+    expect(workflowError(new Error("the tests did not pass"), "build").retryable).toBe(false);
+  });
+});
+
+describe("what earns a retry budget", () => {
+  it("does NOT retry a submitted failure — the employee ran and reported a verdict", async () => {
+    const definition = definitionWith("submitted-failure");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await service.submitAttemptOutput({
+      sessionId: "session:work:1", outcome: "failure",
+      summary: "Stopping: this work is already merged; advancing would run two pipelines in one worktree.",
+    });
+
+    const settled = service.getRun(definition.id, run.id)!;
+    expect(attemptsOf(definition.id, run.id)).toEqual([1]);
+    expect(settled.status).toBe("failed");
+    expect(settled.error).toMatchObject({ code: "workflow-submitted-failure", retryable: false });
+  });
+
+  it("retries an engine transport fault and consumes the budget", async () => {
+    const definition = definitionWith("transport-fault");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+
+    await executor.failTurn("work", "Interactive turn failed: server_error");
+    expect(service.getRun(definition.id, run.id)!.status).toBe("waiting");
+    await service.recover(now.toISOString()); // the wake the runner's timer performs live
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2]);
+
+    await executor.failTurn("work", "Interactive turn failed: server_error");
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2]);
+    expect(service.getRun(definition.id, run.id)!.status).toBe("failed");
+  });
+
+  it("does NOT retry an engine failure that is not a transport fault", async () => {
+    const definition = definitionWith("engine-verdict");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.failTurn("work", "Interactive turn failed: invalid_request");
+
+    expect(attemptsOf(definition.id, run.id)).toEqual([1]);
+    expect(service.getRun(definition.id, run.id)!.status).toBe("failed");
+  });
+
+  it("retries a dispatch that never reached a session, whatever its message says", async () => {
+    const definition = definitionWith("dispatch-throw");
+    executor.failStarts = 1;
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+
+    expect(service.getRun(definition.id, run.id)!.attempts[0]!.error)
+      .toMatchObject({ code: "workflow-dispatch-failed", retryable: true });
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2]);
+  });
+
+  it("retries an attempt interrupted with no recorded cause, and spends the budget", async () => {
+    const definition = definitionWith("restart-interrupt");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.interrupt("work", "Interrupted: gateway restarted while workflow attempt was running");
+
+    expect(service.getRun(definition.id, run.id)!.attempts[0]!.error)
+      .toMatchObject({ code: "workflow-attempt-interrupted", retryable: true });
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2]);
+
+    // The budget WAS spent: a stop is a decision about this attempt, so the
+    // second interruption exhausts it.
+    await executor.interrupt("work", "Interrupted: stopped");
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2]);
+    expect(service.getRun(definition.id, run.id)!.status).toBe("failed");
+  });
+
+  it("does NOT retry a forced attempt-stop — the operator decided about this attempt", async () => {
+    const definition = definitionWith("operator-stop");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.stop("work");
+
+    expect(service.getRun(definition.id, run.id)!.attempts[0])
+      .toMatchObject({ status: "cancelled", error: { code: "workflow-attempt-interrupted", retryable: false } });
+    // Two attempts were authored and one is untouched: a stop is a decision, and
+    // re-dispatching would overrule it.
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition.id, run.id)).toEqual([1]);
+    expect(service.getRun(definition.id, run.id)!.status).toBe("failed");
+  });
+
+  it("spends NO budget on a gateway restart — it replaces the attempt instead", async () => {
+    const definition = definitionWith("gateway-restart");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.restart("work");
+
+    expect(service.getRun(definition.id, run.id)!.attempts[0]!.error)
+      .toMatchObject({ code: "workflow-attempt-restart-interrupted", retryable: true });
+    // Replaced at once: no backoff to wake, so no recover() in between.
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2]);
+
+    // And the two-attempt budget is still whole for a fault that IS about the work.
+    await executor.failTurn("work", "Interactive turn failed: server_error");
+    await service.recover(now.toISOString());
+    expect(attemptsOf(definition.id, run.id)).toEqual([1, 2, 3]);
+  });
+
+  it("records the error as CLASSIFIED, never rewriting the flag to mean 'we retried'", async () => {
+    const definition = definitionWith("honest-flag");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.failTurn("work", "Interactive turn failed: server_error");
+    await service.recover(now.toISOString());
+    await executor.failTurn("work", "Interactive turn failed: server_error");
+
+    // Same fault, both attempts: the stored flag describes the ERROR, so it reads
+    // the same on the attempt that retried and the one that exhausted the budget.
+    expect(service.getRun(definition.id, run.id)!.attempts.map((attempt) => attempt.error?.retryable))
+      .toEqual([true, true]);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/run-spend-attribution.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/run-spend-attribution.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+import type { WorkflowTodoSessionLink } from "../runner.js";
+
+/* A run bound to a Todo must attribute what it spent to THAT Todo: every phase
+ * session is linked to it, so the Todo's derived spend covers the pipeline. */
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete the task.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: sessionIdFor(command.owner.nodeId, command.owner.attempt) };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null { return null; }
+  async succeed(nodeId: string, fields: Record<string, JsonValue>): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    const event: WorkflowAttemptCompletion = {
+      sessionId: sessionIdFor(nodeId, command.owner.attempt), owner: command.owner, terminalVersion: 1, turn: 1,
+      outcome: "succeeded", finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\``,
+      completedAt: new Date().toISOString(),
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+}
+
+function sessionIdFor(nodeId: string, attempt: number): string { return `session:${nodeId}:${attempt}`; }
+
+class RecordingLink implements WorkflowTodoSessionLink {
+  readonly links: Array<{ todoId: string; sessionId: string }> = [];
+  link(input: { todoId: string; sessionId: string }): void { this.links.push(input); }
+  // Spend attribution is what this suite is about; the run ledger has its own.
+  openRun(): void {}
+  closeRun(): void {}
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let todoSessions: RecordingLink;
+let service: WorkflowService;
+const now = new Date("2026-07-21T10:00:00.000Z");
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function employeeNode(id: string): WorkflowNode {
+  return {
+    id, type: "employee", name: id, config: {
+      employee: { source: "fixed", value: "worker" }, prompt: `Run ${id}.`,
+      output: { fields: { value: { type: "string", required: true } }, allowAdditionalFields: false },
+    },
+  };
+}
+
+/** trigger → plan → verify → end: two phases, so attribution must cover both. */
+function twoPhaseDefinition(id: string): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({
+    ...created,
+    inputs: [],
+    nodes: [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      employeeNode("plan"),
+      employeeNode("verify"),
+      { id: "done", type: "end", name: "Done", config: { result: "success" } },
+    ],
+    edges: [
+      edge("start-plan", "start", "success", "plan"),
+      edge("plan-verify", "plan", "success", "verify"),
+      edge("verify-done", "verify", "success", "done"),
+    ],
+  }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+function serviceWith(
+  link: WorkflowTodoSessionLink | undefined,
+  sessionSpend?: (sessionIds: string[]) => number,
+): WorkflowService {
+  return new WorkflowService({
+    repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models,
+    now: () => now.toISOString(),
+    ...(link ? { todoSessions: link } : {}),
+    ...(sessionSpend ? { sessionSpend } : {}),
+  });
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-spend-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  executor = new FakeExecutor();
+  todoSessions = new RecordingLink();
+  service = serviceWith(todoSessions);
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("attributing a run's spend to the Todo it is bound to", () => {
+  it("links EVERY phase session of a bound run to that Todo", async () => {
+    const definition = twoPhaseDefinition("bound-run");
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-1" });
+    expect(todoSessions.links).toEqual([{ todoId: "OPS-1", sessionId: "session:plan:1" }]);
+
+    await executor.succeed("plan", { value: "planned" });
+    expect(todoSessions.links).toEqual([
+      { todoId: "OPS-1", sessionId: "session:plan:1" },
+      { todoId: "OPS-1", sessionId: "session:verify:1" },
+    ]);
+
+    await executor.succeed("verify", { value: "verified" });
+    expect(service.getRun(definition.id, run.id)!.status).toBe("completed");
+  });
+
+  it("links nothing when the run is not bound to a Todo", async () => {
+    const definition = twoPhaseDefinition("unbound-run");
+    await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.succeed("plan", { value: "planned" });
+    expect(todoSessions.links).toEqual([]);
+  });
+
+  it("sums the costs of every attempt session in the run", async () => {
+    service.dispose();
+    const costs = new Map([
+      ["session:plan:1", 1.25],
+      ["session:verify:1", 0.75],
+    ]);
+    const seen: string[][] = [];
+    service = serviceWith(undefined, (sessionIds) => {
+      seen.push(sessionIds);
+      return sessionIds.reduce((sum, id) => sum + (costs.get(id) ?? 0), 0);
+    });
+    const definition = twoPhaseDefinition("costed-run");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.succeed("plan", { value: "planned" });
+
+    expect(service.getRunSpend(definition.id, run.id)).toBe(2);
+    expect(seen).toEqual([["session:plan:1", "session:verify:1"]]);
+  });
+
+  it("runs the workflow to completion when the bound Todo no longer exists", async () => {
+    service.dispose();
+    service = serviceWith({
+      link: ({ todoId }) => { throw new Error(`linkSession: work item ${todoId} not found`); },
+      openRun: () => {}, closeRun: () => {},
+    });
+    const definition = twoPhaseDefinition("missing-todo");
+    const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "OPS-404" });
+    expect(run.status).toBe("running");
+
+    await executor.succeed("plan", { value: "planned" });
+    await executor.succeed("verify", { value: "verified" });
+    const final = service.getRun(definition.id, run.id)!;
+    expect(final.status).toBe("completed");
+    expect(final.attempts.every((attempt) => attempt.status === "completed")).toBe(true);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/runtime.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/runtime.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { JsonPrimitive, JsonValue, WorkflowDefinition, WorkflowNodeOutput } from '../model.js';
+import type {
+  ResolvedEmployeeConfig,
+  WorkflowApprovalRecord,
+  WorkflowAttemptRecord,
+  WorkflowAttemptStatus,
+  WorkflowError,
+  WorkflowNodeRunRecord,
+  WorkflowNodeRunStatus,
+  WorkflowRunDetail,
+  WorkflowRunRecord,
+  WorkflowRunStatus,
+} from '../runtime.js';
+
+const startedAt = '2026-07-20T00:00:00.000Z';
+
+function definition(): WorkflowDefinition {
+  return {
+    schemaVersion: 1,
+    id: 'example-workflow',
+    title: 'Example workflow',
+    revision: 1,
+    enabled: false,
+    nodes: [],
+    edges: [],
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+}
+
+describe('canonical runtime and record types', () => {
+  it('exports every locked runtime record shape', () => {
+    const primitive: JsonPrimitive = null;
+    const json: JsonValue = { primitive, list: [true, 1, 'value'] };
+    const output: WorkflowNodeOutput = { text: 'Done.', fields: { result: json }, employeeId: 'worker', sessionId: 'session-1' };
+    const resolved: ResolvedEmployeeConfig = {
+      employeeId: 'worker',
+      engine: 'codex',
+      model: 'model-name',
+      effort: 'high',
+      retry: { attempts: 1, delaySeconds: 0, backoff: 'fixed' },
+      timeoutMinutes: 30,
+    };
+    const error: WorkflowError = { code: 'attempt-failed', message: 'Attempt failed.', retryable: true, nodeId: 'work', attempt: 1, details: { reason: 'test' } };
+    const run: WorkflowRunRecord = {
+      id: 'run-1', workflowId: 'example-workflow', workflowTitle: 'Example workflow', definitionRevision: 1,
+      definition: definition(), input: { topic: 'release' },
+      trigger: { nodeId: 'start', kind: 'manual', payload: {} }, status: 'running', revision: 1,
+      startedAt,
+    };
+    const nodeRun: WorkflowNodeRunRecord = {
+      runId: run.id, nodeId: 'work', nodeType: 'employee', status: 'running', activated: true,
+      resolvedConfig: { employeeId: resolved.employeeId }, input: run.input,
+    };
+    const attempt: WorkflowAttemptRecord = {
+      runId: run.id, nodeId: 'work', attempt: 1, status: 'running', resolvedConfig: resolved,
+      input: run.input, startedAt: run.startedAt, remindersSent: 0, stopNudgesSent: 0, extensions: 0,
+      lastProcessedTurn: 0,
+    };
+    const approval: WorkflowApprovalRecord = {
+      runId: run.id, nodeId: 'approve', status: 'approved', requestedAt: run.startedAt,
+      decidedAt: run.startedAt, decidedBy: 'operator', decision: 'approve', reason: 'Looks good.',
+    };
+    const detail: WorkflowRunDetail = { ...run, nodeRuns: [nodeRun], attempts: [attempt], approvals: [approval], childRuns: [] };
+
+    expect(detail).toMatchObject({ id: 'run-1', status: 'running' });
+    expect(output.fields.result).toEqual(json);
+    expect(error.retryable).toBe(true);
+  });
+
+  it('exports the locked status unions', () => {
+    expectTypeOf<WorkflowRunStatus>().toEqualTypeOf<'pending' | 'running' | 'waiting' | 'completed' | 'failed' | 'cancelled'>();
+    expectTypeOf<WorkflowNodeRunStatus>().toEqualTypeOf<'pending' | 'ready' | 'dispatching' | 'running' | 'waiting' | 'completed' | 'failed' | 'skipped' | 'cancelled'>();
+    expectTypeOf<WorkflowAttemptStatus>().toEqualTypeOf<'dispatching' | 'running' | 'completed' | 'failed' | 'timed-out' | 'cancelled'>();
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/service-validation.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/service-validation.test.ts
@@ -1,0 +1,335 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletionListener } from "../../shared/types.js";
+import type { Binding, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository, WorkflowRepositoryError } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService, WorkflowServiceError } from "../service.js";
+
+class Executor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: `session:${command.owner.runId}:${command.owner.nodeId}` };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+}
+
+const trigger: WorkflowNode = { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } };
+const scheduleTrigger: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "schedule", cron: "0 * * * *", timezone: "UTC" } };
+const eventTrigger: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "event", eventName: "build.finished" } };
+const poisonSchedule: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "schedule", cron: "every weekday please", timezone: "UTC" } };
+const todoTrigger: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "todo-status", status: "assigned" } };
+const commentWait: WorkflowNode = { id: "hold", type: "wait", name: "Ask operator",
+  config: { mode: "todo-comment", timeoutMinutes: 60 } };
+const todoStatusTrigger: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "todo-status", status: "in_review", label: "build" } };
+const conflictingTodoFilters: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "todo-status", status: "in_review", label: "build", unlabeled: true } };
+const finish: WorkflowNode = { id: "finish", type: "end", name: "Finish", config: { result: "success" } };
+const employee: Employee = { name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work." };
+const models: ModelRegistry = { "test-engine": { name: "test-engine", available: true, defaultModel: "test-model",
+  effortMechanism: "codex-config", models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }] } };
+const edge = (id: string, from: string, to: string) => ({
+  id,
+  from: { nodeId: from, port: "success" as const },
+  to: { nodeId: to, port: "input" as const },
+});
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: Executor;
+let definitionChanges: Array<{ workflowId: string; revision: number }>;
+let runChanges: Array<{ workflowId: string; runId: string }>;
+let service: WorkflowService;
+
+function save(id: string, nodes: WorkflowNode[], edges: ReturnType<typeof edge>[]): WorkflowDefinition {
+  const created = service.createDefinition({ id, title: id });
+  definitionChanges.length = 0;
+  return service.saveDefinition({ ...created, nodes, edges }, created.revision);
+}
+
+function worker(employee: Binding<string> = { source: "fixed", value: "worker" }): WorkflowNode {
+  return { id: "work", type: "employee", name: "Work", config: { employee, prompt: "Do work." } };
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-service-validation-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => "2026-07-22T10:00:00.000Z");
+  executor = new Executor();
+  definitionChanges = [];
+  runChanges = [];
+  service = new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    onDefinitionChange: (change) => definitionChanges.push(change),
+    onChange: (change) => runChanges.push(change),
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("Workflow executable service boundaries", () => {
+  it("refuses a fixed self-targeting workflow-call before saving the draft", () => {
+    const created = service.createDefinition({ id: "self-call", title: "Self call" });
+    const call: WorkflowNode = { id: "children", type: "workflow-call", name: "Children", config: {
+      workflowId: { source: "fixed", value: created.id }, concurrency: 2,
+    } };
+    const draft = { ...created, nodes: [trigger, call, finish], edges: [
+      edge("start-call", "start", "children"), edge("call-finish", "children", "finish"),
+    ] };
+
+    expect(() => service.saveDefinition(draft, created.revision)).toThrow(expect.objectContaining({
+      code: "invalid-definition",
+      issues: [expect.objectContaining({ code: "workflow-call-self-reference", nodeId: "children" })],
+    }));
+    expect(repository.getDefinition(created.id)).toEqual(created);
+  });
+
+  it("rejects zero-node enable without changing the stored definition", () => {
+    const created = service.createDefinition({ id: "empty-flow", title: "Empty flow" });
+    definitionChanges.length = 0;
+    let caught: unknown;
+
+    expect(() => service.setEnabled({ id: created.id, enabled: true, expectedRevision: created.revision + 1 }))
+      .toThrow(expect.objectContaining<Partial<WorkflowRepositoryError>>({ code: "revision-conflict" }));
+    try { service.setEnabled({ id: created.id, enabled: true, expectedRevision: created.revision }); }
+    catch (error) { caught = error; }
+
+    expect(caught).toEqual(new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", [
+      { code: "missing-end-path", message: "A Trigger must have a directed path to an End." },
+      { code: "trigger-count", message: "Workflow must contain at least one Trigger." },
+    ]));
+    expect(repository.getDefinition(created.id)).toEqual(created);
+    expect(definitionChanges).toEqual([]);
+    expect(service.listRuns(created.id, {}).items).toEqual([]);
+    expect(executor.commands).toEqual([]);
+    expect(runChanges).toEqual([]);
+  });
+
+  it("rejects manual-trigger-only run before creating a run or dispatching a session", async () => {
+    const saved = save("manual-only", [trigger], []);
+    const enabled = repository.setEnabled(saved.id, true, saved.revision);
+    definitionChanges.length = 0;
+    let caught: unknown;
+
+    try { await service.startManual({ workflowId: enabled.id, input: {} }); }
+    catch (error) { caught = error; }
+
+    expect(caught).toEqual(new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", [
+      { code: "dead-node", message: "Reachable non-End node has no path to an End.", nodeId: "start" },
+      { code: "missing-end-path", message: "A Trigger must have a directed path to an End." },
+    ]));
+    expect(service.listRuns(enabled.id, {}).items).toEqual([]);
+    expect(executor.commands).toEqual([]);
+    expect(runChanges).toEqual([]);
+    expect(repository.getDefinition(enabled.id)).toEqual(enabled);
+  });
+
+  it("validates an enabled revision that deleted its Manual trigger before requiring that trigger", async () => {
+    const authored = save("deleted-manual", [trigger, finish], [edge("start-finish", "start", "finish")]);
+    const enabled = service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision });
+    const revised = service.saveDefinition({ ...enabled, nodes: [finish], edges: [] }, enabled.revision);
+    definitionChanges.length = 0;
+
+    await expect(service.startManual({ workflowId: revised.id, input: {} })).rejects.toEqual(
+      new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", [
+        { code: "unreachable-node", message: "Node is not reachable from a Trigger.", nodeId: "finish" },
+        { code: "missing-end-path", message: "A Trigger must have a directed path to an End." },
+        { code: "trigger-count", message: "Workflow must contain at least one Trigger." },
+      ]),
+    );
+    expect(revised).toMatchObject({ enabled: true, revision: enabled.revision + 1 });
+    expect(repository.getDefinition(revised.id)).toEqual(revised);
+    expect(definitionChanges).toEqual([]);
+    expect(service.listRuns(revised.id, {}).items).toEqual([]);
+    expect(executor.commands).toEqual([]);
+    expect(runChanges).toEqual([]);
+  });
+
+  it.each([
+    ["Schedule", scheduleTrigger],
+    ["Event", eventTrigger],
+  ])("keeps valid %s-only workflows executable before returning the no-Manual-trigger error", async (label, authoredTrigger) => {
+    const authored = save(`valid-${label.toLowerCase()}`, [authoredTrigger, finish], [edge("start-finish", "start", "finish")]);
+    const enabled = service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision });
+    definitionChanges.length = 0;
+
+    await expect(service.startManual({ workflowId: enabled.id, input: {} })).rejects.toEqual(
+      new WorkflowRepositoryError("bad-input", "Workflow does not have an enabled manual trigger."),
+    );
+    expect(repository.getDefinition(enabled.id)).toEqual(enabled);
+    expect(definitionChanges).toEqual([]);
+    expect(service.listRuns(enabled.id, {}).items).toEqual([]);
+    expect(executor.commands).toEqual([]);
+    expect(runChanges).toEqual([]);
+  });
+
+  it("keeps disabled and absent workflow manual-start errors unchanged", async () => {
+    const disabled = save("disabled-flow", [trigger, finish], [edge("start-finish", "start", "finish")]);
+    definitionChanges.length = 0;
+
+    for (const workflowId of [disabled.id, "missing-flow"]) {
+      await expect(service.startManual({ workflowId, input: {} })).rejects.toEqual(
+        new WorkflowRepositoryError("bad-input", "Workflow does not have an enabled manual trigger."),
+      );
+    }
+    expect(repository.getDefinition(disabled.id)).toEqual(disabled);
+    expect(definitionChanges).toEqual([]);
+    expect(service.listRuns(disabled.id, {}).items).toEqual([]);
+    expect(executor.commands).toEqual([]);
+    expect(runChanges).toEqual([]);
+  });
+
+  it("preserves canonical field issue order, path, code, and message", () => {
+    const authored = save("invalid-field", [
+      trigger,
+      worker({ source: "input", path: "assignee" }),
+      finish,
+    ], [edge("start-work", "start", "work"), edge("work-finish", "work", "finish")]);
+    const expected = [{
+      code: "undeclared-input",
+      message: "Input binding references an undeclared Workflow input.",
+      nodeId: "work",
+      path: "nodes.1.config.employee",
+    }];
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      let caught: unknown;
+      try { service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision }); }
+      catch (error) { caught = error; }
+      expect(caught).toEqual(new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", expected));
+    }
+    expect(repository.getDefinition(authored.id)).toEqual(authored);
+    expect(definitionChanges).toEqual([{ workflowId: authored.id, revision: authored.revision }]);
+  });
+
+  it("refuses an unparseable Schedule cron expression on save and on enable", () => {
+    const created = service.createDefinition({ id: "poison-schedule", title: "Poison schedule" });
+    const poison = { ...created, nodes: [poisonSchedule, finish], edges: [edge("start-finish", "start", "finish")] };
+    const expected = new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.",
+      [{ code: "invalid-schedule", message: "schedule must be a valid cron expression", nodeId: "start", path: "config.cron" }]);
+    definitionChanges.length = 0;
+    let saveError: unknown;
+    let enableError: unknown;
+
+    try { service.saveDefinition(poison, created.revision); } catch (error) { saveError = error; }
+    expect(saveError).toEqual(expected);
+    expect(repository.getDefinition(created.id)).toEqual(created);
+
+    // Seeded past the gate, exactly as a row authored before it existed would be.
+    const stored = repository.saveDefinition(poison, created.revision);
+    try { service.setEnabled({ id: stored.id, enabled: true, expectedRevision: stored.revision }); }
+    catch (error) { enableError = error; }
+
+    expect(enableError).toEqual(expected);
+    expect(repository.getDefinition(stored.id)).toMatchObject({ enabled: false, revision: stored.revision });
+    expect(definitionChanges).toEqual([]);
+  });
+
+  it("refuses a conflicting unlabeled+label revision of an already-enabled todo-status Workflow", () => {
+    const authored = save("todo-filters", [todoStatusTrigger, finish], [edge("start-finish", "start", "finish")]);
+    const enabled = service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision });
+    definitionChanges.length = 0;
+    let caught: unknown;
+
+    try {
+      service.saveDefinition({ ...enabled, nodes: [conflictingTodoFilters, finish] }, enabled.revision);
+    } catch (error) { caught = error; }
+
+    expect(caught).toEqual(new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", [{
+      code: "conflicting-todo-filters",
+      message: "A todo-status trigger cannot set both unlabeled and label: a Todo carrying no labels"
+        + " can never carry the one named. Set only one.",
+      nodeId: "start",
+      path: "nodes.0.config.unlabeled",
+    }]));
+    expect(repository.getDefinition(enabled.id)).toEqual(enabled);
+    expect(definitionChanges).toEqual([]);
+  });
+
+  it("cannot carry a Schedule trigger into createDefinition in the first place", () => {
+    expect(() => service.createDefinition(
+      { id: "created-with-nodes", title: "Created", nodes: [poisonSchedule] } as unknown as { id: string; title: string },
+    )).toThrow(expect.objectContaining<Partial<WorkflowRepositoryError>>({ code: "bad-input" }));
+    expect(repository.getDefinition("created-with-nodes")).toBeNull();
+  });
+
+  it("keeps valid enable, revision conflicts, and manual dispatch behavior unchanged", async () => {
+    const authored = save("valid-flow", [trigger, worker(), finish], [
+      edge("start-work", "start", "work"),
+      edge("work-finish", "work", "finish"),
+    ]);
+
+    expect(() => service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision + 1 }))
+      .toThrow(expect.objectContaining<Partial<WorkflowRepositoryError>>({ code: "revision-conflict" }));
+    expect(repository.getDefinition(authored.id)).toEqual(authored);
+    const enabled = service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision });
+    expect(enabled).toMatchObject({ enabled: true, revision: authored.revision + 1 });
+
+    const run = await service.startManual({ workflowId: enabled.id, input: {}, idempotencyKey: "valid-1" });
+    const replay = await service.startManual({ workflowId: enabled.id, input: {}, idempotencyKey: "valid-1" });
+    expect(run).toMatchObject({ workflowId: enabled.id, status: "running", definitionRevision: enabled.revision });
+    expect(replay.id).toBe(run.id);
+    expect(service.listRuns(enabled.id, {}).items).toHaveLength(1);
+    expect(executor.commands).toHaveLength(1);
+  });
+
+  it.each([["schedule", scheduleTrigger], ["event", eventTrigger]] as const)(
+    "refuses to save a Todo-comment Wait that only a %s Trigger reaches", (_kind, poisonTrigger) => {
+      const created = service.createDefinition({ id: `${_kind}-comment-wait`, title: "Comment wait" });
+      const poison = { ...created, nodes: [poisonTrigger, commentWait, finish],
+        edges: [edge("start-hold", "start", "hold"), edge("hold-finish", "hold", "finish")] };
+
+      let saveError: unknown;
+      try { service.saveDefinition(poison, created.revision); } catch (error) { saveError = error; }
+      expect(saveError).toEqual(new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", [{
+        code: "todo-comment-wait-trigger",
+        message: "A Wait node that waits for a Todo comment must be reachable from a Trigger that binds a Todo.",
+        nodeId: "hold", path: "nodes.1.config.mode",
+      }]));
+      expect(repository.getDefinition(created.id)).toEqual(created);
+    });
+
+  it("saves and enables a Todo-comment Wait behind a todo-status Trigger", () => {
+    const authored = save("todo-comment-wait", [todoTrigger, commentWait, finish], [
+      edge("start-hold", "start", "hold"),
+      edge("hold-finish", "hold", "finish"),
+    ]);
+
+    expect(service.setEnabled({ id: authored.id, enabled: true, expectedRevision: authored.revision }))
+      .toMatchObject({ enabled: true });
+  });
+
+  it("leaves a disconnected Todo-comment Wait draft saveable", () => {
+    const authored = save("draft-comment-wait", [scheduleTrigger, worker(), commentWait, finish], [
+      edge("start-work", "start", "work"),
+      edge("work-finish", "work", "finish"),
+    ]);
+
+    expect(authored.nodes.map((node) => node.id)).toContain("hold");
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/session-started-runs.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/session-started-runs.test.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue, TriggerNode, WorkflowDefinition } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { ResolvedEmployeeConfig, WorkflowRunDetail } from "../runtime.js";
+import { assertCallableCaller } from "../session-caller.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+const NOW = "2026-08-18T12:00:00.000Z";
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class Executor {
+  readonly stopped: string[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    return { sessionId: attemptSession(command.owner.runId) };
+  }
+  async stopAttempt(input: { sessionId: string }): Promise<void> { this.stopped.push(input.sessionId); }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: Executor;
+let service: WorkflowService;
+
+/** Every Workflow here has the same shape, so a run's only attempt session is
+ *  addressable from its run id alone. */
+function attemptSession(runId: string): string { return `session:${runId}:work`; }
+
+function save(id: string, trigger: TriggerNode["config"] = { kind: "manual" }): WorkflowDefinition {
+  const created = service.createDefinition({ id, title: id });
+  const saved = service.saveDefinition({ ...created, nodes: [
+    { id: "start", type: "trigger", name: "Start", config: trigger },
+    { id: "work", type: "employee", name: "Work", config: {
+      employee: { source: "fixed", value: "worker" }, prompt: "Do the work.",
+    } },
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+  ], edges: [
+    { id: "start-work", from: { nodeId: "start", port: "success" }, to: { nodeId: "work", port: "input" } },
+    { id: "work-finish", from: { nodeId: "work", port: "success" }, to: { nodeId: "finish", port: "input" } },
+  ] }, created.revision);
+  return service.setEnabled({ id, enabled: true, expectedRevision: saved.revision });
+}
+
+/** A run sitting on a live attempt of its Employee node, whose trigger payload
+ *  carries a `caller` key — ancestry on a manual fire, business data on an event. */
+function runWithCallerPayload(definition: WorkflowDefinition, config: ResolvedEmployeeConfig,
+  caller: JsonValue, kind: "manual" | "event"): string {
+  const created = repository.createRun({ workflowId: definition.id, input: {},
+    trigger: { nodeId: "start", kind, payload: { caller } } });
+  const run = repository.getRun(definition.id, created.id)!;
+  repository.mutateRun(run.id, run.revision, (tx) => {
+    tx.setNodeStatus("work", "running", { activated: true, startedAt: NOW });
+    const attempt = tx.createAttempt({ nodeId: "work", resolvedConfig: config, input: {} });
+    tx.settleAttempt("work", attempt.attempt, { status: "running", sessionId: attemptSession(run.id) });
+  });
+  return run.id;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-session-started-runs-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => NOW);
+  executor = new Executor();
+  service = new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => NOW,
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("Workflow runs started from an attempt session", () => {
+  it("refuses a run of the Workflow the calling attempt is itself running", async () => {
+    const alpha = save("alpha-flow");
+    const run = await service.startManual({ workflowId: alpha.id, input: {} });
+
+    await expect(service.startManual({
+      workflowId: alpha.id, input: {}, callerSessionId: attemptSession(run.id),
+    })).rejects.toMatchObject({ code: "bad-input", message: "Workflow call recursion is not allowed." });
+    expect(service.listRuns(alpha.id, {}).items).toHaveLength(1);
+  });
+
+  it("walks the ancestry through a session-started hop, not only Workflow Calls", async () => {
+    const alpha = save("alpha-flow");
+    const beta = save("beta-flow");
+    const alphaRun = await service.startManual({ workflowId: alpha.id, input: {} });
+    const betaRun = await service.startManual({
+      workflowId: beta.id, input: {}, callerSessionId: attemptSession(alphaRun.id),
+    });
+
+    await expect(service.startManual({
+      workflowId: alpha.id, input: {}, callerSessionId: attemptSession(betaRun.id),
+    })).rejects.toMatchObject({ code: "bad-input", message: "Workflow call recursion is not allowed." });
+  });
+
+  it("refuses an ancestry that loops back on itself", async () => {
+    const chain = save("chain-flow");
+    const target = save("target-flow");
+    const seed = await service.startManual({ workflowId: chain.id, input: {} });
+    const resolvedConfig = service.getRun(chain.id, seed.id)!.attempts[0]!.resolvedConfig;
+    const first = repository.createRun({ workflowId: chain.id, input: {},
+      trigger: { nodeId: "start", kind: "manual", payload: {} } }).id;
+    const second = runWithCallerPayload(chain, resolvedConfig,
+      { workflowId: chain.id, runId: first, nodeId: "work" }, "manual");
+
+    // `createRun` mints its own run id, so no run can name a successor at the
+    // moment it is written. The loop is closed over the read instead — the shape
+    // a hand-edited or half-restored ledger would hand the guard.
+    const looped: Parameters<typeof assertCallableCaller>[0] = {
+      findAttemptBySessionId: (sessionId) => repository.findAttemptBySessionId(sessionId),
+      listRecoverableRuns: () => repository.listRecoverableRuns(),
+      getRun: (workflowId, runId): WorkflowRunDetail | null => {
+        const run = repository.getRun(workflowId, runId);
+        if (!run || run.id !== first) return run;
+        return { ...run, trigger: { ...run.trigger,
+          payload: { caller: { workflowId: chain.id, runId: second, nodeId: "work" } } } };
+      },
+    };
+
+    expect(() => assertCallableCaller(looped, target.id,
+      { workflowId: chain.id, runId: second, nodeId: "work" }))
+      .toThrow("Workflow caller ancestry contains a cycle.");
+  });
+
+  it("refuses an ancestry nested deeper than the cap", async () => {
+    const chain = save("chain-flow");
+    const target = save("target-flow");
+    const seed = await service.startManual({ workflowId: chain.id, input: {} });
+    const resolvedConfig = service.getRun(chain.id, seed.id)!.attempts[0]!.resolvedConfig;
+    let runId = seed.id;
+    for (let depth = 0; depth < 129; depth += 1) {
+      const caller = { workflowId: chain.id, runId, nodeId: "work" };
+      runId = repository.createRun({ workflowId: chain.id, input: {},
+        trigger: { nodeId: "start", kind: "manual", payload: { caller } } }).id;
+    }
+    const leaf = repository.getRun(chain.id, runId)!;
+    repository.mutateRun(leaf.id, leaf.revision, (tx) => {
+      tx.setNodeStatus("work", "running", { activated: true, startedAt: NOW });
+      const attempt = tx.createAttempt({ nodeId: "work", resolvedConfig, input: {} });
+      tx.settleAttempt("work", attempt.attempt, { status: "running", sessionId: attemptSession(leaf.id) });
+    });
+
+    await expect(service.startManual({
+      workflowId: target.id, input: {}, callerSessionId: attemptSession(leaf.id),
+    })).rejects.toMatchObject({ code: "bad-input", message: "Workflow caller ancestry is too deep." });
+  }, 30_000);
+
+  it("links a sanctioned spawn under the calling node and cancels it with the parent", async () => {
+    const alpha = save("alpha-flow");
+    const beta = save("beta-flow");
+    const alphaRun = await service.startManual({ workflowId: alpha.id, input: {} });
+    const betaRun = await service.startManual({
+      workflowId: beta.id, input: {}, callerSessionId: attemptSession(alphaRun.id),
+    });
+
+    // The spawn is still running, so its session comes off its own attempt row rather than a node output.
+    expect(service.getRun(alpha.id, alphaRun.id)!.childRuns).toEqual([{
+      runId: betaRun.id, workflowId: beta.id, nodeId: "work", status: "running", startedAt: NOW,
+      sessionId: attemptSession(betaRun.id),
+    }]);
+
+    await service.cancelRun({ workflowId: alpha.id, runId: alphaRun.id, reason: "Parent stopped." });
+
+    expect(service.getRun(beta.id, betaRun.id)!.status).toBe("cancelled");
+  });
+
+  it("does not mistake an event payload's own caller field for ancestry", async () => {
+    const alpha = save("alpha-flow");
+    const beta = save("beta-flow");
+    const events = save("event-flow", { kind: "event", eventName: "thing.happened" });
+    const seed = await service.startManual({ workflowId: alpha.id, input: {} });
+    const config = service.getRun(alpha.id, seed.id)!.attempts[0]!.resolvedConfig;
+    const fired = runWithCallerPayload(events, config,
+      { workflowId: alpha.id, runId: "run_11111111-2222-4333-8444-555555555555", nodeId: "work" }, "event");
+
+    const spawned = await service.startManual({
+      workflowId: beta.id, input: {}, callerSessionId: attemptSession(fired),
+    });
+
+    expect(service.getRun(events.id, fired)!.childRuns.map((child) => child.runId)).toEqual([spawned.id]);
+  });
+
+  it("does not list an event-fired run as a child of the run its payload names", async () => {
+    const alpha = save("alpha-flow");
+    const events = save("event-flow", { kind: "event", eventName: "thing.happened" });
+    const parent = await service.startManual({ workflowId: alpha.id, input: {} });
+    const config = service.getRun(alpha.id, parent.id)!.attempts[0]!.resolvedConfig;
+
+    runWithCallerPayload(events, config, { workflowId: alpha.id, runId: parent.id, nodeId: "work" }, "event");
+
+    expect(service.getRun(alpha.id, parent.id)!.childRuns).toEqual([]);
+  });
+
+  it("leaves a run started outside an attempt exactly as it was", async () => {
+    const alpha = save("alpha-flow");
+    const lookup = vi.spyOn(repository, "findAttemptBySessionId");
+
+    const operator = await service.startManual({ workflowId: alpha.id, input: {} });
+    expect(lookup).not.toHaveBeenCalled();
+    expect(operator.trigger).toEqual({ nodeId: "start", kind: "manual", payload: {} });
+
+    const outsider = await service.startManual({
+      workflowId: alpha.id, input: {}, callerSessionId: "session-of-nobody", todoId: "PLA-1",
+    });
+    expect(outsider.trigger).toEqual({ nodeId: "start", kind: "manual", payload: {}, todoId: "PLA-1" });
+    expect(service.getRun(alpha.id, operator.id)!.childRuns).toEqual([]);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/stop-nudge.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/stop-nudge.test.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import { STOP_NUDGE_TEXT } from "../../sessions/stop-nudge.js";
+import type { WorkflowDefinition, WorkflowOutputSchema } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+/** Ordinary progress talk — the case the nudge exists for. It submits nothing,
+ *  claims no terminal state, and asks the caller nothing. */
+const NARRATION = "I am reviewing the remaining files now.";
+
+const employee: Employee = {
+  name: "worker",
+  displayName: "Worker",
+  department: "operations",
+  rank: "employee",
+  engine: "test-engine",
+  model: "test-model",
+  effortLevel: "high",
+  persona: "Complete the workflow step.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine",
+    available: true,
+    defaultModel: "test-model",
+    effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  readonly reminders: Array<{ sessionId: string; text: string }> = [];
+  remindError: Error | undefined;
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+  private readonly turns = new Map<string, number>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: this.sessionId(command) };
+  }
+  async stopAttempt(): Promise<void> {}
+  async remind(input: { sessionId: string; text: string }): Promise<void> {
+    if (this.remindError) throw this.remindError;
+    this.reminders.push(input);
+  }
+  attemptState(): { idle: boolean; runningChildren: number } {
+    return { idle: true, runningChildren: 0 };
+  }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null {
+    return null;
+  }
+  async turnEnd(finalText: string): Promise<void> {
+    const command = this.commands.at(-1)!;
+    const sessionId = this.sessionId(command);
+    const turn = (this.turns.get(sessionId) ?? 0) + 1;
+    this.turns.set(sessionId, turn);
+    await Promise.all([...this.listeners].map((listener) => listener({
+      sessionId,
+      owner: command.owner,
+      turn,
+      terminalVersion: 1,
+      outcome: "succeeded",
+      finalText,
+      completedAt: now,
+    })));
+  }
+  sessionId(command = this.commands.at(-1)!): string {
+    return `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let service: WorkflowService;
+let now: string;
+
+function saveDefinition(id: string, output?: WorkflowOutputSchema): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({
+    ...created,
+    nodes: [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      {
+        id: "work",
+        type: "employee",
+        name: "Work",
+        config: {
+          employee: { source: "fixed", value: "worker" },
+          prompt: "Complete the work.",
+          ...(output ? { output } : {}),
+          retry: { attempts: 1, delaySeconds: 0, backoff: "fixed" },
+        },
+      },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ],
+    edges: [
+      { id: "start-work", from: { nodeId: "start", port: "success" }, to: { nodeId: "work", port: "input" } },
+      { id: "work-finish", from: { nodeId: "work", port: "success" }, to: { nodeId: "finish", port: "input" } },
+    ],
+  }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+async function start(id: string, output?: WorkflowOutputSchema) {
+  const definition = saveDefinition(id, output);
+  const run = await service.startManual({ workflowId: definition.id, input: {} });
+  return { definition, run, sessionId: executor.sessionId() };
+}
+
+function attempt(definitionId: string, runId: string) {
+  return service.getRun(definitionId, runId)?.attempts[0];
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-stop-nudge-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  now = "2026-07-21T10:00:00.000Z";
+  repository = new WorkflowRepository(database, () => now);
+  executor = new FakeExecutor();
+  service = new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => now,
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("stop nudge at turn end", () => {
+  it("nudges a turn that ended on narration instead of arming the five-minute rung", async () => {
+    const { definition, run, sessionId } = await start("narrated-turn");
+    await executor.turnEnd(NARRATION);
+
+    expect(executor.reminders).toEqual([{ sessionId, text: STOP_NUDGE_TEXT }]);
+    expect(attempt(definition.id, run.id)).toMatchObject({ status: "running", stopNudgesSent: 1, remindersSent: 0 });
+    expect(attempt(definition.id, run.id)?.nextReminderAt).toBeUndefined();
+  });
+
+  it("spends two nudges, then hands the third narration turn to the time ladder", async () => {
+    const { definition, run } = await start("two-nudges-then-ladder");
+    await executor.turnEnd(NARRATION);
+    await executor.turnEnd(NARRATION);
+
+    expect(executor.reminders).toHaveLength(2);
+    expect(attempt(definition.id, run.id)).toMatchObject({ stopNudgesSent: 2 });
+
+    await executor.turnEnd(NARRATION);
+
+    expect(executor.reminders).toHaveLength(2);
+    expect(attempt(definition.id, run.id)).toMatchObject({
+      stopNudgesSent: 2,
+      remindersSent: 0,
+      nextReminderAt: "2026-07-21T10:05:00.000Z",
+    });
+  });
+
+  it("does not nudge a turn that claimed a terminal state", async () => {
+    const { definition, run } = await start("terminal-claim");
+    await executor.turnEnd("The migration is implemented and all tests pass.");
+
+    expect(executor.reminders).toEqual([]);
+    expect(attempt(definition.id, run.id)).toMatchObject({
+      stopNudgesSent: 0,
+      nextReminderAt: "2026-07-21T10:05:00.000Z",
+    });
+  });
+
+  it("does not nudge a turn that carried a valid output block", async () => {
+    const output: WorkflowOutputSchema = {
+      fields: { result: { type: "string", required: true } },
+      allowAdditionalFields: false,
+    };
+    const { definition, run } = await start("narration-with-block", output);
+    await executor.turnEnd(`${NARRATION}\n\`\`\`jinn-output\n{"result":"shipped"}\n\`\`\``);
+
+    expect(executor.reminders).toEqual([]);
+    expect(attempt(definition.id, run.id)).toMatchObject({ status: "completed", stopNudgesSent: 0 });
+  });
+
+  it("does not nudge a turn whose output was already submitted through the tool", async () => {
+    const output: WorkflowOutputSchema = {
+      fields: { result: { type: "string", required: true } },
+      allowAdditionalFields: false,
+    };
+    const { definition, run, sessionId } = await start("submitted-then-narrated", output);
+    await service.submitAttemptOutput({ sessionId, fields: { result: "shipped" } });
+    await executor.turnEnd(NARRATION);
+
+    expect(executor.reminders).toEqual([]);
+    expect(attempt(definition.id, run.id)).toMatchObject({ status: "completed", stopNudgesSent: 0 });
+  });
+
+  it("arms the ordinary rung when the nudge cannot be dispatched", async () => {
+    const { definition, run } = await start("undispatchable-nudge");
+    executor.remindError = new Error('Workflow attempt session "session:x" is not idle.');
+
+    await expect(executor.turnEnd(NARRATION)).resolves.toBeUndefined();
+
+    expect(executor.reminders).toEqual([]);
+    expect(attempt(definition.id, run.id)).toMatchObject({
+      status: "running",
+      stopNudgesSent: 0,
+      remindersSent: 0,
+      nextReminderAt: "2026-07-21T10:05:00.000Z",
+    });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/todo-capability-boundary.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/todo-capability-boundary.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOWS_DIR = path.resolve(import.meta.dirname, '..');
+const SQLITE_OWNERS = new Set([
+  'import-v1.ts',
+  'repository-migrations.ts',
+  'repository-run-transaction.ts',
+  'repository-runs.ts',
+  'repository-support.ts',
+  'repository.ts',
+]);
+
+function productionWorkflowSources(): Array<{ file: string; source: string }> {
+  return fs.readdirSync(WORKFLOWS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+    .map((entry) => ({
+      file: entry.name,
+      source: fs.readFileSync(path.join(WORKFLOWS_DIR, entry.name), 'utf8'),
+    }));
+}
+
+describe('Workflow/Todo capability boundary', () => {
+  it('keeps raw Todo storage, session DB, and Todo write capabilities outside Workflow runtime', () => {
+    const forbidden = [
+      { label: 'sessions registry import', pattern: /from\s+['"][^'"]*sessions\/registry(?:\.js)?['"]/ },
+      { label: 'raw database type', pattern: /\bDatabase\b|better-sqlite3/ },
+      { label: 'raw Todo SQL/table name', pattern: /\bwork_items\b|\bwork_item_events\b/ },
+      { label: 'Todo write-module value import', pattern: /^import(?!\s+type\b)[^;]*work-items\/(?:store|transitions|approvals)(?:\.js)?['"]/m },
+      { label: 'Todo write primitive', pattern: /\b(?:createWorkItem|updateWorkItem|transitionDerived|requestApproval|decideWorkItemApproval)\b/ },
+      { label: 'raw DB acquisition', pattern: /\binitDb\s*\(/ },
+    ];
+    const violations = productionWorkflowSources().flatMap(({ file, source }) =>
+      forbidden
+        .filter(({ label, pattern }) =>
+          pattern.test(source) && (label !== 'raw database type' || !SQLITE_OWNERS.has(file)),
+        )
+        .map(({ label }) => `${file}: ${label}`),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/validation.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/validation.test.ts
@@ -1,0 +1,1000 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  Binding,
+  ConditionNode,
+  TriggerNode,
+  WorkflowDefinition,
+  WorkflowEdge,
+  WorkflowInputField,
+  WorkflowNode,
+} from '../model.js';
+import { workflowDefinitionSchema, workflowDraftSchema } from '../model.js';
+import {
+  outputPorts,
+  topologicalOrder,
+  validateExecutableWorkflow,
+  type WorkflowValidationIssue,
+} from '../validation.js';
+
+const fixed = (value: string): Binding<string> => ({ source: 'fixed', value });
+const input = (path: string): Binding<string> => ({ source: 'input', path });
+
+function trigger(id = 'trigger'): WorkflowNode {
+  return { id, type: 'trigger', name: id, config: { kind: 'manual' } };
+}
+
+function employee(id: string, employeeBinding: Binding<string> = fixed('worker')): WorkflowNode {
+  return { id, type: 'employee', name: id, config: { employee: employeeBinding, prompt: `Run ${id}.` } };
+}
+
+function workflowCall(id: string, workflowId: Binding<string> = fixed('child-flow')): WorkflowNode {
+  return {
+    id,
+    type: 'workflow-call',
+    name: id,
+    config: {
+      workflowId,
+      items: { source: 'fixed', value: [{ topic: 'one' }] },
+      input: { topic: { source: 'trigger', path: 'item.topic' } },
+      concurrency: 2,
+    },
+  };
+}
+
+function condition(id: string, ports = ['yes'], defaultPort = 'no'): ConditionNode {
+  return {
+    id,
+    type: 'condition',
+    name: id,
+    config: {
+      cases: ports.map((port) => ({
+        port,
+        label: port,
+        all: [{ left: fixed(port), operator: 'equals', right: fixed(port) }],
+      })),
+      defaultPort,
+    },
+  };
+}
+
+function merge(id: string): WorkflowNode {
+  return { id, type: 'merge', name: id, config: { mode: 'wait-all' } };
+}
+
+function approval(id: string, approver?: Binding<string>): WorkflowNode {
+  return {
+    id,
+    type: 'approval',
+    name: id,
+    config: { description: `Approve ${id}.`, ...(approver ? { approver } : {}) },
+  };
+}
+
+function waitNode(id: string, timestamp?: Binding<string>): WorkflowNode {
+  return timestamp
+    ? { id, type: 'wait', name: id, config: { mode: 'until', timestamp } }
+    : { id, type: 'wait', name: id, config: { mode: 'duration', minutes: 1 } };
+}
+
+function end(id = 'end', output?: Binding): WorkflowNode {
+  return {
+    id,
+    type: 'end',
+    name: id,
+    config: { result: 'success', ...(output ? { output } : {}) },
+  };
+}
+
+function edge(
+  id: string,
+  from: string,
+  to: string,
+  port = 'success',
+  targetPort: string = 'input',
+): WorkflowEdge {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: targetPort as 'input' } };
+}
+
+function field(key: string): WorkflowInputField {
+  return { key, label: key, type: 'string', required: true };
+}
+
+function definition(
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[],
+  inputs?: WorkflowInputField[],
+): WorkflowDefinition {
+  return {
+    schemaVersion: 1,
+    id: 'validation-fixture',
+    title: 'Validation fixture',
+    revision: 1,
+    enabled: false,
+    ...(inputs ? { inputs } : {}),
+    nodes,
+    edges,
+    createdAt: '2026-07-20T00:00:00.000Z',
+    updatedAt: '2026-07-20T00:00:00.000Z',
+  };
+}
+
+function validChain(): WorkflowDefinition {
+  return definition(
+    [trigger(), employee('first'), employee('second'), end()],
+    [edge('e1', 'trigger', 'first'), edge('e2', 'first', 'second'), edge('e3', 'second', 'end')],
+  );
+}
+
+function codes(result: ReturnType<typeof validateExecutableWorkflow>): string[] {
+  return result.issues.map((issue) => issue.code);
+}
+
+function issue(result: ReturnType<typeof validateExecutableWorkflow>, code: string): WorkflowValidationIssue {
+  const found = result.issues.find((entry) => entry.code === code);
+  expect(found, `Expected issue ${code}`).toBeDefined();
+  return found!;
+}
+
+const malformedResult = {
+  ok: false,
+  issues: [{ code: 'invalid-definition', message: 'Workflow definition is invalid.' }],
+};
+const invalidDefinitionError = new Error('Workflow definition is invalid.');
+
+function throwingProxy<T extends object>(value: T, trapped: () => void): T {
+  return new Proxy(value, {
+    get() { trapped(); throw new Error('poison getter executed'); },
+    getOwnPropertyDescriptor() { trapped(); throw new Error('poison descriptor executed'); },
+    ownKeys() { trapped(); throw new Error('poison keys executed'); },
+  });
+}
+
+function withPrototypeProperty(key: string, descriptor: PropertyDescriptor, run: () => void): void {
+  const previous = Object.getOwnPropertyDescriptor(Object.prototype, key);
+  try {
+    Object.defineProperty(Object.prototype, key, { ...descriptor, configurable: true }); run();
+  } finally {
+    if (previous) Object.defineProperty(Object.prototype, key, previous); else Reflect.deleteProperty(Object.prototype, key);
+  }
+}
+
+describe('valid executable graphs', () => {
+  it('accepts Manual -> Employee -> Employee -> End', () => {
+    expect(validateExecutableWorkflow(validChain())).toEqual({ ok: true, issues: [] });
+  });
+
+  it('accepts a workflow-call success path and validates every authored binding', () => {
+    const graph = definition(
+      [trigger(), workflowCall('children'), end()],
+      [edge('e1', 'trigger', 'children'), edge('e2', 'children', 'end')],
+    );
+
+    expect(outputPorts(graph.nodes[1]!)).toEqual(['success']);
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+
+    const malformed = structuredClone(graph);
+    const call = malformed.nodes[1] as Extract<WorkflowNode, { type: 'workflow-call' }>;
+    call.config.input = { topic: { source: 'node', nodeId: 'missing', path: 'fields.topic' } };
+    expect(codes(validateExecutableWorkflow(malformed))).toContain('unknown-node-binding');
+  });
+
+  it('refuses a fixed workflow-call target equal to the defining workflow', () => {
+    const graph = definition(
+      [trigger(), workflowCall('children', fixed('validation-fixture')), end()],
+      [edge('e1', 'trigger', 'children'), edge('e2', 'children', 'end')],
+    );
+
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'workflow-call-self-reference',
+      nodeId: 'children',
+      path: 'nodes.1.config.workflowId',
+    }));
+  });
+
+  it('accepts branching, fan-out, Condition, Merge, Approval recovery, and Wait', () => {
+    const graph = definition(
+      [
+        trigger(), condition('choice'), employee('left'), employee('right'), merge('join'), approval('gate'),
+        employee('recovery'), merge('decision'), waitNode('pause'), end(),
+      ],
+      [
+        edge('e1', 'trigger', 'choice'), edge('e2', 'choice', 'left', 'yes'), edge('e3', 'choice', 'right', 'no'),
+        edge('e4', 'left', 'join'), edge('e5', 'right', 'join'), edge('e6', 'join', 'gate'),
+        edge('e7', 'gate', 'decision', 'approved'), edge('e8', 'gate', 'recovery', 'rejected'),
+        edge('e9', 'recovery', 'decision'), edge('e10', 'decision', 'pause'), edge('e11', 'pause', 'end'),
+      ],
+    );
+
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+});
+
+describe('canonical schema boundary', () => {
+  it('rejects an extra edge property before executable graph operations', () => {
+    const graph = definition([trigger(), end()], [edge('finish', 'trigger', 'end')]);
+    graph.edges[0] = { ...graph.edges[0]!, unexpected: true } as unknown as WorkflowEdge;
+
+    expect(workflowDefinitionSchema.safeParse(graph).success).toBe(false);
+    expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+    expect(() => topologicalOrder(graph)).toThrowError(invalidDefinitionError);
+  });
+
+  it('rejects an extra node property before executable graph operations', () => {
+    const malformedNode = { ...trigger(), unexpected: true } as unknown as WorkflowNode;
+    const graph = definition([malformedNode, end()], [edge('finish', 'trigger', 'end')]);
+
+    expect(workflowDefinitionSchema.safeParse(graph).success).toBe(false);
+    expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+    expect(() => topologicalOrder(graph)).toThrowError(invalidDefinitionError);
+    expect(outputPorts(malformedNode)).toEqual([]);
+  });
+
+  it('keeps a structurally valid disabled draft editable before it is executable', () => {
+    const draft = { nodes: [trigger()], edges: [] };
+    const disabled = definition(draft.nodes, draft.edges);
+
+    expect(disabled.enabled).toBe(false);
+    expect(workflowDraftSchema.safeParse(draft).success).toBe(true);
+    expect(validateExecutableWorkflow(disabled).ok).toBe(false);
+    expect(codes(validateExecutableWorkflow(disabled))).not.toContain('invalid-definition');
+  });
+});
+
+describe('triggers, End paths, and cycles', () => {
+  it('requires at least one Trigger', () => {
+    const result = validateExecutableWorkflow(definition([employee('work'), end()], [edge('e1', 'work', 'end')]));
+    expect(result.issues).toContainEqual({ code: 'trigger-count', message: 'Workflow must contain at least one Trigger.' });
+  });
+
+  it('accepts one Todo trigger and one Workflow Call trigger when both reach an End', () => {
+    const graph = definition([
+      { id: 'todo-trigger', type: 'trigger', name: 'Todo', config: { kind: 'todo-status', status: 'in_review' } },
+      { id: 'call-trigger', type: 'trigger', name: 'Called', config: { kind: 'workflow-call' } },
+      end('todo-end'),
+      end('call-end'),
+    ], [edge('todo-finish', 'todo-trigger', 'todo-end'), edge('call-finish', 'call-trigger', 'call-end')]);
+
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+
+  it('reports a duplicate Trigger kind on the duplicate node', () => {
+    const graph = definition([
+      trigger('first-trigger'),
+      trigger('second-trigger'),
+      end('first-end'),
+      end('second-end'),
+    ], [edge('first-finish', 'first-trigger', 'first-end'), edge('second-finish', 'second-trigger', 'second-end')]);
+
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual({
+      code: 'duplicate-trigger-kind',
+      message: 'Workflow must contain at most one manual Trigger.',
+      nodeId: 'second-trigger',
+    });
+  });
+
+  it('requires a directed Trigger-to-End path even when an End exists', () => {
+    const graph = definition([trigger(), employee('dead'), end()], [edge('e1', 'trigger', 'dead')]);
+    expect(codes(validateExecutableWorkflow(graph))).toEqual(expect.arrayContaining(['missing-end-path', 'dead-node']));
+  });
+
+  it.each([
+    [
+      'self-loop',
+      definition(
+        [trigger(), employee('loop'), end()],
+        [edge('e1', 'loop', 'loop'), edge('e2', 'trigger', 'loop'), edge('e3', 'loop', 'end')],
+      ),
+    ],
+    [
+      'multi-node cycle',
+      definition(
+        [trigger(), merge('a'), merge('b'), end()],
+        [
+          edge('e1', 'trigger', 'a'), edge('e2', 'b', 'a'), edge('e3', 'a', 'b'),
+          edge('e4', 'trigger', 'b'), edge('e5', 'b', 'end'),
+        ],
+      ),
+    ],
+    [
+      'cycle disconnected from Trigger',
+      definition(
+        [trigger(), end(), merge('a'), merge('b')],
+        [edge('e1', 'trigger', 'end'), edge('e2', 'a', 'b'), edge('e3', 'b', 'a')],
+      ),
+    ],
+  ])('reports a %s without throwing', (_label, graph) => {
+    const result = validateExecutableWorkflow(graph);
+    expect(result.ok).toBe(false);
+    expect(codes(result)).toContain('cycle');
+  });
+});
+
+describe('edge references and ports', () => {
+  it('reports unknown source and target nodes with edge metadata', () => {
+    const graph = definition(
+      [trigger(), end()],
+      [edge('bad-source', 'missing-source', 'end'), edge('bad-target', 'trigger', 'missing-target')],
+    );
+    const result = validateExecutableWorkflow(graph);
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: 'unknown-source-node', edgeId: 'bad-source', nodeId: 'missing-source',
+    }));
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: 'unknown-target-node', edgeId: 'bad-target', nodeId: 'missing-target',
+    }));
+  });
+
+  it.each([
+    ['trigger', trigger('source'), 'error'],
+    ['employee', employee('source'), 'approved'],
+    ['condition', condition('source'), 'success'],
+    ['merge', merge('source'), 'error'],
+    ['approval', approval('source'), 'success'],
+    ['wait', waitNode('source'), 'error'],
+    ['end', end('source'), 'success'],
+  ])('rejects an invalid %s source port', (_type, source, port) => {
+    const nodes = source.type === 'trigger'
+      ? [source, end()]
+      : [trigger(), source, end()];
+    const edges = source.type === 'trigger'
+      ? [edge('invalid', source.id, 'end', port)]
+      : [edge('enter', 'trigger', source.id), edge('invalid', source.id, 'end', port)];
+    expect(validateExecutableWorkflow(definition(nodes, edges)).issues).toContainEqual(expect.objectContaining({
+      code: 'invalid-source-port', edgeId: 'invalid', nodeId: source.id,
+    }));
+  });
+
+  it('requires every target port to be exactly input', () => {
+    const graph = validChain();
+    graph.edges[1]!.to.port = 'success' as 'input';
+    expect(workflowDefinitionSchema.safeParse(graph).success).toBe(false);
+    expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+  });
+
+  it('flags only the later exact duplicate route and excludes it from incoming counts', () => {
+    const graph = definition(
+      [trigger(), employee('work'), end()],
+      [edge('first', 'trigger', 'work'), edge('later', 'trigger', 'work'), edge('finish', 'work', 'end')],
+    );
+    const result = validateExecutableWorkflow(graph);
+    expect(result.issues).toContainEqual(expect.objectContaining({ code: 'duplicate-edge', edgeId: 'later' }));
+    expect(codes(result)).not.toContain('multiple-incoming');
+  });
+
+  it('allows fan-out from one source port to distinct targets', () => {
+    const graph = definition(
+      [trigger(), employee('left'), employee('right'), end('left-end'), end('right-end')],
+      [
+        edge('e1', 'trigger', 'left'), edge('e2', 'trigger', 'right'),
+        edge('e3', 'left', 'left-end'), edge('e4', 'right', 'right-end'),
+      ],
+    );
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+});
+
+describe('incoming cardinality and terminal boundaries', () => {
+  it('rejects every valid incoming edge to a Trigger', () => {
+    const graph = definition(
+      [trigger(), employee('work'), end()],
+      [edge('enter', 'trigger', 'work'), edge('back', 'work', 'trigger'), edge('finish', 'work', 'end')],
+    );
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'trigger-incoming', nodeId: 'trigger', edgeId: 'back',
+    }));
+  });
+
+  it('flags later incoming edges beyond the first for an ordinary node', () => {
+    const graph = definition(
+      [trigger(), employee('left'), employee('right'), employee('target'), end()],
+      [
+        edge('e1', 'trigger', 'left'), edge('e2', 'trigger', 'right'), edge('first', 'left', 'target'),
+        edge('later', 'right', 'target'), edge('finish', 'target', 'end'),
+      ],
+    );
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'multiple-incoming', nodeId: 'target', edgeId: 'later',
+    }));
+  });
+
+  it('excludes a later excess incoming edge from reachability analysis', () => {
+    const graph = definition(
+      [trigger(), employee('source'), employee('target'), end()],
+      [edge('first', 'source', 'target'), edge('later', 'trigger', 'target'), edge('finish', 'target', 'end')],
+    );
+    const result = validateExecutableWorkflow(graph);
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: 'multiple-incoming', nodeId: 'target', edgeId: 'later',
+    }));
+    expect(result.issues.filter((item) => item.code === 'unreachable-node').map((item) => item.nodeId))
+      .toEqual(['source', 'target', 'end']);
+  });
+
+  it('keeps the first authored ordinary incoming edge authoritative', () => {
+    const graph = definition(
+      [trigger(), employee('source'), employee('target'), end()],
+      [edge('first', 'trigger', 'target'), edge('later', 'source', 'target'), edge('finish', 'target', 'end')],
+    );
+    const result = validateExecutableWorkflow(graph);
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: 'multiple-incoming', nodeId: 'target', edgeId: 'later',
+    }));
+    expect(result.issues).toContainEqual(expect.objectContaining({ code: 'unreachable-node', nodeId: 'source' }));
+    expect(result.issues).not.toContainEqual(expect.objectContaining({ code: 'unreachable-node', nodeId: 'target' }));
+    expect(result.issues).not.toContainEqual(expect.objectContaining({ code: 'unreachable-node', nodeId: 'end' }));
+  });
+
+  it('excludes Trigger incoming edges from cycle analysis', () => {
+    const graph = definition(
+      [trigger(), employee('work'), end()],
+      [edge('enter', 'trigger', 'work'), edge('back', 'work', 'trigger'), edge('finish', 'work', 'end')],
+    );
+    const result = validateExecutableWorkflow(graph);
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: 'trigger-incoming', nodeId: 'trigger', edgeId: 'back',
+    }));
+    expect(codes(result)).not.toContain('cycle');
+  });
+});
+
+describe('Merge predecessor cardinality and terminal boundaries', () => {
+  it.each([
+    ['zero', []],
+    ['one', [edge('one', 'trigger', 'join')]],
+  ])('requires two distinct valid predecessor edges for Merge with %s', (_label, incoming) => {
+    const graph = definition(
+      [trigger(), merge('join'), end()],
+      [...incoming, edge('finish', 'join', 'end')],
+    );
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'merge-predecessors', nodeId: 'join',
+    }));
+  });
+
+  it('accepts two or more distinct valid Merge predecessor edges', () => {
+    const graph = definition(
+      [trigger(), employee('left'), employee('right'), merge('join'), end()],
+      [
+        edge('e1', 'trigger', 'left'), edge('e2', 'trigger', 'right'), edge('e3', 'left', 'join'),
+        edge('e4', 'right', 'join'), edge('e5', 'trigger', 'join'), edge('e6', 'join', 'end'),
+      ],
+    );
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+
+  it('does not count an exact duplicate route as a second Merge predecessor', () => {
+    const graph = definition(
+      [trigger(), merge('join'), end()],
+      [edge('first', 'trigger', 'join'), edge('duplicate', 'trigger', 'join'), edge('finish', 'join', 'end')],
+    );
+    expect(codes(validateExecutableWorkflow(graph))).toEqual(expect.arrayContaining(['duplicate-edge', 'merge-predecessors']));
+  });
+
+  it('requires distinct Merge predecessor node IDs across different source ports', () => {
+    const graph = definition(
+      [trigger(), employee('work'), merge('join'), end()],
+      [
+        edge('enter', 'trigger', 'work'), edge('success', 'work', 'join'),
+        edge('error', 'work', 'join', 'error'), edge('finish', 'join', 'end'),
+      ],
+    );
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'merge-predecessors',
+      nodeId: 'join',
+      message: 'Merge nodes require at least two distinct predecessor nodes.',
+    }));
+  });
+
+  it('accepts exactly two distinct Merge predecessor node IDs', () => {
+    const graph = definition(
+      [trigger(), employee('left'), employee('right'), merge('join'), end()],
+      [
+        edge('left-in', 'trigger', 'left'), edge('right-in', 'trigger', 'right'),
+        edge('left-join', 'left', 'join'), edge('right-join', 'right', 'join'), edge('finish', 'join', 'end'),
+      ],
+    );
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+
+  it('reports every outgoing edge authored on End', () => {
+    const graph = definition(
+      [trigger(), end(), employee('after'), end('last')],
+      [edge('enter', 'trigger', 'end'), edge('out', 'end', 'after'), edge('finish', 'after', 'last')],
+    );
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'end-outgoing', nodeId: 'end', edgeId: 'out',
+    }));
+  });
+});
+
+describe('reachability and liveness', () => {
+  it('reports non-Trigger nodes unreachable through valid edges', () => {
+    const graph = validChain();
+    graph.nodes.push(employee('stray'));
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'unreachable-node', nodeId: 'stray',
+    }));
+  });
+
+  it('reports a reachable non-End node with no path to End', () => {
+    const graph = definition(
+      [trigger(), employee('finish'), employee('dead'), end()],
+      [edge('e1', 'trigger', 'finish'), edge('e2', 'finish', 'end'), edge('e3', 'trigger', 'dead')],
+    );
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'dead-node', nodeId: 'dead',
+    }));
+  });
+
+  it('does not require Employee error or Approval rejected outputs to be connected', () => {
+    const graph = definition(
+      [trigger(), employee('work'), approval('gate'), end()],
+      [edge('e1', 'trigger', 'work'), edge('e2', 'work', 'gate'), edge('e3', 'gate', 'end', 'approved')],
+    );
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+});
+
+describe('Condition ports and outputPorts', () => {
+  it.each([
+    ['empty case', condition('choice', [''])],
+    ['duplicate case', condition('choice', ['same', 'same'])],
+    ['default collision', condition('choice', ['same'], 'same')],
+  ])('maps a schema-invalid %s to one stable definition issue', (_label, choice) => {
+    const graph = definition([trigger(), choice, end()], [edge('e1', 'trigger', 'choice')]);
+    expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+  });
+
+  it.each([
+    ['unsafe case', condition('choice', ['not.safe']), 'nodes.1.config.cases.0.port'],
+    ['unsafe default', condition('choice', ['yes'], '__proto__'), 'nodes.1.config.defaultPort'],
+  ])('fails closed for %s ports', (_label, choice, path) => {
+    const graph = definition([trigger(), choice, end()], [edge('e1', 'trigger', 'choice')]);
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'invalid-condition-port', nodeId: 'choice', path,
+    }));
+  });
+
+  it('returns no ports when a Condition node fails its canonical schema', () => {
+    const choice = condition('choice', ['first', 'second', 'first', 'bad.port'], 'second');
+    expect(outputPorts(choice)).toEqual([]);
+  });
+
+  it('returns every locked variant contract as a fresh array', () => {
+    const cases: Array<[WorkflowNode, string[]]> = [
+      [trigger(), ['success']],
+      [employee('work'), ['success', 'error']],
+      [condition('choice', ['first', 'second'], 'fallback'), ['first', 'second', 'fallback']],
+      [merge('join'), ['success']],
+      [approval('gate'), ['approved', 'rejected']],
+      [waitNode('pause'), ['success']],
+      [end(), []],
+    ];
+    for (const [node, expected] of cases) {
+      const first = outputPorts(node);
+      const second = outputPorts(node);
+      expect(first).toEqual(expected);
+      expect(second).toEqual(expected);
+      expect(second).not.toBe(first);
+      first.push('mutated');
+      expect(outputPorts(node)).toEqual(expected);
+    }
+  });
+});
+
+function bindingGraph(): WorkflowDefinition {
+  const work = employee('work', input('employee.id'));
+  if (work.type !== 'employee') throw new Error('fixture');
+  work.config.engine = input('engine');
+  work.config.model = input('model.name');
+  work.config.effort = input('effort') as Binding<'low' | 'medium' | 'high' | 'xhigh'>;
+  const choice = condition('choice');
+  choice.config.cases[0]!.all = [{
+    left: input('left.value'),
+    operator: 'equals',
+    right: input('right.value'),
+  }];
+  return definition(
+    [
+      trigger(), work, choice, approval('gate', input('approver.id')), waitNode('pause', input('timestamp')),
+      end('success-end', input('result.value')), end('default-end'), end('rejected-end'),
+    ],
+    [
+      edge('e1', 'trigger', 'work'), edge('e2', 'work', 'choice'), edge('e3', 'choice', 'gate', 'yes'),
+      edge('e4', 'choice', 'default-end', 'no'), edge('e5', 'gate', 'pause', 'approved'),
+      edge('e6', 'gate', 'rejected-end', 'rejected'), edge('e7', 'pause', 'success-end'),
+    ],
+    ['employee', 'engine', 'model', 'effort', 'left', 'right', 'approver', 'timestamp', 'result'].map(field),
+  );
+}
+
+describe('Workflow input declarations', () => {
+  it('accepts every explicitly traversed input Binding location using the first path segment', () => {
+    expect(validateExecutableWorkflow(bindingGraph())).toEqual({ ok: true, issues: [] });
+  });
+
+  it.each([
+    ['employee', 'nodes.1.config.employee'],
+    ['engine', 'nodes.1.config.engine'],
+    ['model', 'nodes.1.config.model'],
+    ['effort', 'nodes.1.config.effort'],
+    ['left', 'nodes.2.config.cases.0.all.0.left'],
+    ['right', 'nodes.2.config.cases.0.all.0.right'],
+    ['approver', 'nodes.3.config.approver'],
+    ['timestamp', 'nodes.4.config.timestamp'],
+    ['result', 'nodes.5.config.output'],
+  ])('reports missing %s declarations at the known config path', (key, path) => {
+    const graph = bindingGraph();
+    graph.inputs = graph.inputs!.filter((entry) => entry.key !== key);
+    expect(validateExecutableWorkflow(graph).issues).toContainEqual(expect.objectContaining({
+      code: 'undeclared-input', path,
+    }));
+  });
+
+  it('treats a single source-word path as an ordinary declared input key', () => {
+    const graph = definition(
+      [trigger(), employee('work', input('input')), end()],
+      [edge('e1', 'trigger', 'work'), edge('e2', 'work', 'end')],
+      [field('input')],
+    );
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+
+  it('does not require declarations for fixed, trigger, run, or node bindings', () => {
+    const work = employee('work', fixed('worker'));
+    if (work.type !== 'employee') throw new Error('fixture');
+    work.config.engine = { source: 'trigger', path: 'trigger' };
+    work.config.model = { source: 'run', path: 'run' };
+    const graph = definition(
+      [trigger(), work, end('end', { source: 'node', nodeId: 'work', path: 'nodes' })],
+      [edge('e1', 'trigger', 'work'), edge('e2', 'work', 'end')],
+    );
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+  });
+});
+
+describe('deterministic issue behavior', () => {
+  it('sorts by node rank, then edge rank, then code and remains byte-identical without mutation', () => {
+    const graph = definition(
+      [trigger(), employee('first'), employee('second'), end()],
+      [
+        edge('bad-port', 'first', 'second', 'approved'),
+        edge('unknown', 'missing', 'end'),
+        edge('incoming', 'second', 'trigger'),
+        edge('outgoing', 'end', 'first'),
+      ],
+    );
+    const snapshot = structuredClone(graph);
+    const first = validateExecutableWorkflow(graph);
+    const second = validateExecutableWorkflow(graph);
+
+    expect(JSON.stringify(second.issues)).toBe(JSON.stringify(first.issues));
+    expect(graph).toEqual(snapshot);
+    expect(first.ok).toBe(first.issues.length === 0);
+    expect(first.issues.map((entry) => [entry.nodeId, entry.edgeId, entry.code])).toEqual([
+      ['trigger', 'incoming', 'trigger-incoming'],
+      ['trigger', undefined, 'dead-node'],
+      ['first', 'bad-port', 'invalid-source-port'],
+      ['first', undefined, 'unreachable-node'],
+      ['second', undefined, 'unreachable-node'],
+      ['end', 'outgoing', 'end-outgoing'],
+      ['end', 'outgoing', 'invalid-source-port'],
+      ['end', undefined, 'unreachable-node'],
+      ['missing', 'unknown', 'unknown-source-node'],
+      [undefined, undefined, 'missing-end-path'],
+    ]);
+  });
+
+  it('de-duplicates the same code/nodeId/edgeId/path tuple', () => {
+    const choice = condition('choice', ['same', 'same'], 'same');
+    const graph = definition([trigger(), choice, end()], [edge('e1', 'trigger', 'choice')]);
+    const tuples = validateExecutableWorkflow(graph).issues.map((entry) => JSON.stringify([
+      entry.code, entry.nodeId, entry.edgeId, entry.path,
+    ]));
+    expect(new Set(tuples).size).toBe(tuples.length);
+  });
+});
+
+describe('topologicalOrder', () => {
+  it('preserves authored node order among simultaneously ready nodes', () => {
+    const graph = definition(
+      [trigger(), employee('second'), employee('first'), merge('join'), end()],
+      [
+        edge('e1', 'trigger', 'first'), edge('e2', 'trigger', 'second'), edge('e3', 'first', 'join'),
+        edge('e4', 'second', 'join'), edge('e5', 'join', 'end'),
+      ],
+    );
+    const snapshot = structuredClone(graph);
+    expect(topologicalOrder(graph)).toEqual(['trigger', 'second', 'first', 'join', 'end']);
+    expect(graph).toEqual(snapshot);
+  });
+
+  it('throws one stable generic Error on a cycle', () => {
+    const graph = definition(
+      [trigger(), employee('loop'), end()],
+      [edge('e1', 'trigger', 'loop'), edge('e2', 'loop', 'loop'), edge('e3', 'loop', 'end')],
+    );
+    expect(() => topologicalOrder(graph)).toThrowError(new Error('Workflow graph contains a directed cycle.'));
+  });
+
+  it('throws one stable generic Error on an unknown edge reference', () => {
+    const graph = definition([trigger(), end()], [edge('bad', 'trigger', 'missing')]);
+    expect(() => topologicalOrder(graph)).toThrowError(new Error('Workflow graph contains an unknown node reference.'));
+  });
+});
+
+function maximumGraph(): WorkflowDefinition {
+  const employees = Array.from({ length: 50 }, (_, index) => employee(`employee-${index}`));
+  const merges = Array.from({ length: 48 }, (_, index) => merge(`merge-${index}`));
+  const nodes = [trigger(), ...employees, ...merges, end()];
+  const edges: WorkflowEdge[] = employees.map((node, index) => edge(`enter-${index}`, 'trigger', node.id));
+  for (let index = 0; index < merges.length; index += 1) {
+    const target = merges[index]!.id;
+    if (index > 0) edges.push(edge(`chain-${index}`, merges[index - 1]!.id, target));
+    edges.push(edge(`base-${index}`, employees[index % employees.length]!.id, target));
+  }
+  for (let index = 0; edges.length < 299; index += 1) {
+    const source = employees[index % employees.length]!.id;
+    const target = merges[(Math.floor(index / employees.length) + index + 1) % merges.length]!.id;
+    if (!edges.some((item) => item.from.nodeId === source && item.to.nodeId === target)) {
+      edges.push(edge(`fan-${index}`, source, target));
+    }
+  }
+  edges.push(edge('finish', merges.at(-1)!.id, 'end'));
+  return definition(nodes, edges);
+}
+
+describe('bounded and malformed inputs', () => {
+  it('handles a valid 100-node, 300-edge graph without a timing assertion', () => {
+    const graph = maximumGraph();
+    expect(graph.nodes).toHaveLength(100);
+    expect(graph.edges).toHaveLength(300);
+    expect(validateExecutableWorkflow(graph)).toEqual({ ok: true, issues: [] });
+    expect(topologicalOrder(graph)).toHaveLength(100);
+  });
+
+  it('fails closed for hand-built malformed Condition values without mutating or throwing', () => {
+    const malformed = condition('choice') as unknown as { config: { cases: unknown; defaultPort: unknown } };
+    malformed.config.cases = null;
+    malformed.config.defaultPort = 1;
+    const graph = definition(
+      [trigger(), malformed as unknown as WorkflowNode, end()],
+      [edge('e1', 'trigger', 'choice')],
+    );
+    const snapshot = structuredClone(graph);
+    expect(() => validateExecutableWorkflow(graph)).not.toThrow();
+    expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+    expect(graph).toEqual(snapshot);
+  });
+
+  it('treats malformed top-level collections as a structural-schema prerequisite without throwing', () => {
+    const graph = { ...validChain(), nodes: null, edges: null } as unknown as WorkflowDefinition;
+    expect(() => validateExecutableWorkflow(graph)).not.toThrow();
+    expect(validateExecutableWorkflow(graph).ok).toBe(false);
+  });
+});
+
+describe('adversarial public seams', () => {
+  it('maps throwing and revoked definition Proxies to stable public outcomes without invoking traps', () => {
+    let calls = 0;
+    const poison = new Proxy(validChain(), {
+      get() { calls += 1; throw new Error('poison getter executed'); },
+      getOwnPropertyDescriptor() { calls += 1; throw new Error('poison descriptor executed'); },
+      ownKeys() { calls += 1; throw new Error('poison keys executed'); },
+    });
+    const revoked = Proxy.revocable(validChain(), {});
+    revoked.revoke();
+    for (const hostile of [poison, revoked.proxy]) {
+      expect(validateExecutableWorkflow(hostile)).toEqual(malformedResult);
+      expect(validateExecutableWorkflow(hostile)).toEqual(malformedResult);
+      expect(() => topologicalOrder(hostile)).toThrowError(invalidDefinitionError);
+    }
+    expect(calls).toBe(0);
+  });
+
+  it('maps hostile WorkflowNode values to no ports without invoking traps', () => {
+    let calls = 0;
+    const poison = new Proxy(employee('work'), {
+      get() { calls += 1; throw new Error('poison getter executed'); },
+      getOwnPropertyDescriptor() { calls += 1; throw new Error('poison descriptor executed'); },
+      ownKeys() { calls += 1; throw new Error('poison keys executed'); },
+    });
+    const revoked = Proxy.revocable(employee('work'), {});
+    revoked.revoke();
+    expect(outputPorts(poison)).toEqual([]);
+    expect(outputPorts(revoked.proxy)).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  it('rejects accessor-backed public inputs without invoking getters and preserves benign values', () => {
+    let calls = 0;
+    const hostileDefinition = {} as WorkflowDefinition;
+    Object.defineProperty(hostileDefinition, 'nodes', { enumerable: true, get() { calls += 1; throw new Error('getter'); } });
+    const hostileNode = {} as WorkflowNode;
+    Object.defineProperty(hostileNode, 'type', { enumerable: true, get() { calls += 1; throw new Error('getter'); } });
+    expect(validateExecutableWorkflow(hostileDefinition)).toEqual({
+      ok: false,
+      issues: [{ code: 'invalid-definition', message: 'Workflow definition is invalid.' }],
+    });
+    expect(outputPorts(hostileNode)).toEqual([]);
+    expect(() => topologicalOrder(hostileDefinition)).toThrowError(invalidDefinitionError);
+    expect(calls).toBe(0);
+    expect(validateExecutableWorkflow(validChain())).toEqual({ ok: true, issues: [] });
+    expect(outputPorts(employee('work'))).toEqual(['success', 'error']);
+  });
+});
+
+describe('nested adversarial public seams', () => {
+  it('rejects throwing, revoked, and accessor-backed node arrays without invoking traps', () => {
+    let calls = 0;
+    const poison = throwingProxy(validChain().nodes, () => { calls += 1; });
+    const revoked = Proxy.revocable(validChain().nodes, {});
+    revoked.revoke();
+    const accessor = validChain().nodes.slice();
+    Object.defineProperty(accessor, 1, {
+      enumerable: true,
+      get() { calls += 1; throw new Error('node getter executed'); },
+    });
+
+    for (const nodes of [poison, revoked.proxy, accessor]) {
+      const graph = { ...validChain(), nodes };
+      expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+      expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+      expect(() => topologicalOrder(graph)).toThrowError(invalidDefinitionError);
+      expect(() => topologicalOrder(graph)).toThrowError(invalidDefinitionError);
+    }
+    expect(calls).toBe(0);
+  });
+
+  it('rejects hostile edges, inputs, and a nested endpoint object at the definition boundary', () => {
+    let calls = 0;
+    const trapped = () => { calls += 1; };
+    const hostileEdges = { ...validChain(), edges: throwingProxy(validChain().edges, trapped) };
+    const hostileInputs = {
+      ...validChain(), inputs: throwingProxy([field('worker')], trapped),
+    };
+    const hostileEndpoint = validChain();
+    hostileEndpoint.edges[0]!.from = throwingProxy(hostileEndpoint.edges[0]!.from, trapped);
+
+    for (const graph of [hostileEdges, hostileInputs, hostileEndpoint]) {
+      expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+      expect(() => topologicalOrder(graph)).toThrowError(invalidDefinitionError);
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+describe('nested adversarial Condition seams', () => {
+  it('rejects hostile cases and predicate arrays with deterministic outcomes', () => {
+    let calls = 0;
+    const trapped = () => { calls += 1; };
+    const hostileCases = condition('choice');
+    hostileCases.config.cases = throwingProxy(hostileCases.config.cases, trapped);
+    const hostilePredicates = condition('choice');
+    hostilePredicates.config.cases[0]!.all = throwingProxy(
+      hostilePredicates.config.cases[0]!.all,
+      trapped,
+    );
+
+    for (const choice of [hostileCases, hostilePredicates]) {
+      const graph = definition([trigger(), choice, end()], [
+        edge('e1', 'trigger', 'choice'), edge('e2', 'choice', 'end', 'yes'),
+      ]);
+      expect(outputPorts(choice)).toEqual([]);
+      expect(outputPorts(choice)).toEqual([]);
+      expect(validateExecutableWorkflow(graph)).toEqual(malformedResult);
+      expect(() => topologicalOrder(graph)).toThrowError(invalidDefinitionError);
+    }
+    expect(calls).toBe(0);
+  });
+
+  it('rejects a nested accessor object without invoking its getter and preserves canonical values', () => {
+    let calls = 0;
+    const hostile = condition('choice');
+    Object.defineProperty(hostile.config.cases[0]!, 'port', {
+      enumerable: true,
+      get() { calls += 1; throw new Error('case getter executed'); },
+    });
+    expect(outputPorts(hostile)).toEqual([]);
+    expect(calls).toBe(0);
+    expect(outputPorts(condition('choice', ['first', 'second'], 'fallback')))
+      .toEqual(['first', 'second', 'fallback']);
+    expect(validateExecutableWorkflow(validChain())).toEqual({ ok: true, issues: [] });
+    expect(topologicalOrder(validChain())).toEqual(['trigger', 'first', 'second', 'end']);
+  });
+});
+
+describe('inherited adversarial public seams', () => {
+  it('ignores inherited throwing accessors at node and definition boundaries', () => {
+    let calls = 0;
+    const choice = condition('choice');
+    Reflect.deleteProperty(choice.config, 'defaultPort');
+    const graph = definition([trigger(), choice, end()], [edge('e1', 'trigger', 'choice'), edge('e2', 'choice', 'end', 'yes')]);
+    const snapshot = structuredClone(graph);
+    withPrototypeProperty('defaultPort', { get() { calls += 1; throw new Error('inherited poison'); } }, () => {
+      const result = validateExecutableWorkflow(graph);
+      expect(result).toEqual(malformedResult);
+      expect(validateExecutableWorkflow(graph)).toEqual(result);
+      expect(outputPorts(choice)).toEqual([]);
+      expect(outputPorts(choice)).toEqual([]);
+    });
+    const missingNodes = validChain();
+    Reflect.deleteProperty(missingNodes, 'nodes');
+    const topologicalSnapshot = structuredClone(missingNodes);
+    withPrototypeProperty('nodes', { get() { calls += 1; throw new Error('inherited poison'); } }, () => {
+      expect(() => topologicalOrder(missingNodes)).toThrowError(invalidDefinitionError);
+      expect(() => topologicalOrder(missingNodes)).toThrowError(invalidDefinitionError);
+    });
+    expect(calls).toBe(0);
+    expect(graph).toEqual(snapshot);
+    expect(missingNodes).toEqual(topologicalSnapshot);
+  });
+
+  it('ignores benign inherited values while preserving own-data diagnostics', () => {
+    const inherited = condition('choice');
+    Reflect.deleteProperty(inherited.config, 'defaultPort');
+    const inheritedGraph = definition([trigger(), inherited, end()], [edge('e1', 'trigger', 'choice'), edge('e2', 'choice', 'end', 'yes')]);
+    withPrototypeProperty('defaultPort', { value: 'inherited' }, () => {
+      expect(outputPorts(inherited)).toEqual([]);
+      expect(validateExecutableWorkflow(inheritedGraph)).toEqual(malformedResult);
+    });
+    const ownData = condition('choice') as unknown as { config: { defaultPort: unknown } };
+    ownData.config.defaultPort = 1;
+    const ownGraph = definition([trigger(), ownData as WorkflowNode, end()], [edge('e1', 'trigger', 'choice'), edge('e2', 'choice', 'end', 'yes')]);
+    const snapshot = structuredClone(ownGraph);
+    expect(validateExecutableWorkflow(ownGraph)).toEqual(malformedResult);
+    expect(outputPorts(ownData as WorkflowNode)).toEqual([]);
+    expect(outputPorts(ownData as WorkflowNode)).toEqual([]);
+    expect(ownGraph).toEqual(snapshot);
+  });
+});
+
+describe('Schedule trigger cron and timezone', () => {
+  function scheduled(cron: string, timezone: string): WorkflowDefinition {
+    return definition(
+      [{ id: 'trigger', type: 'trigger', name: 'trigger', config: { kind: 'schedule', cron, timezone } }, end()],
+      [edge('e1', 'trigger', 'end')],
+    );
+  }
+
+  it('accepts a parseable cron expression paired with a real IANA timezone', () => {
+    expect(validateExecutableWorkflow(scheduled('0 9 * * 1-5', 'Europe/Sofia'))).toEqual({ ok: true, issues: [] });
+  });
+
+  it.each([
+    ['every weekday please', 'UTC', 'config.cron', 'schedule must be a valid cron expression'],
+    ['0 9 * * 1-5', 'Mars/Olympus', 'config.timezone', 'timezone "Mars/Olympus" is not a valid IANA timezone'],
+  ])('reports %j / %j as an invalid-schedule issue on its trigger node', (cron, timezone, path, message) => {
+    const result = validateExecutableWorkflow(scheduled(cron, timezone));
+    expect(result.ok).toBe(false);
+    expect(issue(result, 'invalid-schedule')).toEqual({ code: 'invalid-schedule', message, nodeId: 'trigger', path });
+  });
+});
+
+describe('Todo trigger filters', () => {
+  function filtered(config: Record<string, unknown>): WorkflowDefinition {
+    return definition(
+      [{ id: 'todo-trigger', type: 'trigger', name: 'trigger',
+        config: { kind: 'todo-status', status: 'assigned', ...config } as TriggerNode['config'] }, end()],
+      [edge('e1', 'todo-trigger', 'end')],
+    );
+  }
+
+  it('accepts each live filter on its own', () => {
+    expect(validateExecutableWorkflow(filtered({ unlabeled: true, unassigned: true, rootOnly: true })))
+      .toEqual({ ok: true, issues: [] });
+    expect(validateExecutableWorkflow(filtered({ label: 'build', unassigned: true }))).toEqual({ ok: true, issues: [] });
+  });
+
+  it('rejects a trigger that demands no labels and a specific label at once', () => {
+    const result = validateExecutableWorkflow(filtered({ unlabeled: true, label: 'build' }));
+
+    expect(result.ok).toBe(false);
+    expect(issue(result, 'conflicting-todo-filters')).toEqual({
+      code: 'conflicting-todo-filters',
+      message: 'A todo-status trigger cannot set both unlabeled and label: a Todo carrying no labels can never carry the one named. Set only one.',
+      nodeId: 'todo-trigger',
+      path: 'nodes.0.config.unlabeled',
+    });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-control-flow.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-control-flow.test.ts
@@ -1,0 +1,385 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+import { validateExecutableWorkflow } from "../validation.js";
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete the task.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: this.sessionId(command.owner.nodeId, command.owner.attempt) };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null { return null; }
+  async succeed(nodeId: string, fields: Record<string, JsonValue>): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    const event: WorkflowAttemptCompletion = {
+      sessionId: this.sessionId(nodeId, command.owner.attempt), owner: command.owner, terminalVersion: 1, turn: 1,
+      outcome: "succeeded", finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\``,
+      completedAt: new Date().toISOString(),
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+  private sessionId(nodeId: string, attempt: number): string { return `session:${nodeId}:${attempt}`; }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let service: WorkflowService;
+let now: Date;
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function employeeNode(id: string): WorkflowNode {
+  return {
+    id, type: "employee", name: id, config: {
+      employee: { source: "fixed", value: "worker" }, prompt: `Run ${id}.`,
+      output: { fields: { value: { type: "string", required: true } }, allowAdditionalFields: false },
+    },
+  };
+}
+
+function saveDefinition(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({
+    ...created,
+    inputs: [
+      { key: "score", label: "Score", type: "number", required: false },
+      { key: "labels", label: "Labels", type: "string", required: false },
+    ],
+    nodes,
+    edges,
+  }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-control-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  executor = new FakeExecutor();
+  now = new Date("2026-07-21T10:00:00.000Z");
+  service = new WorkflowService({
+    repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models,
+    now: () => now.toISOString(),
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("Workflow durable control flow", () => {
+  it("resolves an End output binding into the completed node fields", async () => {
+    const definition = saveDefinition("end-output", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "finish", type: "end", name: "Finish", config: {
+        result: "success", output: { source: "fixed", value: { result: "shipped", count: 2 } },
+      } },
+    ], [edge("start-finish", "start", "success", "finish")]);
+
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+
+    expect(run.status).toBe("completed");
+    expect(run.nodeRuns.find((node) => node.nodeId === "finish")?.output).toEqual({
+      text: "",
+      fields: { result: "shipped", count: 2 },
+    });
+  });
+
+  it("fails an End whose output binding resolves to a non-object value", async () => {
+    const definition = saveDefinition("invalid-end-output", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "finish", type: "end", name: "Finish", config: {
+        result: "success", output: { source: "fixed", value: "not-an-object" },
+      } },
+    ], [edge("start-finish", "start", "success", "finish")]);
+
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+
+    expect(run.status).toBe("failed");
+    expect(run.nodeRuns.find((node) => node.nodeId === "finish")).toMatchObject({
+      status: "failed",
+      error: { message: expect.stringMatching(/End finish output must resolve to a JSON object/) },
+    });
+  });
+
+  it.each([
+    [{ score: 9, labels: ["urgent", "release"] }, "first", "chosen"],
+    [{ score: 7, labels: ["release"] }, "second", "chosen-second"],
+    [{ score: 1, labels: [] }, "otherwise", "defaulted"],
+  ] as const)("evaluates ordered Condition cases with all predicates and selects %s", async (input, expectedPort, expectedEnd) => {
+    const definition = saveDefinition(`condition-${expectedPort}`, [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "choose", type: "condition", name: "Choose", config: {
+        cases: [
+          { port: "first", label: "First", all: [
+            { left: { source: "input", path: "score" }, operator: "gte", right: { source: "fixed", value: 8 } },
+            { left: { source: "input", path: "labels" }, operator: "contains", right: { source: "fixed", value: "urgent" } },
+          ] },
+          { port: "second", label: "Second", all: [
+            { left: { source: "input", path: "score" }, operator: "gte", right: { source: "fixed", value: 5 } },
+          ] },
+        ],
+        defaultPort: "otherwise",
+      } },
+      { id: "chosen", type: "end", name: "Chosen", config: { result: "success" } },
+      { id: "chosen-second", type: "end", name: "Second", config: { result: "success" } },
+      { id: "defaulted", type: "end", name: "Default", config: { result: "success" } },
+    ], [
+      edge("start-choice", "start", "success", "choose"),
+      edge("choice-first", "choose", "first", "chosen"),
+      edge("choice-second", "choose", "second", "chosen-second"),
+      edge("choice-default", "choose", "otherwise", "defaulted"),
+    ]);
+
+    const canonicalInput = { score: input.score, labels: [...input.labels] };
+    const first = await service.startManual({ workflowId: definition.id, input: canonicalInput, idempotencyKey: "same-run" });
+    const replay = await service.startManual({ workflowId: definition.id, input: canonicalInput, idempotencyKey: "same-run" });
+
+    expect(first.status).toBe("completed");
+    expect(first.nodeRuns.find((node) => node.nodeId === expectedEnd)?.status).toBe("completed");
+    expect(first.nodeRuns.filter((node) => node.nodeType === "end" && node.nodeId !== expectedEnd)
+      .every((node) => node.status === "skipped")).toBe(true);
+    expect(first.nodeRuns.find((node) => node.nodeId === "choose")?.output?.fields).toEqual({ port: expectedPort });
+    expect(replay).toEqual(first);
+  });
+
+  it("waits for every activated Merge predecessor, exposes outputs by node id, and replays once", async () => {
+    const definition = saveDefinition("parallel-merge", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      employeeNode("alpha"), employeeNode("beta"),
+      { id: "join", type: "merge", name: "Join", config: { mode: "wait-all" } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [
+      edge("start-alpha", "start", "success", "alpha"), edge("start-beta", "start", "success", "beta"),
+      edge("alpha-join", "alpha", "success", "join"), edge("beta-join", "beta", "success", "join"),
+      edge("join-finish", "join", "success", "finish"),
+    ]);
+    const started = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(executor.commands.map((command) => command.owner.nodeId)).toEqual(["alpha", "beta"]);
+    expect(executor.commands[0]?.prompt).toContain("Run alpha.\n\n---\n");
+    expect(executor.commands[0]?.prompt).toContain("Calling `workflow_submit_output` is what completes this workflow step");
+
+    await executor.succeed("alpha", { value: "A" });
+    expect(service.getRun(definition.id, started.id)).toMatchObject({ status: "running" });
+    expect(service.getRun(definition.id, started.id)?.nodeRuns.find((node) => node.nodeId === "join"))
+      .toMatchObject({ activated: true, status: "pending" });
+
+    await executor.succeed("beta", { value: "B" });
+    const completed = service.getRun(definition.id, started.id)!;
+    const join = completed.nodeRuns.find((node) => node.nodeId === "join")!;
+    expect(completed.status).toBe("completed");
+    expect(join).toMatchObject({ status: "completed", output: { fields: { byNode: {
+      alpha: { text: "Done.\n", fields: { value: "A" }, employeeId: "worker", engine: "test-engine", model: "test-model", sessionId: "session:alpha:1" },
+      beta: { text: "Done.\n", fields: { value: "B" }, employeeId: "worker", engine: "test-engine", model: "test-model", sessionId: "session:beta:1" },
+    } } } });
+    const revision = completed.revision;
+    await executor.succeed("beta", { value: "B" });
+    expect(service.getRun(definition.id, started.id)).toMatchObject({ revision, status: "completed" });
+  });
+
+  it("waits for deep fanout predecessors that remain reachable before freezing Merge output", async () => {
+    const definition = saveDefinition("deep-parallel-merge", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      employeeNode("alpha"), employeeNode("alpha-two"), employeeNode("beta"), employeeNode("beta-two"),
+      { id: "join", type: "merge", name: "Join", config: { mode: "wait-all" } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [
+      edge("start-alpha", "start", "success", "alpha"), edge("alpha-two", "alpha", "success", "alpha-two"),
+      edge("start-beta", "start", "success", "beta"), edge("beta-two", "beta", "success", "beta-two"),
+      edge("alpha-join", "alpha-two", "success", "join"), edge("beta-join", "beta-two", "success", "join"),
+      edge("join-finish", "join", "success", "finish"),
+    ]);
+    const started = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.succeed("alpha", { value: "A1" });
+    expect(executor.commands.find((item) => item.owner.nodeId === "alpha-two")?.prompt)
+      .toContain("`alpha: session:alpha:1`");
+    await executor.succeed("alpha-two", { value: "A2" });
+
+    const half = service.getRun(definition.id, started.id)!;
+    expect(half.status).toBe("running");
+    expect(half.nodeRuns.find((node) => node.nodeId === "join")).toMatchObject({ activated: true, status: "pending" });
+    expect(half.nodeRuns.find((node) => node.nodeId === "finish")?.status).toBe("pending");
+
+    await executor.succeed("beta", { value: "B1" });
+    await executor.succeed("beta-two", { value: "B2" });
+    const completed = service.getRun(definition.id, started.id)!;
+    expect(completed.status).toBe("completed");
+    expect(completed.nodeRuns.find((node) => node.nodeId === "join")?.output?.fields.byNode)
+      .toMatchObject({ "alpha-two": { fields: { value: "A2" } }, "beta-two": { fields: { value: "B2" } } });
+  });
+
+  it("rejects invalid Condition node bindings while preserving legitimate missing-value predicates", async () => {
+    const created = repository.createDefinition({ id: "condition-bindings", title: "Condition bindings" });
+    const nodes: WorkflowNode[] = [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      employeeNode("source"), employeeNode("sibling"),
+      { id: "choose", type: "condition", name: "Choose", config: { cases: [{ port: "found", label: "Found", all: [{
+        left: { source: "node", nodeId: "source", path: "fields.value" }, operator: "exists",
+      }] }], defaultPort: "absent" } },
+      { id: "found", type: "end", name: "Found", config: { result: "success" } },
+      { id: "absent", type: "end", name: "Absent", config: { result: "success" } },
+      { id: "sibling-end", type: "end", name: "Sibling", config: { result: "success" } },
+    ];
+    const edges = [
+      edge("start-source", "start", "success", "source"), edge("source-choose", "source", "success", "choose"),
+      edge("choose-found", "choose", "found", "found"), edge("choose-absent", "choose", "absent", "absent"),
+      edge("start-sibling", "start", "success", "sibling"), edge("sibling-end", "sibling", "success", "sibling-end"),
+    ];
+    const definition = { ...created, nodes, edges };
+    const binding = definition.nodes.find((node) => node.id === "choose")! as Extract<WorkflowNode, { type: "condition" }>;
+    const withLeft = (left: typeof binding.config.cases[number]["all"][number]["left"]): WorkflowDefinition => ({
+      ...definition, nodes: nodes.map((node) => node.id === "choose" ? {
+        ...binding, config: { ...binding.config, cases: [{ ...binding.config.cases[0]!, all: [{ ...binding.config.cases[0]!.all[0]!, left }] }] },
+      } : node),
+    });
+
+    expect(validateExecutableWorkflow(withLeft({ source: "node", nodeId: "ghost", path: "fields.value" })).issues)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ code: "unknown-node-binding", nodeId: "choose" })]));
+    expect(validateExecutableWorkflow(withLeft({ source: "node", nodeId: "sibling", path: "fields.value" })).issues)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ code: "non-predecessor-binding", nodeId: "choose" })]));
+    expect(validateExecutableWorkflow(withLeft({ source: "node", nodeId: "source", path: "fields..value" })).issues)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ code: "invalid-definition" })]));
+
+    const absent = saveDefinition("legitimate-absence", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "choose", type: "condition", name: "Choose", config: { cases: [{ port: "present", label: "Present", all: [{
+        left: { source: "input", path: "score" }, operator: "exists",
+      }] }], defaultPort: "missing" } },
+      { id: "present", type: "end", name: "Present", config: { result: "success" } },
+      { id: "missing", type: "end", name: "Missing", config: { result: "success" } },
+    ], [edge("start-choose", "start", "success", "choose"), edge("present", "choose", "present", "present"),
+      edge("missing", "choose", "missing", "missing")]);
+    const run = await service.startManual({ workflowId: absent.id, input: {} });
+    expect(run.nodeRuns.find((node) => node.nodeId === "missing")?.status).toBe("completed");
+  });
+
+  it("persists Wait resumeAt, reconstructs, resumes once when due, and stays cancelled", async () => {
+    const definition = saveDefinition("durable-wait", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "pause", type: "wait", name: "Pause", config: { mode: "duration", minutes: 5 } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("start-pause", "start", "success", "pause"), edge("pause-finish", "pause", "success", "finish")]);
+    const waiting = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(waiting).toMatchObject({ status: "waiting" });
+    expect(waiting.nodeRuns.find((node) => node.nodeId === "pause")).toMatchObject({
+      activated: true, status: "waiting", resumeAt: "2026-07-21T10:05:00.000Z",
+    });
+
+    service.dispose();
+    now = new Date("2026-07-21T10:05:00.000Z");
+    service = new WorkflowService({
+      repository, executor: executor as unknown as WorkflowSessionExecutor,
+      employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+    });
+    await expect(service.recover(now.toISOString())).resolves.toEqual({ resumedRuns: 0, resumedWaits: 1, resumedComments: 0 });
+    const completed = service.getRun(definition.id, waiting.id)!;
+    expect(completed.status).toBe("completed");
+    expect(completed.nodeRuns.find((node) => node.nodeId === "pause")).toMatchObject({ status: "completed" });
+    const revision = completed.revision;
+    await expect(service.recover(now.toISOString())).resolves.toEqual({ resumedRuns: 0, resumedWaits: 0, resumedComments: 0 });
+    expect(service.getRun(definition.id, waiting.id)?.revision).toBe(revision);
+
+    now = new Date("2026-07-21T11:00:00.000Z");
+    const another = await service.startManual({ workflowId: definition.id, input: {} });
+    const cancelled = await service.cancelRun({ workflowId: definition.id, runId: another.id, reason: "no longer needed" });
+    now = new Date("2026-07-21T12:00:00.000Z");
+    await expect(service.recover(now.toISOString())).resolves.toEqual({ resumedRuns: 0, resumedWaits: 0, resumedComments: 0 });
+    expect(service.getRun(definition.id, another.id)).toEqual(cancelled);
+  });
+
+  it.each(["approve", "reject"] as const)("persists and reconstructs an authorized Approval %s audit", async (decision) => {
+    const definition = saveDefinition(`durable-${decision}`, [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "review", type: "approval", name: "Review", config: {
+        description: "Approve the result", approver: { source: "fixed", value: "reviewer" },
+      } },
+      { id: "accepted", type: "end", name: "Accepted", config: { result: "success" } },
+      { id: "declined", type: "end", name: "Declined", config: { result: "success" } },
+    ], [
+      edge("start-review", "start", "success", "review"), edge("review-approved", "review", "approved", "accepted"),
+      edge("review-rejected", "review", "rejected", "declined"),
+    ]);
+    const waiting = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(waiting).toMatchObject({ status: "waiting", approvals: [{
+      nodeId: "review", status: "pending", requestedAt: now.toISOString(), approverRef: "reviewer",
+    }] });
+    await expect(service.decideApproval({ workflowId: definition.id, runId: waiting.id, nodeId: "review",
+      decision, decidedBy: "intruder", expectedRevision: waiting.revision })).rejects.toThrow(/not authorized/i);
+
+    service.dispose();
+    service = new WorkflowService({
+      repository, executor: executor as unknown as WorkflowSessionExecutor,
+      employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+    });
+    const decided = await service.decideApproval({ workflowId: definition.id, runId: waiting.id, nodeId: "review",
+      decision, decidedBy: "reviewer", reason: decision === "reject" ? "Needs changes" : undefined,
+      expectedRevision: waiting.revision });
+    expect(decided.status).toBe("completed");
+    expect(decided.approvals).toEqual([expect.objectContaining({
+      nodeId: "review", status: decision === "approve" ? "approved" : "rejected", decision,
+      decidedBy: "reviewer", decidedAt: now.toISOString(), ...(decision === "reject" ? { reason: "Needs changes" } : {}),
+    })]);
+    expect(decided.nodeRuns.find((node) => node.nodeId === (decision === "approve" ? "accepted" : "declined"))?.status)
+      .toBe("completed");
+    await expect(service.decideApproval({ workflowId: definition.id, runId: waiting.id, nodeId: "review",
+      decision, decidedBy: "reviewer", expectedRevision: decided.revision })).rejects.toThrow(/already decided/i);
+  });
+
+  it("fails an Approval and its run atomically when the selected authored port has no route", async () => {
+    const definition = saveDefinition("approval-missing-route", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "review", type: "approval", name: "Review", config: {
+        description: "Approve the result", approver: { source: "fixed", value: "reviewer" },
+      } },
+      { id: "accepted", type: "end", name: "Accepted", config: { result: "success" } },
+    ], [edge("start-review", "start", "success", "review"), edge("approved", "review", "approved", "accepted")]);
+    const waiting = await service.startManual({ workflowId: definition.id, input: {} });
+    const rejected = await service.decideApproval({ workflowId: definition.id, runId: waiting.id, nodeId: "review",
+      decision: "reject", decidedBy: "reviewer", reason: "No", expectedRevision: waiting.revision });
+
+    expect(rejected).toMatchObject({ status: "failed", error: { code: "workflow-approval-route-missing", nodeId: "review" } });
+    expect(rejected.approvals).toEqual([expect.objectContaining({ status: "rejected", decision: "reject", reason: "No" })]);
+    expect(rejected.nodeRuns.find((node) => node.nodeId === "review"))
+      .toMatchObject({ status: "failed", error: { code: "workflow-approval-route-missing" } });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-engine-chain-walk.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-engine-chain-walk.test.ts
@@ -1,0 +1,259 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener } from "../../shared/types.js";
+import type { JsonValue, WorkflowDefinition } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+// The health store is gateway-wide; a suite that let it write would both leak
+// records into whatever runs next and read whatever ran before.
+const recordEngineUnavailableMock = vi.fn();
+vi.mock("../../shared/engine-health.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../shared/engine-health.js")>()),
+  readEngineHealth: () => ({}),
+  recordEngineUnavailable: (...args: unknown[]) => recordEngineUnavailableMock(...args),
+}));
+
+/**
+ * PLA-149: an engine that has no allowance left never answered the question, so
+ * the run asks the next engine in the chain rather than freezing on prose about
+ * the provider. What it must NOT do is treat every failure that way, or keep
+ * asking engines it has already asked.
+ */
+
+const QUOTA = "Interactive turn failed: usage limit reached";
+
+const employee: Employee = { name: "worker", displayName: "Worker", department: "platform", rank: "employee",
+  engine: "codex", model: "sol", persona: "Complete the work." };
+const models: ModelRegistry = {
+  codex: { name: "codex", available: true, defaultModel: "sol",
+    models: [{ id: "sol", label: "Sol", supportsEffort: false, effortLevels: [] }] },
+  claude: { name: "claude", available: true, defaultModel: "opus",
+    models: [{ id: "opus", label: "Opus", supportsEffort: false, effortLevels: [] }] },
+  grok: { name: "grok", available: true, defaultModel: "grok-4",
+    models: [{ id: "grok-4", label: "Grok", supportsEffort: false, effortLevels: [] }] },
+} as unknown as ModelRegistry;
+
+class FakeExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: `session:${command.owner.nodeId}:${command.owner.attempt}` };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null { return null; }
+  attemptState(): { idle: boolean; runningChildren: number } { return { idle: true, runningChildren: 0 }; }
+
+  async failTurn(nodeId: string, error: string): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    const event: WorkflowAttemptCompletion = {
+      sessionId: `session:${nodeId}:${command.owner.attempt}`, owner: command.owner,
+      terminalVersion: 1, turn: 1, completedAt: now.toISOString(), outcome: "failed", error,
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+  /** The engine each attempt of this node actually ran on, in order. */
+  enginesFor(nodeId: string): (string | undefined)[] {
+    return this.commands.filter((item) => item.owner.nodeId === nodeId).map((item) => item.engine);
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: FakeExecutor;
+let service: WorkflowService;
+/** What config.yaml currently says, re-read on every walk. */
+let chains: Record<string, string[]>;
+/** What the bound Todo currently says about where the next attempt runs. */
+let override: { engine: string | null; model: string | null } | undefined;
+const now = new Date("2026-08-19T10:00:00.000Z");
+
+/** trigger → work → end, `work` carrying the DEFAULT single-attempt budget so a
+ *  substitution has to happen without a retry budget to spend. */
+function definitionWith(id: string, config: Record<string, JsonValue> = {}): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({
+    ...created,
+    inputs: [],
+    nodes: [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "work", type: "employee", name: "Work", config: {
+        employee: { source: "fixed", value: "worker" }, prompt: "Run the work.",
+        output: { fields: {}, allowAdditionalFields: true }, ...config } },
+      { id: "done", type: "end", name: "Done", config: { result: "success" } },
+    ],
+    edges: [
+      { id: "start-work", from: { nodeId: "start", port: "success" }, to: { nodeId: "work", port: "input" } },
+      { id: "work-done", from: { nodeId: "work", port: "success" }, to: { nodeId: "done", port: "input" } },
+    ],
+  }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-chain-walk-"));
+  chains = { codex: ["claude"] };
+  override = undefined;
+  recordEngineUnavailableMock.mockClear();
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  executor = new FakeExecutor();
+  service = new WorkflowService({
+    repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+    todoDispatch: { read: () => override },
+    engineFallback: { chainFor: (engine) => chains[engine] ?? [] },
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+/** Start `id`, let its first attempt die of quota, and let the runner's timer wake. */
+async function quotaFailedRun(id: string, config: Record<string, JsonValue> = {}) {
+  const definition = definitionWith(id, config);
+  const run = await service.startManual({ workflowId: definition.id, input: {}, todoId: "PLA-1" });
+  await executor.failTurn("work", QUOTA);
+  await service.recover(now.toISOString());
+  return { workflowId: definition.id, runId: run.id };
+}
+
+function attempts(workflowId: string, runId: string) {
+  return service.getRun(workflowId, runId)!.attempts;
+}
+
+describe("an Employee node whose engine runs out of allowance", () => {
+  it("re-dispatches on the chain engine and the run completes", async () => {
+    const { workflowId, runId } = await quotaFailedRun("chain-walk");
+
+    expect(executor.enginesFor("work")).toEqual(["codex", "claude"]);
+    await service.submitAttemptOutput({ sessionId: "session:work:2", outcome: "success", summary: "Done." });
+
+    expect(service.getRun(workflowId, runId)!.status).toBe("completed");
+  });
+
+  it("substitutes on the default single-attempt budget — availability does not spend it", async () => {
+    const { workflowId, runId } = await quotaFailedRun("no-budget");
+
+    // retry.attempts defaults to 1, so a second attempt exists only because the
+    // substitution is not a retry of the same request.
+    expect(attempts(workflowId, runId).map((attempt) => attempt.resolvedConfig.retry.attempts)).toEqual([1, 1]);
+    expect(attempts(workflowId, runId)).toHaveLength(2);
+  });
+
+  it("runs the substitute on that engine's own default model", async () => {
+    const { workflowId, runId } = await quotaFailedRun("default-model");
+
+    expect(attempts(workflowId, runId).at(-1)!.resolvedConfig).toMatchObject({ engine: "claude", model: "opus" });
+  });
+
+  it("records what it substituted for, and why", async () => {
+    const { workflowId, runId } = await quotaFailedRun("provenance");
+
+    expect(attempts(workflowId, runId).map((attempt) => attempt.resolvedConfig.substitutedFrom))
+      .toEqual([undefined, { engine: "codex", reason: "out of quota" }]);
+  });
+
+  it("freezes exactly as before when the node opted out", async () => {
+    const { workflowId, runId } = await quotaFailedRun("opted-out", { fallback: "none" });
+
+    expect(executor.enginesFor("work")).toEqual(["codex"]);
+    expect(service.getRun(workflowId, runId)!.status).toBe("failed");
+    expect(service.getRun(workflowId, runId)!.nodeRuns.find((node) => node.nodeId === "work")!.status).toBe("failed");
+  });
+
+  it("uses an explicit chain verbatim and ignores the configured one", async () => {
+    const { workflowId, runId } = await quotaFailedRun("explicit-chain", { fallback: ["grok"] });
+
+    expect(executor.enginesFor("work")).toEqual(["codex", "grok"]);
+    expect(attempts(workflowId, runId).at(-1)!.resolvedConfig.engine).toBe("grok");
+  });
+
+  it("treats an explicit inherit exactly as an absent fallback", async () => {
+    await quotaFailedRun("inherit", { fallback: "inherit" });
+
+    expect(executor.enginesFor("work")).toEqual(["codex", "claude"]);
+  });
+
+  it("walks the chain of the engine a Todo override resolved to, not the node's pin", async () => {
+    chains = { codex: ["grok"], claude: ["grok"] };
+    override = { engine: "claude", model: null };
+    const { workflowId, runId } = await quotaFailedRun("todo-override", { engine: { source: "fixed", value: "codex" } });
+
+    expect(executor.enginesFor("work")).toEqual(["claude", "grok"]);
+    expect(attempts(workflowId, runId).at(-1)!.resolvedConfig.substitutedFrom).toEqual({ engine: "claude", reason: "out of quota" });
+  });
+
+  it("skips members it already burned an attempt on, then freezes once they are gone", async () => {
+    chains = { codex: ["claude", "grok"] };
+    const { workflowId, runId } = await quotaFailedRun("exhausted");
+
+    await executor.failTurn("work", QUOTA);
+    await service.recover(now.toISOString());
+    await executor.failTurn("work", QUOTA);
+    await service.recover(now.toISOString());
+
+    expect(executor.enginesFor("work")).toEqual(["codex", "claude", "grok"]);
+    expect(service.getRun(workflowId, runId)!.status).toBe("failed");
+  });
+
+  it("terminates on a chain that names its way back", async () => {
+    chains = { codex: ["claude"], claude: ["codex"] };
+    const { workflowId, runId } = await quotaFailedRun("cycle");
+
+    await executor.failTurn("work", QUOTA);
+    await service.recover(now.toISOString());
+
+    expect(executor.enginesFor("work")).toEqual(["codex", "claude"]);
+    expect(service.getRun(workflowId, runId)!.status).toBe("failed");
+  });
+
+  it("records the engine that could not serve, so the next walk can prefer around it", async () => {
+    await quotaFailedRun("records-health");
+
+    expect(recordEngineUnavailableMock).toHaveBeenCalledWith("codex", "out of quota", undefined);
+  });
+});
+
+describe("failures no other engine gets past", () => {
+  it("never substitutes for a verdict the employee submitted, whatever prose it carries", async () => {
+    const definition = definitionWith("submitted");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await service.submitAttemptOutput({
+      sessionId: "session:work:1", outcome: "failure", summary: "Stopping: the upstream API is rate limited.",
+    });
+    await service.recover(now.toISOString());
+
+    expect(executor.enginesFor("work")).toEqual(["codex"]);
+    expect(service.getRun(definition.id, run.id)!.status).toBe("failed");
+  });
+
+  it("never substitutes for a credential, or for prose it does not recognise", async () => {
+    for (const [id, failure] of [["auth", "Interactive turn failed: invalid api key"],
+      ["terminal", "the tests did not pass"]] as const) {
+      const definition = definitionWith(id);
+      const run = await service.startManual({ workflowId: definition.id, input: {} });
+      await executor.failTurn("work", failure);
+      await service.recover(now.toISOString());
+
+      expect(service.getRun(definition.id, run.id)!.attempts).toHaveLength(1);
+      expect(service.getRun(definition.id, run.id)!.status).toBe("failed");
+    }
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-fanout.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-fanout.test.ts
@@ -1,0 +1,464 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Employee,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+} from "../../shared/types.js";
+import type { JsonValue, WorkflowCallNode, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work.",
+};
+const models: ModelRegistry = {
+  "test-engine": {
+    name: "test-engine", available: true, defaultModel: "test-model", effortMechanism: "codex-config",
+    models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }],
+  },
+};
+
+class Executor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  readonly stopped: string[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return { sessionId: this.sessionId(command) };
+  }
+  async stopAttempt(input: { sessionId: string }): Promise<void> { this.stopped.push(input.sessionId); }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  readTerminalCompletion(): null { return null; }
+  async settle(command: WorkflowAttemptCommand, outcome: "succeeded" | "failed", fields: Record<string, JsonValue> = {}): Promise<void> {
+    const event: WorkflowAttemptCompletion = {
+      sessionId: this.sessionId(command),
+      owner: command.owner,
+      terminalVersion: 1,
+      turn: 1,
+      outcome,
+      ...(outcome === "succeeded"
+        ? { finalText: `Done.\n\`\`\`jinn-output\n${JSON.stringify(fields)}\n\`\`\`` }
+        : { error: "Child failed." }),
+      completedAt: "2026-08-05T12:05:00.000Z",
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+  private sessionId(command: WorkflowAttemptCommand): string {
+    return `session:${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: Executor;
+let service: WorkflowService;
+
+function buildService(): WorkflowService {
+  return new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => "2026-08-05T12:00:00.000Z",
+  });
+}
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function save(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = service.createDefinition({ id, title: id });
+  const saved = service.saveDefinition({ ...created, nodes, edges }, created.revision);
+  return service.setEnabled({ id, enabled: true, expectedRevision: saved.revision });
+}
+
+function childWorkflow(id = "child-flow"): WorkflowDefinition {
+  return save(id, [
+    { id: "start", type: "trigger", name: "Called", config: { kind: "workflow-call" } },
+    { id: "work", type: "employee", name: "Work", config: {
+      employee: { source: "fixed", value: "worker" }, prompt: "Process {{ input.topic }}.",
+      retry: { attempts: 1, delaySeconds: 0, backoff: "fixed" },
+    } },
+    { id: "finish", type: "end", name: "Finish", config: {
+      result: "success", output: { source: "node", nodeId: "work", path: "fields" },
+    } },
+  ], [edge("start-work", "start", "success", "work"), edge("work-finish", "work", "success", "finish")]);
+}
+
+function parentWorkflow(id = "parent-flow", options: { items?: JsonValue[]; concurrency?: number } = {}): WorkflowDefinition {
+  const items = options.items ?? [
+    { topic: "alpha" }, { topic: "beta" }, { topic: "gamma" }, { topic: "delta" },
+  ];
+  const call: WorkflowNode = { id: "children", type: "workflow-call", name: "Children", config: {
+    workflowId: { source: "fixed", value: "child-flow" },
+    items: { source: "fixed", value: items },
+    input: {
+      topic: { source: "trigger", path: "item.topic" },
+      ordinal: { source: "trigger", path: "itemIndex" },
+    },
+    concurrency: options.concurrency ?? 2,
+  } };
+  return save(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    call,
+    { id: "route", type: "condition", name: "Route", config: {
+      cases: [{ port: "partial", label: "Partial", all: [{
+        left: { source: "node", nodeId: "children", path: "fields.summary" },
+        operator: "equals", right: { source: "fixed", value: "partial" },
+      }] }],
+      defaultPort: "other",
+    } },
+    { id: "partial", type: "end", name: "Partial", config: {
+      result: "success", output: { source: "fixed", value: { route: "partial" } },
+    } },
+    { id: "other", type: "end", name: "Other", config: {
+      result: "success", output: { source: "fixed", value: { route: "other" } },
+    } },
+  ], [
+    edge("start-children", "start", "success", "children"),
+    edge("children-route", "children", "success", "route"),
+    edge("route-partial", "route", "partial", "partial"),
+    edge("route-other", "route", "other", "other"),
+  ]);
+}
+
+function todoCallParent(id: string, workflowId: string, input: NonNullable<WorkflowCallNode["config"]["input"]>,
+  item: JsonValue): WorkflowDefinition {
+  return save(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "children", type: "workflow-call", name: "Children", config: {
+      workflowId: { source: "fixed", value: workflowId },
+      items: { source: "fixed", value: [item] },
+      input,
+      concurrency: 1,
+    } },
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+  ], [edge("call", "start", "success", "children"), edge("finish", "children", "success", "finish")]);
+}
+
+function nonTerminalChildren(parentRunId: string): number {
+  return repository.listChildRuns(parentRunId, "children")
+    .filter((child) => !["completed", "failed", "cancelled"].includes(child.status)).length;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-fanout-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => "2026-08-05T12:00:00.000Z");
+  executor = new Executor();
+  service = buildService();
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("Workflow Call fan-out", () => {
+  it("binds a direct call to a validated Todo and includes it in idempotency", async () => {
+    const target = childWorkflow("todo-call-target");
+    const callerDefinition = save("todo-call-caller", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "work", type: "employee", name: "Work", config: {
+        employee: { source: "fixed", value: "worker" }, prompt: "Call the child.",
+      } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("work", "start", "success", "work"), edge("finish", "work", "success", "finish")]);
+    const callerRun = await service.startManual({ workflowId: callerDefinition.id, input: {} });
+    const call = {
+      workflowId: target.id,
+      caller: { workflowId: callerDefinition.id, runId: callerRun.id, nodeId: "work" },
+      input: { topic: "bound" },
+      idempotencyKey: "todo-bound-call",
+      itemIndex: 4,
+    };
+
+    const first = await service.callWorkflow({ ...call, todoId: "PLA-9" });
+    const replay = await service.callWorkflow({ ...call, todoId: "PLA-9" });
+
+    expect(first.trigger.todoId).toBe("PLA-9");
+    expect(replay.id).toBe(first.id);
+    await expect(service.callWorkflow({ ...call, todoId: "PLA-10" })).rejects.toMatchObject({
+      code: "idempotency-conflict",
+    });
+
+    const runCount = service.listRuns(target.id, {}).items.length;
+    for (const [index, todoId] of ["pla-9", "PLA-0", "NOTATODO", 9].entries()) {
+      await expect(service.callWorkflow({
+        ...call,
+        idempotencyKey: `invalid-todo-${index}`,
+        todoId: todoId as string,
+      })).rejects.toMatchObject({ code: "bad-input" });
+      expect(service.listRuns(target.id, {}).items).toHaveLength(runCount);
+    }
+  });
+
+  it("lifts a mapped Todo id onto the child trigger without removing it from input", async () => {
+    const child = childWorkflow("mapped-todo-child");
+    const parent = todoCallParent("mapped-todo-parent", child.id, {
+      todoId: { source: "trigger", path: "item.todoId" },
+      topic: { source: "trigger", path: "item.topic" },
+    }, { todoId: "OPS-7", topic: "mapped" });
+
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    const childSummary = repository.listChildRuns(run.id, "children")[0]!;
+    const childRun = service.getRun(childSummary.workflowId, childSummary.runId)!;
+
+    expect(childRun.trigger.todoId).toBe("OPS-7");
+    expect(childRun.input).toEqual({ todoId: "OPS-7", topic: "mapped" });
+  });
+
+  it("keeps a child unbound when its input mapping has no Todo id", async () => {
+    const child = childWorkflow("unbound-todo-child");
+    const parent = todoCallParent("unbound-todo-parent", child.id, {
+      topic: { source: "trigger", path: "item.topic" },
+    }, { topic: "unbound" });
+
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    const childSummary = repository.listChildRuns(run.id, "children")[0]!;
+    const childRun = service.getRun(childSummary.workflowId, childSummary.runId)!;
+
+    expect(childRun.trigger).not.toHaveProperty("todoId");
+    expect(childRun.input).toEqual({ topic: "unbound" });
+  });
+
+  it("fails the Workflow Call node when its mapped Todo id is malformed", async () => {
+    const child = childWorkflow("invalid-todo-child");
+    const parent = todoCallParent("invalid-todo-parent", child.id, {
+      todoId: { source: "trigger", path: "item.todoId" },
+      topic: { source: "trigger", path: "item.topic" },
+    }, { todoId: "not-a-todo", topic: "invalid" });
+
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+
+    expect(run.status).toBe("failed");
+    expect(run.nodeRuns.find((node) => node.nodeId === "children")).toMatchObject({
+      status: "failed",
+      error: { message: expect.stringMatching(/Workflow Call children.*AAA-123/) },
+    });
+    expect(repository.listChildRuns(run.id, "children")).toEqual([]);
+  });
+
+  it("bounds concurrency, maps each item, joins failures, and routes on summary", async () => {
+    childWorkflow();
+    const parent = parentWorkflow();
+
+    const started = await service.startManual({ workflowId: parent.id, input: {} });
+
+    expect(executor.commands).toHaveLength(2);
+    expect(nonTerminalChildren(started.id)).toBe(2);
+    expect(repository.listChildRuns(started.id, "children").map((child) => ({
+      itemIndex: child.itemIndex,
+      caller: service.getRun(child.workflowId, child.runId)?.trigger.payload.caller,
+      input: service.getRun(child.workflowId, child.runId)?.input,
+    }))).toEqual([
+      { itemIndex: 0, caller: { workflowId: parent.id, runId: started.id, nodeId: "children" }, input: { topic: "alpha", ordinal: 0 } },
+      { itemIndex: 1, caller: { workflowId: parent.id, runId: started.id, nodeId: "children" }, input: { topic: "beta", ordinal: 1 } },
+    ]);
+
+    await executor.settle(executor.commands[0]!, "succeeded", { result: "done-alpha" });
+    await vi.waitFor(() => expect(executor.commands).toHaveLength(3));
+    expect(nonTerminalChildren(started.id)).toBeLessThanOrEqual(2);
+
+    await executor.settle(executor.commands[1]!, "failed");
+    await vi.waitFor(() => expect(executor.commands).toHaveLength(4));
+    expect(nonTerminalChildren(started.id)).toBeLessThanOrEqual(2);
+
+    await executor.settle(executor.commands[2]!, "succeeded", { result: "done-gamma" });
+    await executor.settle(executor.commands[3]!, "succeeded", { result: "done-delta" });
+    await vi.waitFor(() => expect(service.getRun(parent.id, started.id)?.status).toBe("completed"));
+
+    const completed = service.getRun(parent.id, started.id)!;
+    expect(completed.nodeRuns.find((node) => node.nodeId === "children")?.output?.fields).toEqual({
+      total: 4,
+      succeeded: 3,
+      failed: 1,
+      cancelled: 0,
+      summary: "partial",
+      outcomes: [
+        expect.objectContaining({ index: 0, workflowId: "child-flow", status: "succeeded", fields: { result: "done-alpha" } }),
+        expect.objectContaining({ index: 1, workflowId: "child-flow", status: "failed", fields: {} }),
+        expect.objectContaining({ index: 2, workflowId: "child-flow", status: "succeeded", fields: { result: "done-gamma" } }),
+        expect.objectContaining({ index: 3, workflowId: "child-flow", status: "succeeded", fields: { result: "done-delta" } }),
+      ],
+    });
+    expect(completed.nodeRuns.find((node) => node.nodeId === "partial")?.output?.fields).toEqual({ route: "partial" });
+    expect(completed.nodeRuns.find((node) => node.nodeId === "other")?.status).toBe("skipped");
+  });
+
+  it("starts exactly one child when items is absent", async () => {
+    const child = save("single-child", [
+      { id: "start", type: "trigger", name: "Called", config: { kind: "workflow-call" } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("finish", "start", "success", "finish")]);
+    const parent = save("single-parent", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "children", type: "workflow-call", name: "Child", config: {
+        workflowId: { source: "fixed", value: child.id }, concurrency: 2,
+      } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("call", "start", "success", "children"), edge("finish", "children", "success", "finish")]);
+
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+
+    expect(run.status).toBe("completed");
+    expect(repository.listChildRuns(run.id, "children")).toHaveLength(1);
+    expect(repository.listChildRuns(run.id, "children")[0]).toMatchObject({ itemIndex: 0, status: "completed" });
+  });
+
+  it("cancels every non-terminal child when its parent is cancelled", async () => {
+    childWorkflow();
+    const parent = parentWorkflow("cancel-parent", { items: [{ topic: "one" }, { topic: "two" }, { topic: "three" }] });
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    expect(repository.listChildRuns(run.id, "children")).toHaveLength(2);
+
+    await service.cancelRun({ workflowId: parent.id, runId: run.id, reason: "Stop the batch." });
+
+    expect(service.getRun(parent.id, run.id)?.status).toBe("cancelled");
+    expect(repository.listChildRuns(run.id, "children").map((child) => child.status)).toEqual(["cancelled", "cancelled"]);
+  });
+
+  it("does not leave a child running when fan-out creation races parent cancellation", async () => {
+    childWorkflow();
+    const parent = parentWorkflow("racing-cancel-parent", {
+      items: [{ topic: "one" }, { topic: "two" }, { topic: "three" }],
+      concurrency: 2,
+    });
+    const originalCallWorkflow = service.callWorkflow.bind(service);
+    const originalCancelRun = service.cancelRun.bind(service);
+    let releaseSecondCall!: () => void;
+    let secondCallEntered!: () => void;
+    let releaseChildCancellation!: () => void;
+    let childCancellationEntered!: () => void;
+    const secondCallBlocked = new Promise<void>((resolve) => { secondCallEntered = resolve; });
+    const secondCallReleased = new Promise<void>((resolve) => { releaseSecondCall = resolve; });
+    const childCancellationBlocked = new Promise<void>((resolve) => { childCancellationEntered = resolve; });
+    const childCancellationReleased = new Promise<void>((resolve) => { releaseChildCancellation = resolve; });
+    let calls = 0;
+    vi.spyOn(service, "callWorkflow").mockImplementation(async (input) => {
+      calls += 1;
+      if (calls === 2) {
+        secondCallEntered();
+        await secondCallReleased;
+      }
+      return originalCallWorkflow(input);
+    });
+    vi.spyOn(service, "cancelRun").mockImplementation(async (input) => {
+      if (input.workflowId === "child-flow") {
+        childCancellationEntered();
+        await childCancellationReleased;
+      }
+      return originalCancelRun(input);
+    });
+
+    const starting = service.startManual({ workflowId: parent.id, input: {} });
+    await secondCallBlocked;
+    const started = repository.listRuns(parent.id, { limit: 10 }).items[0]!;
+    const cancelling = service.cancelRun({ workflowId: parent.id, runId: started.id, reason: "Stop the batch." });
+    await childCancellationBlocked;
+    releaseSecondCall();
+    await starting;
+    releaseChildCancellation();
+    await cancelling;
+
+    expect(service.getRun(parent.id, started.id)?.status).toBe("cancelled");
+    expect(repository.listChildRuns(started.id, "children").every((child) => child.status === "cancelled")).toBe(true);
+    expect(nonTerminalChildren(started.id)).toBe(0);
+  });
+
+  it("fails the node with the recursion error for a dynamic self target", async () => {
+    const created = service.createDefinition({ id: "dynamic-recursion", title: "Dynamic recursion" });
+    const saved = service.saveDefinition({
+      ...created,
+      inputs: [{ key: "target", label: "Target", type: "string", required: true }],
+      nodes: [
+        { id: "start", type: "trigger", name: "Start", config: { kind: "workflow-call" } },
+        { id: "children", type: "workflow-call", name: "Children", config: {
+          workflowId: { source: "input", path: "target" }, concurrency: 1,
+        } },
+        { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+      ],
+      edges: [edge("call", "start", "success", "children"), edge("finish", "children", "success", "finish")],
+    }, created.revision);
+    const enabled = service.setEnabled({ id: saved.id, enabled: true, expectedRevision: saved.revision });
+    const bootstrap = save("recursion-bootstrap", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "work", type: "employee", name: "Work", config: {
+        employee: { source: "fixed", value: "worker" }, prompt: "Start child.",
+      } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("work", "start", "success", "work"), edge("finish", "work", "success", "finish")]);
+    const bootstrapRun = await service.startManual({ workflowId: bootstrap.id, input: {} });
+
+    const run = await service.callWorkflow({
+      workflowId: enabled.id,
+      caller: { workflowId: bootstrap.id, runId: bootstrapRun.id, nodeId: "work" },
+      input: { target: enabled.id },
+      idempotencyKey: "recursive-entry",
+    });
+
+    expect(run.status).toBe("failed");
+    expect(run.nodeRuns.find((node) => node.nodeId === "children")).toMatchObject({
+      status: "failed",
+      error: { message: expect.stringMatching(/recursion/i) },
+    });
+  });
+
+  it("recovers a parent after its children settle while the service is down without duplicates", async () => {
+    const child = save("parked-child", [
+      { id: "start", type: "trigger", name: "Called", config: { kind: "workflow-call" } },
+      { id: "pause", type: "wait", name: "Pause", config: { mode: "duration", minutes: 60 } },
+      { id: "finish", type: "end", name: "Finish", config: {
+        result: "success", output: { source: "fixed", value: { recovered: true } },
+      } },
+    ], [edge("pause", "start", "success", "pause"), edge("finish", "pause", "success", "finish")]);
+    const parent = save("recover-parent", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "children", type: "workflow-call", name: "Children", config: {
+        workflowId: { source: "fixed", value: child.id },
+        items: { source: "fixed", value: ["one", "two"] },
+        concurrency: 2,
+      } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("children", "start", "success", "children"), edge("finish", "children", "success", "finish")]);
+    const run = await service.startManual({ workflowId: parent.id, input: {} });
+    const children = repository.listChildRuns(run.id, "children");
+    expect(children).toHaveLength(2);
+    expect(children.map((item) => item.status)).toEqual(["waiting", "waiting"]);
+
+    service.dispose();
+    for (const childRun of children) {
+      const detail = repository.getRun(childRun.workflowId, childRun.runId)!;
+      repository.mutateRun(detail.id, detail.revision, (tx) => {
+        tx.setNodeStatus("pause", "completed", { output: { text: "", fields: {} }, endedAt: "2026-08-05T12:05:00.000Z" });
+        tx.setNodeStatus("finish", "completed", { activated: true,
+          output: { text: "", fields: { recovered: true } }, startedAt: "2026-08-05T12:05:00.000Z", endedAt: "2026-08-05T12:05:00.000Z" });
+        tx.setRunStatus("completed", { endedAt: "2026-08-05T12:05:00.000Z" });
+      });
+    }
+
+    service = buildService();
+    await service.recover("2026-08-05T12:05:00.000Z");
+
+    expect(service.getRun(parent.id, run.id)?.status).toBe("completed");
+    expect(repository.listChildRuns(run.id, "children")).toHaveLength(2);
+    expect(service.getRun(parent.id, run.id)?.nodeRuns.find((node) => node.nodeId === "children")?.output?.fields)
+      .toMatchObject({ total: 2, succeeded: 2, failed: 0, cancelled: 0, summary: "all-succeeded" });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-iteration.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-iteration.test.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { JsonValue, WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService, WorkflowServiceError } from "../service.js";
+import { Executor, employee, models } from "./iteration-harness.js";
+
+/**
+ * The runtime half of bounded iteration, on the shape it was built for: a body
+ * that keeps asking for another round. It has to stop at exactly `maxRounds`,
+ * leave through `exhausted`, and keep every round separately readable.
+ */
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: Executor;
+let service: WorkflowService;
+
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function save(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = service.createDefinition({ id, title: id });
+  const saved = service.saveDefinition({ ...created, nodes, edges }, created.revision);
+  return service.setEnabled({ id, enabled: true, expectedRevision: saved.revision });
+}
+
+/** The loop body: one employee that reports a verdict, and echoes which round it
+ *  believes it is in so the round binding can be read back off the attempt. */
+function bodyWorkflow(): WorkflowDefinition {
+  return save("body-flow", [
+    { id: "start", type: "trigger", name: "Called", config: { kind: "workflow-call" } },
+    { id: "work", type: "employee", name: "Work", config: {
+      employee: { source: "fixed", value: "worker" },
+      prompt: "Round {{ input.round }} of {{ input.maxRounds }}.",
+      retry: { attempts: 1, delaySeconds: 0, backoff: "fixed" },
+    } },
+    { id: "finish", type: "end", name: "Finish", config: {
+      result: "success", output: { source: "node", nodeId: "work", path: "fields" },
+    } },
+  ], [edge("start-work", "start", "success", "work"), edge("work-finish", "work", "success", "finish")]);
+}
+
+/** implement/verify/verdict as one authored body called at most `maxRounds`
+ *  times — the shape that costs a duplicated round-2 subgraph today. */
+function loopWorkflow(maxRounds: number): WorkflowDefinition {
+  return save("loop-flow", [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "loop", type: "workflow-call", name: "Rework loop", config: {
+      workflowId: { source: "fixed", value: "body-flow" },
+      input: {
+        round: { source: "trigger", path: "round" },
+        maxRounds: { source: "trigger", path: "maxRounds" },
+      },
+      concurrency: 1,
+      iterate: {
+        maxRounds,
+        continueWhile: [{
+          left: { source: "node", nodeId: "loop", path: "fields.last.verdict" },
+          operator: "equals", right: { source: "fixed", value: "rework" },
+        }],
+      },
+    } },
+    { id: "shipped", type: "end", name: "Shipped", config: {
+      result: "success", output: { source: "fixed", value: { route: "shipped" } },
+    } },
+    { id: "escalated", type: "end", name: "Escalated", config: {
+      result: "success", output: { source: "fixed", value: { route: "escalated" } },
+    } },
+  ], [
+    edge("start-loop", "start", "success", "loop"),
+    edge("loop-shipped", "loop", "success", "shipped"),
+    edge("loop-escalated", "loop", "exhausted", "escalated"),
+  ]);
+}
+
+/** The validation issue codes a rejected authoring call carried. */
+function issueCodes(call: () => unknown): string[] {
+  try { call(); } catch (error) {
+    return error instanceof WorkflowServiceError ? (error.issues ?? []).map((issue) => issue.code) : [];
+  }
+  throw new Error("Expected the call to be refused.");
+}
+
+function endedAt(runId: string): { route: string; status: string } {
+  const detail = service.getRun("loop-flow", runId)!;
+  const ends = detail.nodeRuns.filter((node) => node.nodeType === "end" && node.status === "completed");
+  return { route: ends.map((node) => node.nodeId).join(",") || "none", status: detail.status };
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-iteration-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => "2026-08-20T12:00:00.000Z");
+  executor = new Executor();
+  service = new WorkflowService({
+    repository,
+    executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]),
+    models: () => models,
+    now: () => "2026-08-20T12:00:00.000Z",
+  });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("bounded iteration at run time", () => {
+  it("stops at exactly maxRounds and leaves through the exhausted route when the body keeps asking", async () => {
+    bodyWorkflow();
+    loopWorkflow(3);
+    const run = await service.startManual({ workflowId: "loop-flow", input: {} });
+
+    // Four verdicts offered, three rounds allowed.
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      if (executor.commands.length <= attempt) break;
+      await executor.settleLatest({ verdict: "rework" });
+    }
+
+    const children = repository.listChildRuns(run.id, "loop");
+    expect(children).toHaveLength(3);
+    expect(executor.commands).toHaveLength(3);
+    expect(endedAt(run.id)).toEqual({ route: "escalated", status: "completed" });
+
+    const output = service.getRun("loop-flow", run.id)!.nodeRuns.find((node) => node.nodeId === "loop")!.output!;
+    expect(output.fields).toMatchObject({ round: 3, maxRounds: 3, port: "exhausted", exhausted: true });
+  });
+
+  it("leaves through success as soon as a round stops asking, without spending the rest of the bound", async () => {
+    bodyWorkflow();
+    loopWorkflow(3);
+    const run = await service.startManual({ workflowId: "loop-flow", input: {} });
+
+    await executor.settleLatest({ verdict: "rework" });
+    await executor.settleLatest({ verdict: "ship" });
+
+    expect(repository.listChildRuns(run.id, "loop")).toHaveLength(2);
+    expect(endedAt(run.id)).toEqual({ route: "shipped", status: "completed" });
+    expect(service.getRun("loop-flow", run.id)!.nodeRuns.find((node) => node.nodeId === "loop")!.output!.fields)
+      .toMatchObject({ round: 2, port: "success", exhausted: false, last: { verdict: "ship" } });
+  });
+
+  it("tells each round which one it is", async () => {
+    bodyWorkflow();
+    loopWorkflow(2);
+    await service.startManual({ workflowId: "loop-flow", input: {} });
+
+    await executor.settleLatest({ verdict: "rework" });
+    await executor.settleLatest({ verdict: "rework" });
+
+    expect(executor.commands[0]!.prompt).toContain("Round 1 of 2.");
+    expect(executor.commands[1]!.prompt).toContain("Round 2 of 2.");
+  });
+
+  it("keeps every round separately auditable, each with its own run, status and output", async () => {
+    bodyWorkflow();
+    loopWorkflow(3);
+    const run = await service.startManual({ workflowId: "loop-flow", input: {} });
+
+    await executor.settleLatest({ verdict: "rework" });
+    await executor.settleLatest({ verdict: "ship" });
+
+    const detail = service.getRun("loop-flow", run.id)!;
+    const children = detail.childRuns.filter((child) => child.nodeId === "loop");
+    expect(children.map((child) => child.itemIndex)).toEqual([0, 1]);
+    expect(new Set(children.map((child) => child.runId)).size).toBe(2);
+    expect(children.map((child) => child.endOutput)).toEqual([{ verdict: "rework" }, { verdict: "ship" }]);
+    for (const child of children) {
+      const body = service.getRun(child.workflowId, child.runId)!;
+      expect(body.status).toBe("completed");
+      expect(body.attempts.filter((attempt) => attempt.sessionId).length).toBe(1);
+    }
+
+    const rounds = detail.nodeRuns.find((node) => node.nodeId === "loop")!.output!.fields.rounds as JsonValue[];
+    expect(rounds).toMatchObject([
+      { round: 1, status: "succeeded", fields: { verdict: "rework" } },
+      { round: 2, status: "succeeded", fields: { verdict: "ship" } },
+    ]);
+  });
+
+  it("never lets a round replay the round before it", async () => {
+    bodyWorkflow();
+    loopWorkflow(2);
+    const run = await service.startManual({ workflowId: "loop-flow", input: {} });
+
+    await executor.settleLatest({ verdict: "rework" });
+    await executor.settleLatest({ verdict: "rework" });
+
+    const keys = repository.listChildRuns(run.id, "loop")
+      .map((child) => service.getRun(child.workflowId, child.runId)!.idempotencyKey);
+    expect(new Set(keys).size).toBe(2);
+    expect(keys).toEqual([`${run.id}:loop:1`, `${run.id}:loop:2`]);
+  });
+
+  it("stops on a round that did not finish rather than reading it as a clean loop", async () => {
+    bodyWorkflow();
+    loopWorkflow(3);
+    const run = await service.startManual({ workflowId: "loop-flow", input: {} });
+
+    await executor.failLatest();
+
+    // One round ran and broke. The loop neither claims success nor asks the
+    // broken body for another round.
+    expect(repository.listChildRuns(run.id, "loop")).toHaveLength(1);
+    expect(executor.commands).toHaveLength(1);
+    const detail = service.getRun("loop-flow", run.id)!;
+    expect(detail.status).toBe("failed");
+    expect(endedAt(run.id).route).toBe("none");
+    const loop = detail.nodeRuns.find((node) => node.nodeId === "loop")!;
+    expect(loop.status).not.toBe("completed");
+    expect(detail.error?.message).toMatch(/round 1 failed/);
+  });
+
+  it("refuses to store a loop with no bound, but lets a half-drawn one stay saveable", async () => {
+    bodyWorkflow();
+    const loop = (iterate: Record<string, unknown>): WorkflowNode => ({
+      id: "loop", type: "workflow-call", name: "Loop",
+      config: { workflowId: { source: "fixed", value: "body-flow" }, concurrency: 1, iterate } as never,
+    });
+    const nodes = (iterate: Record<string, unknown>): WorkflowNode[] => [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      loop(iterate),
+      { id: "shipped", type: "end", name: "Shipped", config: { result: "success" } },
+    ];
+    const wired = [edge("start-loop", "start", "success", "loop"), edge("loop-shipped", "loop", "success", "shipped")];
+    const check = [{ left: { source: "node", nodeId: "loop", path: "fields.last.verdict" },
+      operator: "equals", right: { source: "fixed", value: "rework" } }];
+
+    // The bound is node-local, so it is refused before the definition is stored.
+    const draft = service.createDefinition({ id: "unbounded-flow", title: "Unbounded" });
+    expect(() => service.saveDefinition({ ...draft, nodes: nodes({ continueWhile: check }), edges: wired }, draft.revision))
+      .toThrow(WorkflowServiceError);
+    expect(issueCodes(() => service.saveDefinition(
+      { ...draft, nodes: nodes({ continueWhile: check }), edges: wired }, draft.revision))).toContain("unbounded-iteration");
+
+    // The exhausted route is a wiring rule: a loop mid-draw still saves, and
+    // only enabling it insists the escalation lane exists.
+    const partial = service.createDefinition({ id: "half-drawn-flow", title: "Half drawn" });
+    const saved = service.saveDefinition(
+      { ...partial, nodes: nodes({ maxRounds: 2, continueWhile: check }), edges: wired }, partial.revision);
+    expect(saved.revision).toBeGreaterThan(partial.revision);
+    expect(issueCodes(() => service.setEnabled({ id: saved.id, enabled: true, expectedRevision: saved.revision })))
+      .toContain("iteration-missing-exhausted-route");
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-recovery.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-recovery.test.ts
@@ -1,0 +1,419 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Employee, Engine, JinnConfig, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener } from "../../shared/types.js";
+import type { WorkflowDefinition, WorkflowNode } from "../model.js";
+import type { SessionManager } from "../../sessions/manager.js";
+import { resumableEngineSession } from "../../sessions/attempt-continuation.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+const sessionHome = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-recovery-sessions-"));
+process.env.JINN_HOME = sessionHome;
+const employee: Employee = { name: "worker", displayName: "Worker", department: "operations", rank: "employee",
+  engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work." };
+const models: ModelRegistry = { "test-engine": { name: "test-engine", available: true, defaultModel: "test-model",
+  effortMechanism: "codex-config", models: [{ id: "test-model", label: "Test", supportsEffort: true, effortLevels: ["high"] }] } };
+
+class DurableExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  readonly sessions = new Map<string, string>();
+  readonly stopped: string[] = [];
+  failStops = false;
+  failStarts = 0;
+  terminalReader?: (sessionId: string) => WorkflowAttemptCompletion | null;
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+  private readonly receipts = new Map<string, WorkflowAttemptCompletion>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    if (this.failStarts > 0) { this.failStarts -= 1; throw new Error("dispatch unavailable"); }
+    this.commands.push(command);
+    const key = `${command.owner.runId}:${command.owner.nodeId}:${command.owner.attempt}`;
+    const sessionId = this.sessions.get(key) ?? `session:${key}`;
+    this.sessions.set(key, sessionId);
+    return { sessionId };
+  }
+  async stopAttempt(input: { sessionId: string }): Promise<void> {
+    this.stopped.push(input.sessionId);
+    if (this.failStops) throw new Error("stop unavailable");
+  }
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener); return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(sessionId: string): WorkflowAttemptCompletion | null {
+    return this.terminalReader?.(sessionId) ?? this.receipts.get(sessionId) ?? null;
+  }
+  resumableEngineSession(sessionId: string, engine: string): string | null { return resumableEngineSession(sessionId, engine); }
+  async settle(nodeId: string, outcome: "succeeded" | "failed", at: string): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    const key = `${command.owner.runId}:${nodeId}:${command.owner.attempt}`;
+    const event: WorkflowAttemptCompletion = { sessionId: this.sessions.get(key)!, owner: command.owner, turn: 1, terminalVersion: 1,
+      outcome, ...(outcome === "succeeded"
+        ? { finalText: "Done.\n```jinn-output\n{}\n```" }
+        // A transport diagnostic on purpose: these tests exercise the retry
+        // MECHANISM, and only an undelivered attempt earns a retry budget.
+        : { error: "Interactive turn failed: server_error" }), completedAt: at };
+    this.receipts.set(event.sessionId, event);
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+}
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: DurableExecutor;
+let service: WorkflowService;
+let now: Date;
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+function worker(id: string, attempts = 3, delaySeconds = 60): Extract<WorkflowNode, { type: "employee" }> {
+  return { id, type: "employee", name: id, config: { employee: { source: "fixed", value: "worker" }, prompt: `Run ${id}.`,
+    retry: { attempts, delaySeconds, backoff: "exponential" }, timeoutMinutes: 1 } };
+}
+function workerWithoutTimeout(id: string): Extract<WorkflowNode, { type: "employee" }> {
+  const node = worker(id);
+  const { timeoutMinutes: _timeoutMinutes, ...config } = node.config;
+  return { ...node, config };
+}
+function save(id: string, nodes: WorkflowNode[], edges: WorkflowDefinition["edges"]): WorkflowDefinition {
+  const created = repository.createDefinition({ id, title: id });
+  const saved = repository.saveDefinition({ ...created, nodes, edges }, created.revision);
+  return repository.setEnabled(id, true, saved.revision);
+}
+function linear(id: string, work = worker("work", 2, 0), result: "success" | "failure" = "success") {
+  const finish = result === "success" ? "finish" : "failed";
+  return save(id, [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } }, work,
+    { id: finish, type: "end", name: finish, config: { result } },
+  ], [edge("start-work", "start", "success", "work"), edge("work-finish", "work", result === "success" ? "success" : "error", finish)]);
+}
+function buildService(): WorkflowService {
+  return new WorkflowService({ repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString() });
+}
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-recovery-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  now = new Date("2026-07-21T10:00:00.000Z");
+  repository = new WorkflowRepository(database, () => now.toISOString()); executor = new DurableExecutor(); service = buildService();
+});
+afterEach(() => { service.dispose(); vi.useRealTimers(); database.close(); fs.rmSync(root, { recursive: true, force: true }); });
+afterAll(async () => {
+  await import("../../sessions/registry.js");
+  (await import("../../shared/db.js")).__closeDbForTest();
+  fs.rmSync(sessionHome, { recursive: true, force: true });
+});
+describe("Workflow retry, cancellation, and restart recovery", () => {
+  it("persists failure before bounded exponential retry and never duplicates the next attempt", async () => {
+    const definition = linear("retry-flow", worker("work"));
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.settle("work", "failed", now.toISOString());
+    let failed = service.getRun(definition.id, run.id)!;
+    expect(failed.attempts).toMatchObject([{ attempt: 1, status: "failed" }]);
+    expect(failed.nodeRuns.find((node) => node.nodeId === "work")).toMatchObject({
+      status: "waiting", resumeAt: "2026-07-21T10:01:00.000Z",
+    });
+    const secondDatabase = openWorkflowDatabase(path.join(root, "workflows.db"));
+    const secondExecutor = new DurableExecutor();
+    const secondService = new WorkflowService({ repository: new WorkflowRepository(secondDatabase, () => now.toISOString()),
+      executor: secondExecutor as unknown as WorkflowSessionExecutor, employees: () => new Map([[employee.name, employee]]),
+      models: () => models, now: () => now.toISOString() });
+    const [retried, replayed] = await Promise.all([
+      service.retryNode({ workflowId: definition.id, runId: run.id, nodeId: "work", idempotencyKey: "retry-1" }),
+      secondService.retryNode({ workflowId: definition.id, runId: run.id, nodeId: "work", idempotencyKey: "retry-1" }),
+    ]);
+    expect(retried.attempts.map((attempt) => attempt.attempt)).toEqual([1, 2]);
+    expect(replayed.attempts.map((attempt) => attempt.attempt)).toEqual([1, 2]);
+    expect(executor.sessions).toHaveLength(2);
+    now = new Date("2026-07-21T10:02:00.000Z");
+    await executor.settle("work", "failed", now.toISOString());
+    failed = service.getRun(definition.id, run.id)!;
+    expect(failed.nodeRuns.find((node) => node.nodeId === "work")?.resumeAt).toBe("2026-07-21T10:04:00.000Z");
+    const settledReplay = await secondService.retryNode({ workflowId: definition.id, runId: run.id, nodeId: "work", idempotencyKey: "retry-1" });
+    expect(settledReplay.attempts.map((attempt) => attempt.attempt)).toEqual([1, 2]);
+    secondService.dispose(); secondDatabase.close();
+    service.dispose(); service = buildService(); now = new Date("2026-07-21T10:04:00.000Z");
+    await service.recover(now.toISOString());
+    expect(service.getRun(definition.id, run.id)?.attempts.map((attempt) => attempt.attempt)).toEqual([1, 2, 3]);
+    await executor.settle("work", "succeeded", now.toISOString());
+    expect(service.getRun(definition.id, run.id)?.status).toBe("completed");
+  });
+
+  it("rejects incompatible retry-key reuse for another Employee", async () => {
+    const definition = save("retry-key-conflict", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } }, worker("alpha"), worker("beta"),
+      { id: "alpha-end", type: "end", name: "Alpha", config: { result: "success" } },
+      { id: "beta-end", type: "end", name: "Beta", config: { result: "success" } },
+    ], [edge("start-alpha", "start", "success", "alpha"), edge("start-beta", "start", "success", "beta"),
+      edge("alpha-end", "alpha", "success", "alpha-end"), edge("beta-end", "beta", "success", "beta-end")]);
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.settle("alpha", "failed", now.toISOString());
+    await executor.settle("beta", "failed", now.toISOString());
+    await service.retryNode({ workflowId: definition.id, runId: run.id, nodeId: "alpha", idempotencyKey: "same-key" });
+    await expect(service.retryNode({ workflowId: definition.id, runId: run.id, nodeId: "beta", idempotencyKey: "same-key" }))
+      .rejects.toThrow(/idempotency key.*different/i);
+  });
+
+  it("wakes a future Wait committed after boot at exactly resumeAt without external recovery", async () => {
+    service.dispose();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    service = buildService();
+    const definition = save("timer-wait", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "pause", type: "wait", name: "Pause", config: { mode: "duration", minutes: 5 } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ], [edge("start-pause", "start", "success", "pause"), edge("pause-finish", "pause", "success", "finish")]);
+    const waiting = await service.startManual({ workflowId: definition.id, input: {} });
+    now = new Date("2026-07-21T10:04:59.999Z");
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(service.getRun(definition.id, waiting.id)?.status).toBe("waiting");
+    now = new Date("2026-07-21T10:05:00.000Z");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(service.getRun(definition.id, waiting.id)?.status).toBe("completed");
+    now = new Date("2026-07-21T11:00:00.000Z");
+    vi.setSystemTime(now);
+    const disposed = await service.startManual({ workflowId: definition.id, input: {} });
+    service.dispose();
+    now = new Date("2026-07-21T11:05:00.000Z");
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(repository.getRun(definition.id, disposed.id)?.status).toBe("waiting");
+  });
+
+  it("times out a wedged running attempt at its deadline without external recovery", async () => {
+    service.dispose();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    service = buildService();
+    const definition = linear("timer-timeout", worker("work", 1, 0));
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+
+    now = new Date("2026-07-21T10:00:59.999Z");
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(service.getRun(definition.id, run.id)?.attempts).toMatchObject([{ status: "running" }]);
+
+    now = new Date("2026-07-21T10:01:00.000Z");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(service.getRun(definition.id, run.id)?.attempts).toMatchObject([{
+      status: "timed-out",
+      error: { code: "workflow-timeout" },
+    }]);
+  });
+
+  it("defaults an unconfigured employee attempt timeout to 180 minutes", async () => {
+    const definition = linear("default-timeout", workerWithoutTimeout("work"));
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(run.attempts).toMatchObject([{ resolvedConfig: { timeoutMinutes: 180 } }]);
+  });
+
+  it("preserves an authored employee attempt timeout", async () => {
+    const authored = worker("work");
+    const definition = linear("authored-timeout", {
+      ...authored,
+      config: { ...authored.config, timeoutMinutes: 17 },
+    });
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(run.attempts).toMatchObject([{ resolvedConfig: { timeoutMinutes: 17 } }]);
+  });
+
+  it("times out durably, stops the owned session, and advances the deterministic retry", async () => {
+    const definition = linear("timeout-flow");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    now = new Date("2026-07-21T10:01:00.000Z");
+    await service.recover(now.toISOString());
+    const recovered = service.getRun(definition.id, run.id)!;
+    expect(recovered.attempts.map((attempt) => ({ attempt: attempt.attempt, status: attempt.status })))
+      .toEqual([{ attempt: 1, status: "timed-out" }, { attempt: 2, status: "running" }]);
+    expect(executor.stopped).toEqual([expect.stringContaining(":work:1")]);
+  });
+
+  it("retries a running phase attempt orphaned inside its timeout by a gateway restart", async () => {
+    const authoredWorker = worker("work", 2, 60);
+    const definition = linear("restart-orphan-flow", {
+      ...authoredWorker,
+      config: { ...authoredWorker.config, timeoutMinutes: 180 },
+    });
+    const created = repository.createRun({
+      workflowId: definition.id,
+      input: {},
+      trigger: { nodeId: "start", kind: "manual", payload: {} },
+    });
+    const registry = await import("../../sessions/registry.js");
+    const key = `workflow:${definition.id}:${created.id}:work:1`;
+    const session = registry.getOrCreateWorkflowAttemptSession({
+      engine: "test-engine",
+      source: "workflow",
+      sourceRef: key,
+      connector: "workflow",
+      sessionKey: key,
+      employee: "worker",
+      model: "test-model",
+      effortLevel: "high",
+      prompt: "Run work.",
+      workflowProvenance: {
+        kind: "phase",
+        workflowId: definition.id,
+        workflowName: definition.id,
+        runId: created.id,
+        triggerSource: "manual",
+        phase: { nodeId: "work", name: "work", index: 1, round: 1, attempt: 1 },
+      },
+    });
+    registry.updateSession(session.id, { status: "running" });
+    const config = {
+      employeeId: "worker",
+      engine: "test-engine",
+      model: "test-model",
+      effort: "high" as const,
+      retry: { attempts: 2, delaySeconds: 60, backoff: "exponential" as const },
+      timeoutMinutes: 180,
+    };
+    const detail = repository.getRun(definition.id, created.id)!;
+    repository.mutateRun(detail.id, detail.revision, (tx) => {
+      tx.setRunStatus("running");
+      tx.setNodeStatus("start", "completed", {
+        activated: true,
+        startedAt: now.toISOString(),
+        endedAt: now.toISOString(),
+      });
+      tx.setNodeStatus("work", "running", {
+        activated: true,
+        resolvedConfig: config,
+        input: {},
+        startedAt: now.toISOString(),
+      });
+      const attempt = tx.createAttempt({ nodeId: "work", resolvedConfig: config, input: {} });
+      tx.settleAttempt("work", attempt.attempt, { status: "running", sessionId: session.id });
+    });
+    const { WorkflowSessionExecutor: ReceiptReader } = await import("../session-executor.js");
+    const receiptReader = new ReceiptReader(
+      {} as SessionManager,
+      (sessionId) => {
+        const stored = registry.getSession(sessionId);
+        return stored ? { session: stored } : null;
+      },
+    );
+    executor.terminalReader = (sessionId) => receiptReader.readTerminalCompletion(sessionId);
+
+    now = new Date("2026-07-21T10:05:00.000Z");
+    const recovery = registry as typeof registry & {
+      recoverStaleWorkflowAttemptSessions?: () => number;
+    };
+    // Keep the call optional so reverting the boot sweep proves the incident
+    // assertion below instead of failing earlier on a missing export.
+    recovery.recoverStaleWorkflowAttemptSessions?.();
+    await service.recover(now.toISOString());
+
+    const recovered = service.getRun(definition.id, created.id)!;
+    expect(recovered.attempts.map((attempt) => attempt.attempt)).toEqual([1, 2]);
+    expect(recovered.nodeRuns.find((node) => node.nodeId === "work")).toMatchObject({ status: "running" });
+    expect(recovered.status).toBe("running");
+  });
+
+  it("recovers persisted dispatch intent and post-dispatch crash without duplicate session or attempt", async () => {
+    const definition = linear("crash-flow");
+    const created = repository.createRun({ workflowId: definition.id, input: {}, trigger: { nodeId: "start", kind: "manual", payload: {} } });
+    const detail = repository.getRun(definition.id, created.id)!;
+    const config = { employeeId: "worker", engine: "test-engine", model: "test-model", effort: "high" as const,
+      retry: { attempts: 2, delaySeconds: 0, backoff: "exponential" as const }, timeoutMinutes: 1 };
+    repository.mutateRun(detail.id, detail.revision, (tx) => {
+      tx.setRunStatus("running"); tx.setNodeStatus("start", "completed", { activated: true, startedAt: now.toISOString(), endedAt: now.toISOString() });
+      tx.setNodeStatus("work", "dispatching", { activated: true, resolvedConfig: config, input: {}, startedAt: now.toISOString() });
+      tx.createAttempt({ nodeId: "work", resolvedConfig: config, input: {} });
+    });
+    service.dispose(); service = buildService();
+    await service.recover(now.toISOString());
+    expect(service.getRun(definition.id, created.id)?.attempts).toMatchObject([{ attempt: 1, status: "running" }]);
+    expect(executor.sessions).toHaveLength(1);
+    service.dispose(); service = buildService();
+    await service.recover(now.toISOString());
+    expect(service.getRun(definition.id, created.id)?.attempts).toHaveLength(1);
+    expect(executor.sessions).toHaveLength(1);
+  });
+
+  it("reconstructs a crash-after-session-insert with the original durable phase session", async () => {
+    const definition = linear("session-crash-flow");
+    const created = repository.createRun({ workflowId: definition.id, input: {},
+      trigger: { nodeId: "start", kind: "manual", payload: {} } });
+    const config = { employeeId: "worker", engine: "test-engine", model: "test-model", effort: "high" as const,
+      retry: { attempts: 2, delaySeconds: 0, backoff: "exponential" as const }, timeoutMinutes: 1 };
+    const detail = repository.getRun(definition.id, created.id)!;
+    repository.mutateRun(detail.id, detail.revision, (tx) => {
+      tx.setRunStatus("running");
+      tx.setNodeStatus("start", "completed", { activated: true, startedAt: now.toISOString(), endedAt: now.toISOString() });
+      tx.setNodeStatus("work", "dispatching", { activated: true, resolvedConfig: config, input: {}, startedAt: now.toISOString() });
+      tx.createAttempt({ nodeId: "work", resolvedConfig: config, input: {} });
+    });
+    const registry = await import("../../sessions/registry.js");
+    const { SessionManager } = await import("../../sessions/manager.js");
+    const { WorkflowSessionExecutor: RealExecutor } = await import("../session-executor.js");
+    const key = `workflow:${definition.id}:${created.id}:work:1`;
+    const inserted = registry.getOrCreateWorkflowAttemptSession({
+      engine: config.engine, source: "workflow", sourceRef: key, connector: "workflow", sessionKey: key,
+      employee: config.employeeId, model: config.model, effortLevel: config.effort, prompt: "Run work.",
+      workflowProvenance: { kind: "phase", workflowId: definition.id, workflowName: definition.id,
+        runId: created.id, triggerSource: "workflow", phase: { nodeId: "work", name: "work", index: 1, round: 1, attempt: 1 } },
+    });
+    const engine: Engine & { calls: number } = { name: "test-engine", calls: 0,
+      run() { this.calls += 1; return new Promise(() => undefined); } };
+    const sessionConfig = { gateway: { port: 0, host: "127.0.0.1" }, engines: { default: "test-engine",
+      claude: { bin: "", model: "test" }, codex: { bin: "", model: "test" }, "test-engine": {} },
+      connectors: {}, logging: { file: false, stdout: false, level: "error" } } as unknown as JinnConfig;
+    // Fork adaptation: jimmy's SessionManager takes (config, engines, connectorNames)
+    // and wires the employee roster through a setter instead of the constructor.
+    const sessions = new SessionManager(sessionConfig, new Map([[engine.name, engine]]));
+    sessions.setEmployeeProvider((id) => id === employee.name ? employee : undefined);
+    service.dispose();
+    service = new WorkflowService({ repository, executor: new RealExecutor(sessions),
+      employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString() });
+
+    expect(await service.recover(now.toISOString())).toEqual({ resumedRuns: 1, resumedWaits: 0, resumedComments: 0 });
+    await vi.waitFor(() => expect(engine.calls).toBe(1));
+    expect(service.getRun(definition.id, created.id)?.attempts).toMatchObject([
+      { attempt: 1, status: "running", sessionId: inserted.id },
+    ]);
+    expect(await service.recover(now.toISOString())).toEqual({ resumedRuns: 0, resumedWaits: 0, resumedComments: 0 });
+    expect(service.getRun(definition.id, created.id)?.attempts).toHaveLength(1);
+    expect((await import("../../shared/db.js")).initDb().prepare("SELECT COUNT(*) AS count FROM sessions WHERE session_key = ?").get(key))
+      .toEqual({ count: 1 });
+    expect(engine.calls).toBe(1);
+  });
+
+  it("drains cancellation durably even when stopping an owned session fails", async () => {
+    const definition = save("cancel-drain", [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } }, worker("alpha"), worker("beta"),
+      { id: "finish-a", type: "end", name: "A", config: { result: "success" } },
+      { id: "finish-b", type: "end", name: "B", config: { result: "success" } },
+    ], [edge("start-a", "start", "success", "alpha"), edge("start-b", "start", "success", "beta"),
+      edge("a-end", "alpha", "success", "finish-a"), edge("b-end", "beta", "success", "finish-b")]);
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    executor.failStops = true;
+    const cancelled = await service.cancelRun({ workflowId: definition.id, runId: run.id, reason: "stop" });
+    expect(cancelled.status).toBe("cancelled");
+    expect(cancelled.attempts.every((attempt) => attempt.status === "cancelled")).toBe(true);
+    expect(cancelled.nodeRuns.some((node) => ["dispatching", "running", "waiting"].includes(node.status))).toBe(false);
+  });
+
+  it("persists dispatch failure into the authored retry path", async () => {
+    const definition = linear("dispatch-retry");
+    executor.failStarts = 1;
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    expect(run.status).toBe("waiting");
+    await service.recover(now.toISOString());
+    expect(service.getRun(definition.id, run.id)?.attempts.map((attempt) => attempt.status)).toEqual(["failed", "running"]);
+  });
+
+  it("routes an exhausted Employee error and settles a failure End", async () => {
+    const definition = linear("failure-path", worker("work", 1, 0), "failure");
+    const run = await service.startManual({ workflowId: definition.id, input: {} });
+    await executor.settle("work", "failed", now.toISOString());
+    const failed = service.getRun(definition.id, run.id)!;
+    expect(failed.status).toBe("failed");
+    expect(failed.nodeRuns.find((node) => node.nodeId === "failed")?.status).toBe("completed");
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-retry-override.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-retry-override.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener } from "../../shared/types.js";
+import type { WorkflowDefinition, WorkflowNode } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import type { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+/**
+ * ICI-733: a manual retry is exactly when someone has just moved a stuck Todo
+ * onto another engine, so the retry has to RESOLVE the override rather than
+ * copy the config off the attempt that kept failing.
+ */
+
+const sessionHome = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-retry-override-"));
+process.env.JINN_HOME = sessionHome;
+
+const employee: Employee = { name: "worker", displayName: "Worker", department: "platform", rank: "employee",
+  engine: "codex", model: "gpt-5.6-sol", persona: "Complete work." };
+const models: ModelRegistry = {
+  codex: { name: "codex", available: true, defaultModel: "gpt-5.6-sol",
+    models: [{ id: "gpt-5.6-sol", label: "Sol", supportsEffort: false, effortLevels: [] }] },
+  claude: { name: "claude", available: true, defaultModel: "opus",
+    models: [{ id: "opus", label: "Opus", supportsEffort: false, effortLevels: [] }] },
+} as unknown as ModelRegistry;
+
+class StubExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  private readonly listeners = new Set<WorkflowAttemptCompletionListener>();
+
+  async startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    const { runId, nodeId, attempt } = command.owner;
+    return { sessionId: `session:${runId}:${nodeId}:${attempt}` };
+  }
+  async stopAttempt(): Promise<void> {}
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    this.listeners.add(listener); return () => { this.listeners.delete(listener); };
+  }
+  readTerminalCompletion(): WorkflowAttemptCompletion | null { return null; }
+  async failLatest(nodeId: string): Promise<void> {
+    const command = this.commands.filter((item) => item.owner.nodeId === nodeId).at(-1)!;
+    const event: WorkflowAttemptCompletion = {
+      sessionId: `session:${command.owner.runId}:${nodeId}:${command.owner.attempt}`, owner: command.owner,
+      turn: 1, terminalVersion: 1, outcome: "failed", error: "Interactive turn failed: server_error",
+      completedAt: now.toISOString(),
+    };
+    await Promise.all([...this.listeners].map((listener) => listener(event)));
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let executor: StubExecutor;
+let service: WorkflowService;
+let now: Date;
+/** What the bound Todo currently says, re-read on every resolution. */
+let override: { engine: string | null; model: string | null } | undefined;
+
+function definition(): WorkflowDefinition {
+  const work: WorkflowNode = { id: "work", type: "employee", name: "Work", config: {
+    employee: { source: "fixed", value: "worker" }, prompt: "Run the work.",
+    // A retry budget that never elapses inside the test, so the only second
+    // attempt is the manual one.
+    retry: { attempts: 3, delaySeconds: 3600, backoff: "fixed" }, timeoutMinutes: 60 } };
+  const created = repository.createDefinition({ id: "retry-override", title: "Retry override" });
+  const saved = repository.saveDefinition({ ...created, nodes: [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } }, work,
+    { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+  ], edges: [
+    { id: "start-work", from: { nodeId: "start", port: "success" }, to: { nodeId: "work", port: "input" } },
+    { id: "work-finish", from: { nodeId: "work", port: "success" }, to: { nodeId: "finish", port: "input" } },
+  ] }, created.revision);
+  return repository.setEnabled("retry-override", true, saved.revision);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-workflow-retry-"));
+  now = new Date("2026-08-13T10:00:00.000Z");
+  override = undefined;
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database, () => now.toISOString());
+  executor = new StubExecutor();
+  service = new WorkflowService({ repository, executor: executor as unknown as WorkflowSessionExecutor,
+    employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
+    todoDispatch: { read: () => override } });
+});
+
+afterEach(() => { service.dispose(); database.close(); fs.rmSync(root, { recursive: true, force: true }); });
+afterAll(async () => {
+  (await import("../../shared/db.js")).__closeDbForTest();
+  fs.rmSync(sessionHome, { recursive: true, force: true });
+});
+
+/** A bound run whose first attempt has dispatched and failed. */
+async function failedFirstAttempt(): Promise<{ workflowId: string; runId: string }> {
+  const flow = definition();
+  const run = await service.startManual({ workflowId: flow.id, input: {}, todoId: "JIN-1" });
+  expect(executor.commands).toHaveLength(1);
+  expect(executor.commands[0]).toMatchObject({ engine: "codex", model: "gpt-5.6-sol" });
+  await executor.failLatest("work");
+  return { workflowId: flow.id, runId: run.id };
+}
+
+describe("a manual retry of a Todo-bound Employee node", () => {
+  it("runs on the override set while the failing attempt was in flight", async () => {
+    const { workflowId, runId } = await failedFirstAttempt();
+
+    override = { engine: "claude", model: "opus" };
+    const retried = await service.retryNode({ workflowId, runId, nodeId: "work", idempotencyKey: "retry-1" });
+
+    expect(executor.commands.at(-1)).toMatchObject({ engine: "claude", model: "opus" });
+    expect(retried.attempts.at(-1)?.resolvedConfig).toMatchObject({ engine: "claude", model: "opus" });
+  });
+
+  it("takes the engine's default model when the override names only an engine", async () => {
+    const { workflowId, runId } = await failedFirstAttempt();
+
+    override = { engine: "claude", model: null };
+    await service.retryNode({ workflowId, runId, nodeId: "work", idempotencyKey: "retry-2" });
+
+    expect(executor.commands.at(-1)).toMatchObject({ engine: "claude", model: "opus" });
+  });
+
+  it("keeps the employee's own engine when the Todo says nothing", async () => {
+    const { workflowId, runId } = await failedFirstAttempt();
+
+    await service.retryNode({ workflowId, runId, nodeId: "work", idempotencyKey: "retry-3" });
+
+    expect(executor.commands.at(-1)).toMatchObject({ engine: "codex", model: "gpt-5.6-sol" });
+  });
+});

--- a/packages/jimmy/src/workflows/__tests__/workflow-session-continuation.test.ts
+++ b/packages/jimmy/src/workflows/__tests__/workflow-session-continuation.test.ts
@@ -1,0 +1,192 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Employee,
+  Engine,
+  EngineResult,
+  JinnConfig,
+  ModelRegistry,
+  WorkflowAttemptCommand,
+} from "../../shared/types.js";
+import { getSession } from "../../sessions/registry.js";
+import { SessionManager } from "../../sessions/manager.js";
+import type { WorkflowDefinition } from "../model.js";
+import { openWorkflowDatabase } from "../repository-migrations.js";
+import { WorkflowRepository } from "../repository.js";
+import { WorkflowSessionExecutor } from "../session-executor.js";
+import { WorkflowService } from "../service.js";
+
+/* A rework round is its own node, so it used to dispatch a session that knew
+ * nothing and re-derived the whole brief. These are the two halves of the fix:
+ * round two resumes round one's engine thread, and when there is nothing
+ * resumable it dispatches exactly as it did before. */
+
+const home = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-continuation-vertical-"));
+process.env.JINN_HOME = home;
+
+const employee: Employee = {
+  name: "worker", displayName: "Worker", department: "platform", rank: "employee",
+  engine: "claude", model: "opus", effortLevel: "high", persona: "Do the work.",
+};
+const config = {
+  gateway: { port: 0, host: "127.0.0.1" },
+  engines: { default: "claude", claude: { bin: process.execPath, model: "opus" }, codex: { bin: process.execPath, model: "gpt" } },
+  connectors: {}, logging: { file: false, stdout: false, level: "error" },
+  mcp: { gateway: { enabled: false }, browser: { enabled: false } },
+} as unknown as JinnConfig;
+const models: ModelRegistry = {
+  claude: { name: "claude", available: true, defaultModel: "opus", effortMechanism: "claude-flag",
+    models: [{ id: "opus", label: "Opus", supportsEffort: true, effortLevels: ["low", "medium", "high"] }] },
+  codex: { name: "codex", available: true, defaultModel: "gpt", effortMechanism: "none",
+    models: [{ id: "gpt", label: "GPT", supportsEffort: false, effortLevels: [] }] },
+};
+
+class DeferredEngine implements Engine {
+  constructor(readonly name: string) {}
+  readonly calls: Parameters<Engine["run"]>[0][] = [];
+  private readonly pending: Array<(result: EngineResult) => void> = [];
+  run(opts: Parameters<Engine["run"]>[0]): Promise<EngineResult> {
+    this.calls.push(opts);
+    return new Promise((resolve) => this.pending.push(resolve));
+  }
+  resolve(result: EngineResult): void { this.pending.shift()!(result); }
+  kill(): void {}
+  isAlive(): boolean { return true; }
+  killAll(): void {}
+  killIdle(): void {}
+}
+
+/** The real executor, with the dispatch commands kept for inspection. */
+class RecordingExecutor extends WorkflowSessionExecutor {
+  readonly commands: WorkflowAttemptCommand[] = [];
+  override startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    this.commands.push(command);
+    return super.startAttempt(command);
+  }
+}
+
+let root: string;
+let database: Database.Database;
+let repository: WorkflowRepository;
+let engine: DeferredEngine;
+let executor: RecordingExecutor;
+let service: WorkflowService;
+
+function definition(engineName: "claude" | "codex", delta = "Fix only what the review flagged."): WorkflowDefinition {
+  const created = repository.createDefinition({ id: `flow-${engineName}`, title: `Flow ${engineName}` });
+  const saved = repository.saveDefinition({
+    ...created,
+    nodes: [
+      { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+      { id: "first", type: "employee", name: "First", config: {
+        employee: { source: "fixed", value: "worker" }, engine: { source: "fixed", value: engineName },
+        prompt: "Build the thing.", output: { fields: {}, allowAdditionalFields: true } } },
+      { id: "second", type: "employee", name: "Second", config: {
+        employee: { source: "fixed", value: "worker" }, engine: { source: "fixed", value: engineName },
+        prompt: "Build the thing, and here is the whole brief again.",
+        continueFrom: { nodeId: "first", prompt: delta },
+        output: { fields: {}, allowAdditionalFields: true } } },
+      { id: "finish", type: "end", name: "Finish", config: { result: "success" } },
+    ],
+    edges: [
+      { id: "e1", from: { nodeId: "start", port: "success" }, to: { nodeId: "first", port: "input" } },
+      { id: "e2", from: { nodeId: "first", port: "success" }, to: { nodeId: "second", port: "input" } },
+      { id: "e3", from: { nodeId: "second", port: "success" }, to: { nodeId: "finish", port: "input" } },
+    ],
+  }, created.revision);
+  return repository.setEnabled(saved.id, true, saved.revision);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-continuation-run-"));
+  database = openWorkflowDatabase(path.join(root, "workflows.db"));
+  repository = new WorkflowRepository(database);
+  engine = new DeferredEngine("claude");
+  const engines = new Map<string, Engine>([["claude", engine], ["codex", engine]]);
+  // Fork adaptation: jimmy's SessionManager takes (config, engines, connectorNames)
+  // and wires the employee roster through a setter instead of the constructor.
+  const manager = new SessionManager(config, engines);
+  manager.setEmployeeProvider((id) => id === employee.name ? employee : undefined);
+  executor = new RecordingExecutor(manager);
+  service = new WorkflowService({ repository, executor, employees: () => new Map([[employee.name, employee]]), models: () => models });
+});
+
+afterEach(() => {
+  service.dispose();
+  database.close();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+async function runBothPhases(authored: WorkflowDefinition): Promise<string> {
+  const started = await service.startManual({ workflowId: authored.id, input: {}, idempotencyKey: `run-${authored.id}` });
+  await vi.waitFor(() => expect(engine.calls).toHaveLength(1));
+  engine.resolve({ sessionId: "native-round-1", result: "Done.\n```jinn-output\n{}\n```", durationMs: 1 });
+  await vi.waitFor(() => expect(engine.calls).toHaveLength(2));
+  await vi.waitFor(() => expect(
+    repository.getRun(authored.id, started.id)?.attempts.some((attempt) => attempt.nodeId === "second"),
+  ).toBe(true));
+  return started.id;
+}
+
+describe("a second round on the session the first round left behind", () => {
+  it("dispatches with the first round's engine session and only the delta prompt", async () => {
+    const authored = definition("claude");
+    const runId = await runBothPhases(authored);
+
+    const attempts = repository.getRun(authored.id, runId)!.attempts;
+    const first = attempts.find((attempt) => attempt.nodeId === "first")!;
+    const second = attempts.find((attempt) => attempt.nodeId === "second")!;
+
+    expect(second.resolvedConfig.continuedFrom).toEqual({ sessionId: first.sessionId, engineSessionId: "native-round-1" });
+    expect(executor.commands[1]).toMatchObject({
+      owner: { nodeId: "second" },
+      continueFrom: { engine: "claude", engineSessionId: "native-round-1", sourceSessionId: first.sessionId },
+    });
+    // The session the round runs in, and the resume the engine is actually asked
+    // for: the same thread, not a new one.
+    expect(getSession(second.sessionId!)?.engineSessionId).toBe("native-round-1");
+    expect(engine.calls[1]?.resumeSessionId).toBe("native-round-1");
+    expect(second.sessionId).not.toBe(first.sessionId);
+
+    expect(second.promptText?.startsWith("Fix only what the review flagged.")).toBe(true);
+    expect(second.promptText).toContain("Workflow step completion contract");
+    expect(second.promptText).not.toContain("here is the whole brief again");
+
+    engine.resolve({ sessionId: "native-round-1", result: "Fixed.\n```jinn-output\n{}\n```", durationMs: 1 });
+    await vi.waitFor(() => expect(service.getRun(authored.id, runId)?.status).toBe("completed"));
+  });
+
+  it("dispatches cold on its own brief when the first round's thread cannot be resumed", async () => {
+    // codex resumes out of a per-session home, and this run wrote no rollout —
+    // so the candidate exists and is rejected, which is the fallback path.
+    const authored = definition("codex");
+    const runId = await runBothPhases(authored);
+
+    const second = repository.getRun(authored.id, runId)!.attempts.find((attempt) => attempt.nodeId === "second")!;
+    expect(second.resolvedConfig.continuedFrom).toBeUndefined();
+    expect(executor.commands[1]?.continueFrom).toBeUndefined();
+    expect(getSession(second.sessionId!)?.engineSessionId).toBeNull();
+    expect(second.promptText?.startsWith("Build the thing, and here is the whole brief again.")).toBe(true);
+
+    engine.resolve({ sessionId: "native-round-2", result: "Done.\n```jinn-output\n{}\n```", durationMs: 1 });
+    await vi.waitFor(() => expect(service.getRun(authored.id, runId)?.status).toBe("completed"));
+  });
+
+  it("dispatches cold over a delta whose bindings this run cannot resolve", async () => {
+    // codex again, so the candidate is rejected and the delta never goes out. A
+    // binding only the unused prompt reads must not fail the round reading the
+    // other one.
+    const authored = definition("codex", "Fix {{ input.reviewNote }} and nothing else.");
+    const runId = await runBothPhases(authored);
+
+    const second = repository.getRun(authored.id, runId)!.attempts.find((attempt) => attempt.nodeId === "second")!;
+    expect(second.resolvedConfig.continuedFrom).toBeUndefined();
+    expect(second.promptText?.startsWith("Build the thing, and here is the whole brief again.")).toBe(true);
+
+    engine.resolve({ sessionId: "native-round-2", result: "Done.\n```jinn-output\n{}\n```", durationMs: 1 });
+    await vi.waitFor(() => expect(service.getRun(authored.id, runId)?.status).toBe("completed"));
+  });
+});

--- a/packages/jimmy/src/workflows/approval-description.ts
+++ b/packages/jimmy/src/workflows/approval-description.ts
@@ -1,0 +1,20 @@
+import { logger } from "../shared/logger.js";
+import { interpolateWorkflowPrompt } from "./bindings.js";
+import type { ApprovalNode } from "./model.js";
+import { bindingContext } from "./node-dispatch.js";
+import type { WorkflowRunDetail } from "./runtime.js";
+
+/** What the operator reads at a mirrored gate. Interpolated like any other
+ *  authored string, so an upstream step's output — a screenshot ref included —
+ *  can reach the gate the decision is actually made at. A template that cannot
+ *  resolve must not sink a gate that is already parked: the raw text still
+ *  mirrors, and the gate is still decidable. */
+export function approvalDescription(run: WorkflowRunDetail, node: ApprovalNode): string {
+  try {
+    return interpolateWorkflowPrompt(node.config.description, bindingContext(run));
+  } catch (error) {
+    logger.warn(`Workflow run ${run.id} could not interpolate the description of approval gate ${node.id}: `
+      + `${error instanceof Error ? error.message : String(error)}`);
+    return node.config.description;
+  }
+}

--- a/packages/jimmy/src/workflows/attachment-ref.ts
+++ b/packages/jimmy/src/workflows/attachment-ref.ts
@@ -1,0 +1,62 @@
+/**
+ * The grammar for pointing a workflow run at a Todo attachment without ever
+ * putting the bytes in the run. Its own module because both sides of the loop
+ * need it: the runner and the output validator format and check refs, and the
+ * web surfaces parse one back into the id pair the byte route already serves.
+ *
+ * A ref is a single whitespace-free token, so it survives interpolation into
+ * prose and stores as a plain JSON string with no schema change anywhere:
+ *
+ *     attachment:<TODO-ID>:<attachment-id>:<mime>
+ *     attachment:PLA-1:wia_ab12cd34ef56:image/png
+ *
+ * It deliberately carries no filesystem path. A ref is an employee-authored
+ * string, and a path inside one is an arbitrary file read the moment a renderer
+ * trusts it; the id pair is what the byte route needs anyway, and that route
+ * resolves the real path and the real Content-Type from the attachment row. A
+ * forged mime can therefore only mis-pick the client-side renderer, which
+ * already degrades to a named-file row.
+ */
+
+/** One `type/subtype` token: dot, plus and dash may join runs, never repeat. */
+const MIME_TOKEN = String.raw`[a-z0-9]+(?:[.+-][a-z0-9]+)*`;
+
+const ATTACHMENT_REF = new RegExp(
+  String.raw`^attachment:([A-Z]{3}-[1-9][0-9]*):(wia_[0-9a-f]{12}):(${MIME_TOKEN}/${MIME_TOKEN})$`,
+);
+
+const MIME_ONLY = new RegExp(String.raw`^${MIME_TOKEN}/${MIME_TOKEN}$`);
+
+/** What a ref names, once it has been proven to be one. */
+export interface AttachmentRef {
+  workItemId: string;
+  attachmentId: string;
+  mime: string;
+}
+
+/** The shape of a ref, for the humans and employees who have to write one. */
+export const ATTACHMENT_REF_SHAPE = 'attachment:<TODO-ID>:<attachment-id>:<mime>';
+
+/** The ref for a stored attachment. Never throws: an unusable mime degrades. */
+export function formatAttachmentRef(attachment: {
+  workItemId: string;
+  id: string;
+  mime?: string | null;
+}): string {
+  const mime = attachment.mime?.trim().toLowerCase() ?? '';
+  const usable = MIME_ONLY.test(mime) ? mime : 'application/octet-stream';
+  return `attachment:${attachment.workItemId}:${attachment.id}:${usable}`;
+}
+
+/** The ref's parts, or `null` if the value is not a ref. Shape only — no lookup. */
+export function parseAttachmentRef(value: unknown): AttachmentRef | null {
+  if (typeof value !== 'string') return null;
+  const match = ATTACHMENT_REF.exec(value);
+  if (!match) return null;
+  return { workItemId: match[1]!, attachmentId: match[2]!, mime: match[3]! };
+}
+
+/** Whether a value is a ref, for callers that only need the verdict. */
+export function isAttachmentRef(value: unknown): value is string {
+  return parseAttachmentRef(value) !== null;
+}

--- a/packages/jimmy/src/workflows/bindings.ts
+++ b/packages/jimmy/src/workflows/bindings.ts
@@ -1,0 +1,260 @@
+import { isProxy } from 'node:util/types';
+import { bindingSchema, jsonValueSchema } from './model.js';
+import type { Binding, JsonValue, WorkflowNodeOutput } from './model.js';
+import type { WorkflowError } from './runtime.js';
+
+export interface WorkflowBindingContext {
+  input: Record<string, JsonValue>;
+  /** `item`/`itemIndex` are set for a fan-out child and `round`/`maxRounds` for
+   *  an iteration round, both only while a Workflow Call maps its target's
+   *  inputs — which is where a round gets told which one it is. */
+  trigger: { kind: string; payload: Record<string, JsonValue>; item?: JsonValue; itemIndex?: number;
+    round?: number; maxRounds?: number };
+  nodes: Record<string, { status: string; output: WorkflowNodeOutput | null; error: WorkflowError | null }>;
+  run: { id: string; startedAt: string; todoId?: string };
+}
+
+type WorkflowBindingErrorCode = 'invalid-path' | 'missing-value' | 'type-mismatch' | 'unsafe-value';
+
+export class WorkflowBindingError extends Error {
+  readonly code: 'invalid-path' | 'missing-value' | 'type-mismatch' | 'unsafe-value';
+
+  constructor(code: WorkflowBindingErrorCode, message: string) {
+    super(`${code}: ${message}`);
+    this.name = 'WorkflowBindingError';
+    this.code = code;
+  }
+}
+
+const SEGMENT = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const DANGEROUS = new Set(['__proto__', 'prototype', 'constructor']);
+const SOURCE_ROOTS = new Set(['input', 'trigger', 'run', 'nodes']);
+
+function fail(code: WorkflowBindingErrorCode, message: string): never {
+  throw new WorkflowBindingError(code, message);
+}
+
+export function validateBindingPath(path: string): string[] {
+  if (typeof path !== 'string' || path.length === 0 || path.length > 256) {
+    fail('invalid-path', 'Binding path must contain 1 to 256 characters');
+  }
+  const segments = path.split('.');
+  if (segments.length > 16 || (segments.length > 1 && SOURCE_ROOTS.has(segments[0]!))) {
+    fail('invalid-path', 'Binding path must be relative and contain at most 16 segments');
+  }
+  for (const segment of segments) {
+    if (!SEGMENT.test(segment) || DANGEROUS.has(segment)) {
+      fail('invalid-path', 'Binding path contains an invalid segment');
+    }
+  }
+  return [...segments];
+}
+
+type Descriptors = ReturnType<typeof Object.getOwnPropertyDescriptors>;
+
+function safeDescriptors(value: unknown, allowDangerous = false): { descriptors: Descriptors; array: boolean } {
+  if (value === null || typeof value !== 'object') fail('missing-value', 'Binding path does not exist');
+  if (isProxy(value)) fail('unsafe-value', 'Proxy containers are not allowed');
+  try {
+    const array = Array.isArray(value);
+    const prototype = Object.getPrototypeOf(value);
+    if (array ? prototype !== Array.prototype : prototype !== Object.prototype && prototype !== null) {
+      fail('unsafe-value', 'Only plain JSON containers are allowed');
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (typeof key !== 'string') fail('unsafe-value', 'Container has unsafe properties');
+      const descriptor = descriptors[key]!;
+      if ((!allowDangerous && DANGEROUS.has(key)) || !Object.hasOwn(descriptor, 'value')) {
+        fail('unsafe-value', 'Container has unsafe properties');
+      }
+      const arrayLength = array && key === 'length';
+      if (!arrayLength && !descriptor.enumerable) fail('unsafe-value', 'Container has hidden properties');
+      if (array && !arrayLength && !/^(0|[1-9][0-9]*)$/.test(key)) {
+        fail('unsafe-value', 'Array has non-index properties');
+      }
+    }
+    if (array && !jsonValueSchema.safeParse(value).success) {
+      fail('unsafe-value', 'Array is not canonical JSON');
+    }
+    return { descriptors, array };
+  } catch (error) {
+    if (error instanceof WorkflowBindingError) throw error;
+    fail('unsafe-value', 'Container inspection failed');
+  }
+}
+
+function requireRecord(value: unknown, allowDangerous = false): object {
+  if (value === null || typeof value !== 'object') fail('unsafe-value', 'Binding source must be a record');
+  const inspected = safeDescriptors(value, allowDangerous);
+  if (inspected.array) fail('unsafe-value', 'Binding source must be a record');
+  return value;
+}
+
+function readOwn(value: unknown, key: string, allowDangerous = false): unknown {
+  const inspected = safeDescriptors(value, allowDangerous);
+  if (inspected.array) fail('missing-value', 'Binding path does not exist');
+  const descriptor = inspected.descriptors[key];
+  if (!descriptor || !Object.hasOwn(descriptor, 'value') || descriptor.value === undefined) {
+    fail('missing-value', 'Binding path does not exist');
+  }
+  return descriptor.value;
+}
+
+function normalizeValue(value: unknown): JsonValue {
+  try {
+    const result = jsonValueSchema.safeParse(value);
+    if (!result.success) fail('unsafe-value', 'Resolved value is not safe JSON');
+    return result.data;
+  } catch (error) {
+    if (error instanceof WorkflowBindingError) throw error;
+    fail('unsafe-value', 'Resolved value inspection failed');
+  }
+}
+
+function normalizeBinding(binding: unknown): Binding {
+  classifyBindingEnvelope(binding);
+  const normalized = normalizeValue(binding);
+  try {
+    const result = bindingSchema.safeParse(normalized);
+    if (!result.success) fail('invalid-path', 'Binding has an invalid shape');
+    return result.data as Binding;
+  } catch (error) {
+    if (error instanceof WorkflowBindingError) throw error;
+    fail('unsafe-value', 'Binding inspection failed');
+  }
+}
+
+function classifyBindingEnvelope(binding: unknown): void {
+  if (binding === null || typeof binding !== 'object') fail('invalid-path', 'Binding has an invalid shape');
+  if (isProxy(binding)) fail('unsafe-value', 'Proxy bindings are not allowed');
+  let descriptors: Descriptors;
+  try {
+    const prototype = Object.getPrototypeOf(binding);
+    if (prototype !== Object.prototype && prototype !== null) fail('invalid-path', 'Binding has an invalid shape');
+    descriptors = Object.getOwnPropertyDescriptors(binding);
+  } catch (error) {
+    if (error instanceof WorkflowBindingError) throw error;
+    fail('unsafe-value', 'Binding inspection failed');
+  }
+  const sourceDescriptor = descriptors.source;
+  if (!sourceDescriptor || !sourceDescriptor.enumerable || !Object.hasOwn(sourceDescriptor, 'value')
+    || typeof sourceDescriptor.value !== 'string') fail('invalid-path', 'Binding source is invalid');
+  const source = sourceDescriptor.value;
+  const expected = source === 'fixed' ? ['source', 'value']
+    : source === 'node' ? ['source', 'nodeId', 'path']
+      : source === 'input' || source === 'trigger' || source === 'run' ? ['source', 'path'] : null;
+  const keys = Reflect.ownKeys(descriptors);
+  if (!expected || keys.length !== expected.length
+    || keys.some((key) => typeof key !== 'string' || !expected.includes(key))) {
+    fail('invalid-path', 'Binding has invalid fields');
+  }
+  if (source === 'fixed') return;
+  const pathDescriptor = descriptors.path;
+  if (!pathDescriptor || !pathDescriptor.enumerable || !Object.hasOwn(pathDescriptor, 'value')
+    || typeof pathDescriptor.value !== 'string') fail('invalid-path', 'Binding path is invalid');
+  validateBindingPath(pathDescriptor.value);
+  if (source === 'node') {
+    const nodeDescriptor = descriptors.nodeId;
+    if (!nodeDescriptor || !nodeDescriptor.enumerable || !Object.hasOwn(nodeDescriptor, 'value')
+      || typeof nodeDescriptor.value !== 'string') fail('invalid-path', 'Node identifier is invalid');
+  }
+}
+
+function traverse(root: unknown, segments: string[]): JsonValue {
+  const ancestors = new WeakSet<object>();
+  let current = root;
+  for (const segment of segments) {
+    if (current !== null && typeof current === 'object') {
+      if (ancestors.has(current)) fail('unsafe-value', 'Binding path contains a cycle');
+      ancestors.add(current);
+    }
+    current = readOwn(current, segment);
+  }
+  return normalizeValue(current);
+}
+
+function bindingRoot(binding: Exclude<Binding, { source: 'fixed' }>, context: WorkflowBindingContext): unknown {
+  const safeContext = requireRecord(context);
+  if (binding.source === 'input') return requireRecord(readOwn(safeContext, 'input'));
+  if (binding.source === 'trigger') return requireRecord(readOwn(safeContext, 'trigger'));
+  if (binding.source === 'run') return requireRecord(readOwn(safeContext, 'run'));
+  const nodes = requireRecord(readOwn(safeContext, 'nodes'), true);
+  const node = requireRecord(readOwn(nodes, binding.nodeId, true));
+  const output = readOwn(node, 'output');
+  if (output === null) fail('missing-value', 'Node output is not available');
+  return requireRecord(output);
+}
+
+function resolveBindingInner<T extends JsonValue>(input: Binding<T>, context: WorkflowBindingContext): T {
+  const binding = normalizeBinding(input) as Binding<T>;
+  if (binding.source === 'fixed') return normalizeValue(binding.value) as T;
+  const segments = validateBindingPath(binding.path);
+  return traverse(bindingRoot(binding, context), segments) as T;
+}
+
+export function resolveBinding<T extends JsonValue>(binding: Binding<T>, context: WorkflowBindingContext): T {
+  try {
+    return resolveBindingInner(binding, context);
+  } catch (error) {
+    if (error instanceof WorkflowBindingError) throw error;
+    fail('unsafe-value', 'Binding resolution failed');
+  }
+}
+
+function renderPrimitive(value: JsonValue): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return Object.is(value, -0) ? '0' : `${value}`;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return fail('type-mismatch', 'Prompt placeholders require primitive values');
+}
+
+function resolvePlaceholder(expression: string, context: WorkflowBindingContext): string {
+  const parts = expression.split('.');
+  const source = parts[0];
+  if (source === 'input' || source === 'trigger' || source === 'run') {
+    const path = parts.slice(1).join('.');
+    validateBindingPath(path);
+    return renderPrimitive(resolveBinding({ source, path }, context));
+  }
+  if (source === 'node' && parts.length >= 3) {
+    const nodeId = parts[1]!;
+    const path = parts.slice(2).join('.');
+    validateBindingPath(path);
+    return renderPrimitive(resolveBinding({ source, nodeId, path }, context));
+  }
+  return fail('invalid-path', 'Prompt placeholder has an invalid source or path');
+}
+
+function interpolateInner(template: string, context: WorkflowBindingContext): string {
+  let cursor = 0;
+  let output = '';
+  while (cursor < template.length) {
+    const open = template.indexOf('{{', cursor);
+    const unmatchedClose = template.indexOf('}}', cursor);
+    if (unmatchedClose !== -1 && (open === -1 || unmatchedClose < open)) {
+      fail('invalid-path', 'Prompt contains an unmatched closing delimiter');
+    }
+    if (open === -1) return output + template.slice(cursor);
+    const close = template.indexOf('}}', open + 2);
+    if (close === -1 || template[close + 2] === '}') fail('invalid-path', 'Prompt contains a malformed placeholder');
+    const raw = template.slice(open + 2, close);
+    if (raw.includes('{') || raw.includes('}')) fail('invalid-path', 'Nested placeholders are not allowed');
+    const expression = raw.trim();
+    if (expression.length === 0) fail('invalid-path', 'Prompt placeholder cannot be empty');
+    output += template.slice(cursor, open) + resolvePlaceholder(expression, context);
+    cursor = close + 2;
+  }
+  return output;
+}
+
+export function interpolateWorkflowPrompt(template: string, context: WorkflowBindingContext): string {
+  if (typeof template !== 'string') fail('invalid-path', 'Prompt template must be a string');
+  try {
+    return interpolateInner(template, context);
+  } catch (error) {
+    if (error instanceof WorkflowBindingError) throw error;
+    fail('unsafe-value', 'Prompt interpolation failed');
+  }
+}

--- a/packages/jimmy/src/workflows/capacity.ts
+++ b/packages/jimmy/src/workflows/capacity.ts
@@ -1,0 +1,105 @@
+import os from 'node:os';
+import { resolveBinding, type WorkflowBindingContext } from './bindings.js';
+import type { WorkflowCallNode } from './model.js';
+
+/** Resident working set one engine session costs, near enough. Deliberately
+ *  generous: the failure it prevents is a machine fanning out into swap, and
+ *  overestimating costs a slower fan-out while underestimating costs the box. */
+const SESSION_MEMORY_BUDGET_BYTES = 512 * 1024 * 1024;
+
+/** The authored maximum on a Workflow Call's `concurrency` (see `model.ts`).
+ *  A resolved binding answers to the same bound as a written-in number. */
+const MAX_CONCURRENCY = 16;
+
+/** What the machine looks like at the instant a fan-out asks for room. */
+export interface WorkflowCapacitySnapshot {
+  cpus: number;
+  freeMemBytes: number;
+  /** Engine sessions holding the machine that the asker is not itself running. */
+  activeEngineSessions: number;
+}
+
+/** How wide a fan-out may run on this machine right now.
+ *
+ *  The ceiling is the smallest of three headrooms, then clamped to [1, 16]:
+ *  - CPU: one core stays for the gateway itself, so `cpus - 1`.
+ *  - Memory: how many session-sized working sets fit in free memory, so a
+ *    starved machine narrows the fan-out instead of swapping.
+ *  - Sessions: the CPU headroom minus the engine sessions already running, so a
+ *    fan-out shares the machine with the operator's own work and with a sibling
+ *    workflow rather than competing with it.
+ *
+ *  The floor of 1 is what keeps a run making progress on a loaded machine; the
+ *  cap of 16 is the authored contract and this never widens it. */
+export function systemConcurrencyCeiling(snapshot: WorkflowCapacitySnapshot): number {
+  const cpuHeadroom = Math.max(1, Math.floor(snapshot.cpus) - 1);
+  const memoryHeadroom = Math.max(1, Math.floor(snapshot.freeMemBytes / SESSION_MEMORY_BUDGET_BYTES));
+  const sessionHeadroom = Math.max(1, cpuHeadroom - Math.max(0, Math.floor(snapshot.activeEngineSessions)));
+  return Math.min(cpuHeadroom, memoryHeadroom, sessionHeadroom, MAX_CONCURRENCY);
+}
+
+/** The machine as one fan-out's refill sees it.
+ *
+ *  `activeChildren` — the node's own children still running — comes off the gateway's
+ *  count here, because the refill subtracts them a second time when it takes the
+ *  running children off the effective width. Charged in both places the same sessions
+ *  leave the machine twice: a wave whose children have half finished then reads a
+ *  ceiling no wider than the ones still running, refills none of them, and the fan-out
+ *  stops holding items it never started. */
+export function readCapacitySnapshot(activeEngineSessions: number, activeChildren: number): WorkflowCapacitySnapshot {
+  return {
+    cpus: os.availableParallelism(),
+    freeMemBytes: os.freemem(),
+    activeEngineSessions: Math.max(0, activeEngineSessions - activeChildren),
+  };
+}
+
+/** What a fan-out asked for, what it got, and why they differ. */
+export interface FanoutConcurrency {
+  requested: number;
+  effective: number;
+  limitedBy: 'requested' | 'system-ceiling';
+}
+
+/** Resolve a Workflow Call node's authored concurrency against the machine.
+ *
+ *  `concurrency` is a plain number or a binding a planner node fills in, and
+ *  only the `fixed` arm of that binding is bounded by the schema — a resolved
+ *  node output can be anything at all, so it is checked here against the same
+ *  contract a written-in number answers to. Nothing is defaulted or floored:
+ *  a planner that emits a degree nobody can honour has made an error worth
+ *  failing the run over, not one worth quietly rounding into 1.
+ *
+ *  `capacity` absent means no system ceiling — the authored number stands. */
+export function resolveFanoutConcurrency(
+  node: WorkflowCallNode,
+  context: WorkflowBindingContext,
+  capacity: WorkflowCapacitySnapshot | null,
+): FanoutConcurrency {
+  const authored = node.config.concurrency;
+  const label = `Workflow Call ${node.id} concurrency`;
+  let resolved: unknown = authored;
+  if (typeof authored !== 'number') {
+    try {
+      resolved = resolveBinding(authored, context);
+    } catch (error) {
+      throw new Error(`${label} could not be resolved: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (typeof resolved !== 'number' || !Number.isInteger(resolved) || resolved < 1 || resolved > MAX_CONCURRENCY) {
+    throw new Error(`${label} must resolve to a whole number between 1 and ${MAX_CONCURRENCY}.`);
+  }
+  const effective = capacity ? Math.min(resolved, systemConcurrencyCeiling(capacity)) : resolved;
+  return { requested: resolved, effective, limitedBy: effective < resolved ? 'system-ceiling' : 'requested' };
+}
+
+/** What the node run records about its own fan-out width. `concurrency` keeps
+ *  its name and its meaning — what the author asked for — so an existing reader
+ *  is not silently handed a different number than it was written against. */
+export function fanoutConcurrencyRecord(concurrency: FanoutConcurrency): Record<string, string | number> {
+  return {
+    concurrency: concurrency.requested,
+    concurrencyEffective: concurrency.effective,
+    concurrencyLimitedBy: concurrency.limitedBy,
+  };
+}

--- a/packages/jimmy/src/workflows/contract.ts
+++ b/packages/jimmy/src/workflows/contract.ts
@@ -1,0 +1,54 @@
+import { ATTACHMENT_REF_SHAPE } from "./attachment-ref.js";
+import type { EmployeeNode } from "./model.js";
+
+function tableText(value: string): string {
+  return value.replaceAll("|", "\\|").replace(/\r?\n/g, " ");
+}
+
+export function buildNodeContract(
+  node: EmployeeNode,
+  upstream: Array<{ nodeId: string; sessionId?: string }>,
+): string {
+  const lines = ["## Workflow step completion contract"];
+  if (node.config.output) {
+    lines.push(
+      "",
+      "| Field | Type | Required | Description |",
+      "| --- | --- | --- | --- |",
+    );
+    for (const [name, field] of Object.entries(node.config.output.fields)) {
+      lines.push(`| \`${name}\` | ${field.type} | ${field.required ? "yes" : "no"} | ${
+        field.description ? tableText(field.description) : ""
+      } |`);
+    }
+    if (Object.values(node.config.output.fields).some((field) => field.type.startsWith("attachment"))) {
+      lines.push(
+        "",
+        `An attachment field takes a reference, never bytes: attach the file to this Todo with \`attach_to_work_item\`, then submit the \`${ATTACHMENT_REF_SHAPE}\` ref it returns.`,
+      );
+    }
+    lines.push(
+      "",
+      "When your work is truly finished, call the `workflow_submit_output` tool with these fields.",
+    );
+  }
+  lines.push(
+    "",
+    "Calling `workflow_submit_output` is what completes this workflow step; ending your turn does not. If you delegate to other employees and are waiting on them, end your turn; you will be woken when they reply.",
+  );
+  const readableSessions = upstream.filter(
+    (entry): entry is { nodeId: string; sessionId: string } => Boolean(entry.sessionId),
+  );
+  if (readableSessions.length > 0) {
+    lines.push(
+      "",
+      "Upstream step sessions you may read via jinn session tools (`read_session`, `get_message_context`):",
+      ...readableSessions.map((entry) => `- \`${entry.nodeId}: ${entry.sessionId}\``),
+    );
+  }
+  lines.push(
+    "",
+    "If the `workflow_submit_output` tool is unavailable, end your final message with a ```jinn-output fenced block containing the JSON fields.",
+  );
+  return lines.join("\n");
+}

--- a/packages/jimmy/src/workflows/employee-continuation.ts
+++ b/packages/jimmy/src/workflows/employee-continuation.ts
@@ -1,0 +1,65 @@
+/**
+ * Which completed attempt an Employee node continues from, if any.
+ *
+ * A rework round is its own node, so it dispatches a brand new session that
+ * re-reads everything its predecessor already knows. `continueFrom` names the
+ * node whose engine session it should pick up instead. Two places to look, in
+ * order: this run — the ordinary rework case — then the newest earlier run of
+ * the same Workflow for the same Todo, which is the re-arm case.
+ */
+
+import { logger } from '../shared/logger.js';
+import type { EmployeeNode } from './model.js';
+import type { WorkflowRepository } from './repository.js';
+import type { WorkflowAttemptRecord, WorkflowRunDetail } from './runtime.js';
+
+export interface EmployeeContinuationOptions {
+  repository: Pick<WorkflowRepository, 'findContinuationAttempt'>;
+  /** Null for any candidate that cannot actually be resumed on `engine`. */
+  resumableEngineSession: (sessionId: string, engine: string) => string | null;
+}
+
+/** The prompt an attempt is dispatched with: the delta when it continues something, the node's own brief when it starts cold. */
+export function continuationPrompt(node: EmployeeNode, continued: boolean): string {
+  return continued && node.config.continueFrom ? node.config.continueFrom.prompt : node.config.prompt;
+}
+
+function inRunCandidate(run: WorkflowRunDetail, nodeId: string): WorkflowAttemptRecord | undefined {
+  return run.attempts.filter((attempt) => attempt.nodeId === nodeId
+    && attempt.status === 'completed' && attempt.sessionId).at(-1);
+}
+
+/**
+ * Resolve the engine session this attempt continues, or null to dispatch cold.
+ * Null is a normal outcome — the first round of a run has nothing to continue —
+ * so it is reported at info level rather than raised.
+ */
+export function resolveEmployeeContinuation(
+  run: WorkflowRunDetail,
+  node: EmployeeNode,
+  engine: string,
+  options: EmployeeContinuationOptions,
+): { sessionId: string; engineSessionId: string } | null {
+  const target = node.config.continueFrom?.nodeId;
+  if (!target) return null;
+  const candidates = [
+    () => inRunCandidate(run, target),
+    // Without a Todo there is nothing tying two runs together, so cross-run
+    // continuation simply does not apply — never fall back to "any prior run".
+    () => (run.trigger.todoId
+      ? options.repository.findContinuationAttempt({ workflowId: run.workflowId, nodeId: target,
+        todoId: run.trigger.todoId, runId: run.id, runStartedAt: run.startedAt })
+      : null),
+  ];
+  for (const candidate of candidates) {
+    const attempt = candidate();
+    // The engine the attempt actually ran on, read off what it persisted. Its
+    // session is mutable — an employee switched since keeps the same session row
+    // and records a ref for the new engine, which is not this thread.
+    if (!attempt?.sessionId || attempt.resolvedConfig.engine !== engine) continue;
+    const engineSessionId = options.resumableEngineSession(attempt.sessionId, engine);
+    if (engineSessionId) return { sessionId: attempt.sessionId, engineSessionId };
+  }
+  logger.info(`Workflow ${run.workflowId} run ${run.id} node ${node.id} dispatches cold: no resumable ${engine} attempt of ${target} to continue.`);
+  return null;
+}

--- a/packages/jimmy/src/workflows/engine-chain.ts
+++ b/packages/jimmy/src/workflows/engine-chain.ts
@@ -1,0 +1,170 @@
+import { z } from "zod";
+import { classifyEngineFailureText } from "../shared/engine-failure.js";
+// Type-only, and it has to stay that way: the health store resolves the instance
+// home on import, and this module is reached from every read of a definition.
+import type { EngineHealthReading } from "../shared/engine-health.js";
+import type { ModelRegistry } from "../shared/types.js";
+import { availabilityReason } from "./failure.js";
+import type { WorkflowDefinition } from "./model.js";
+import type { WorkflowError, WorkflowRunDetail } from "./runtime.js";
+
+/**
+ * Which engine covers for one that could not serve a turn.
+ *
+ * An engine that ran out of allowance or could not be reached said nothing about
+ * the work — so unlike a retry, which pays a second time for the same request on
+ * the same provider, a substitution asks a DIFFERENT provider the first question.
+ * That is only honest while the alternatives are ones this node has not already
+ * spent an attempt on, which is why the walk reads the run's attempt history
+ * rather than just the configuration.
+ */
+
+/**
+ * The one failure path that is the ENGINE's account of a turn it could not
+ * serve. A submitted failure is the employee's verdict and an interrupted or
+ * undelivered attempt belongs to the runtime — none of them says the provider
+ * was out of allowance, whatever prose they happen to carry, and reading their
+ * text would let an employee's own summary redirect the run.
+ */
+const SUBSTITUTABLE_FAILURE_CODE = 'workflow-step-failed';
+
+/** `inherit` (the default) takes the engine's configured chain, `none` opts the
+ *  node out entirely, and a list is that node's own chain, used verbatim.
+ *
+ *  Members are plain strings rather than the engine enum on purpose: this module
+ *  is reached from `model.ts`, which the repository parses definitions with, and
+ *  the engine list lives in a module that resolves the instance home on import.
+ *  Pulling that in decides `JINN_HOME` for anything that reads a definition. A
+ *  name no engine answers to is inert anyway — the walk only offers members the
+ *  model registry actually has. */
+export const nodeFallbackSchema = z.union([
+  z.literal('inherit'), z.literal('none'), z.array(z.string().min(1)).min(1),
+]);
+export type NodeFallback = z.infer<typeof nodeFallbackSchema>;
+
+/** The configured `engines.<name>.fallback` chains, read fresh so a hot config
+ *  reload lands on the next attempt. */
+export interface EngineChainSource {
+  chainFor(engine: string): readonly string[];
+}
+
+export interface EngineSubstitution {
+  /** The engine this attempt runs on instead. */
+  engine: string;
+  /** The engine the node's own precedence resolved to, and which could not serve. */
+  from: string;
+  reason: string;
+}
+
+export interface SubstituteDeps {
+  models: () => ModelRegistry;
+  engineFallback?: EngineChainSource;
+  /** Which engines are out of allowance right now, read fresh like `models` so a
+   *  record written mid-run lands on the next attempt. Absent = nothing is known
+   *  and every installed member is equally preferred. */
+  engineHealth?: () => EngineHealthReading;
+}
+
+/**
+ * What a failure says about the ENGINE, or `undefined` when it says nothing —
+ * because it is not the engine's own account of the turn, or because it names
+ * something no other provider gets past.
+ *
+ * Exported because the substitution walk and the health record read the same
+ * signal, and a run that swapped engines while the record still called the old
+ * one healthy would be two answers to one question.
+ */
+export function engineAvailabilityFailure(
+  failure: WorkflowError | undefined,
+): { reason: string; resetsAt?: number } | undefined {
+  if (failure?.code !== SUBSTITUTABLE_FAILURE_CODE) return undefined;
+  const reason = availabilityReason(failure.message);
+  if (reason === undefined) return undefined;
+  const { resetsAt } = classifyEngineFailureText(failure.message);
+  return { reason, ...(resetsAt === undefined ? {} : { resetsAt }) };
+}
+
+/**
+ * Every engine that could stand in for `baseEngine`, in the order to try them.
+ *
+ * An inherited chain is walked transitively — an engine's own cover has cover of
+ * its own — with a visited set, because config.yaml deliberately allows two
+ * engines to name each other. Breadth first, so first preferences are exhausted
+ * before their seconds. An explicit chain is the node's whole answer and is not
+ * walked further.
+ */
+export function engineChain(
+  baseEngine: string,
+  fallback: NodeFallback | undefined,
+  chainFor: (engine: string) => readonly string[],
+): string[] {
+  if (fallback === 'none') return [];
+  if (Array.isArray(fallback)) return [...fallback];
+  const ordered: string[] = [];
+  const seen = new Set([baseEngine]);
+  const queue = [baseEngine];
+  while (queue.length > 0) {
+    for (const next of chainFor(queue.shift()!)) {
+      if (seen.has(next)) continue;
+      seen.add(next);
+      ordered.push(next);
+      queue.push(next);
+    }
+  }
+  return ordered;
+}
+
+function employeeFallback(definition: WorkflowDefinition, nodeId: string): NodeFallback | undefined {
+  const node = definition.nodes.find((candidate) => candidate.id === nodeId);
+  return node?.type === 'employee' ? node.config.fallback : undefined;
+}
+
+/**
+ * The substitution the node's next attempt should make, or `undefined` when it
+ * should not make one — because the failure is one no other engine gets past,
+ * because the node opted out, or because every alternative is already spent.
+ * Both the retry boundary and the dispatcher ask through here, so they cannot
+ * reach different answers about whether a run is out of options.
+ */
+export function selectSubstituteEngine(
+  run: WorkflowRunDetail,
+  nodeId: string,
+  baseEngine: string,
+  failure: WorkflowError | undefined,
+  deps: SubstituteDeps,
+): EngineSubstitution | undefined {
+  const availability = engineAvailabilityFailure(failure);
+  if (availability === undefined) return undefined;
+  const attempted = new Set(run.attempts.filter((attempt) => attempt.nodeId === nodeId)
+    .map((attempt) => attempt.resolvedConfig.engine));
+  // Nothing to cover for until the resolved engine is the one that just failed:
+  // a Todo override naming an engine this node has not tried is itself the answer.
+  if (!attempted.has(baseEngine)) return undefined;
+  const chain = engineChain(baseEngine, employeeFallback(run.definition, nodeId),
+    (engine) => deps.engineFallback?.chainFor(engine) ?? []);
+  const engine = preferredCandidates(chain, attempted, deps.models(), deps.engineHealth?.() ?? {})[0];
+  return engine === undefined ? undefined : { engine, from: baseEngine, reason: availability.reason };
+}
+
+/**
+ * The members this node could still be dispatched to, healthy ones first.
+ *
+ * A member that is out of allowance is held back rather than dropped: health
+ * orders this walk and never shortens it, because a reading nothing verified
+ * must not be able to freeze a run that had somewhere to go. `degraded` is not
+ * read at all — an engine that named no reopening is not out of anything.
+ */
+function preferredCandidates(
+  chain: readonly string[],
+  attempted: ReadonlySet<string>,
+  registry: ModelRegistry,
+  health: EngineHealthReading,
+): string[] {
+  const healthy: string[] = [];
+  const exhausted: string[] = [];
+  for (const candidate of chain) {
+    if (attempted.has(candidate) || !registry[candidate]?.available) continue;
+    (health[candidate]?.state === "exhausted" ? exhausted : healthy).push(candidate);
+  }
+  return [...healthy, ...exhausted];
+}

--- a/packages/jimmy/src/workflows/failure.ts
+++ b/packages/jimmy/src/workflows/failure.ts
@@ -1,0 +1,122 @@
+import type { WorkflowError } from "./runtime.js";
+import type { WorkflowAttemptInterruptionCause } from "../shared/types.js";
+import { classifyEngineFailureText, hasEngineFailureClass, type EngineFailureClass } from "../shared/engine-failure.js";
+
+/**
+ * How a workflow decides whether a failed attempt is worth re-dispatching.
+ *
+ * The boundary is "did the work happen and fail" versus "did the attempt never
+ * land". An attempt that never landed costs nothing to repeat — the retry is the
+ * SAME request, not a second one. An employee that ran and reported failure is a
+ * verdict: re-dispatching it pays twice for a decision already made and can
+ * override a phase that deliberately refused to proceed.
+ *
+ * Most of that is decided STRUCTURALLY, by which path the failure arrived on —
+ * a `startAttempt` throw or a gateway restart is an undelivered attempt whatever
+ * its message says, and a submitted failure is a verdict whatever its message
+ * says. The signatures below are only for the one path with no structure to read:
+ * an engine reporting that its turn failed, where the provider's reason exists
+ * solely as prose.
+ *
+ * There the vocabulary is closed and anything unrecognised is terminal. Guessing
+ * generously spends real money on real failures, so the default is deny.
+ */
+
+/**
+ * Whether an engine diagnostic describes an upstream/transport fault.
+ *
+ * Read off the shared taxonomy: the two classes that mean the request never got
+ * a real answer. Deliberately NOT retried are the classes that name a decision —
+ * `rate-limit`/`quota` (the session manager owns rate-limit waiting, so a
+ * workflow retry on top of it is pure quota burn), `auth-terminal`, and
+ * `terminal` (a retry cannot fix a credential, a quota, or a malformed request).
+ * A provider can be both overloaded and throttling; that text is retried here,
+ * exactly as it was before the classes were named.
+ */
+export function isTransportFailure(message: string): boolean {
+  return hasEngineFailureClass(classifyEngineFailureText(message), "provider-outage", "network");
+}
+
+/**
+ * Whether an engine diagnostic names a fault in OUR configuration rather than a
+ * verdict on the work.
+ *
+ * An engine that refuses a model id never ran the turn, so there is no decision to
+ * honour and nothing was paid for — and the id it refused came from config or from
+ * discovery, both of which an operator can fix without the run dying on top of work
+ * already committed. The retry is not the same request either: `resolveSubstituteModel`
+ * drops a pin it cannot vouch for, so the next attempt goes out on the substitute's
+ * own default rather than repeating the argv that was just refused.
+ */
+export function isConfigFaultFailure(message: string): boolean {
+  return hasEngineFailureClass(classifyEngineFailureText(message), "invalid-model");
+}
+
+/**
+ * Why another engine could serve the turn this one refused, phrased for the run
+ * detail — or `undefined` when swapping engines would change nothing.
+ *
+ * These are the classes that describe the PROVIDER rather than the work: an
+ * allowance, a throttle, a fault, a socket. `auth-terminal` and `terminal` are
+ * absent on purpose — a missing credential and an unrecognised verdict follow
+ * the request wherever it is sent.
+ */
+const AVAILABILITY_REASONS: readonly (readonly [EngineFailureClass, string])[] = [
+  ["quota", "out of quota"],
+  ["rate-limit", "rate-limited"],
+  ["provider-outage", "unavailable"],
+  ["network", "unreachable"],
+];
+
+export function availabilityReason(message: string): string | undefined {
+  const { classes } = classifyEngineFailureText(message);
+  return AVAILABILITY_REASONS.find(([failureClass]) => classes.has(failureClass))?.[1];
+}
+
+/**
+ * Wrap a failure whose only account of itself is its message: an engine turn that
+ * reported an error, or a run-level fault (an unavailable employee, control flow
+ * that did not settle). Retryable when the message names a transport fault or a
+ * model id we got wrong; anything else is read as a verdict.
+ */
+export function workflowError(error: unknown, nodeId: string, attempt?: number): WorkflowError {
+  const value = error instanceof Error ? error : new Error(String(error));
+  return {
+    code: "workflow-step-failed",
+    message: value.message,
+    retryable: isTransportFailure(value.message) || isConfigFaultFailure(value.message),
+    nodeId,
+    ...(attempt ? { attempt } : {}),
+  };
+}
+
+/**
+ * A dispatch that threw before the attempt reached a session. Nothing ran, so
+ * this is the undelivered-attempt case by construction — no message-matching,
+ * because the diagnostic belongs to whatever failed to spawn, not to a provider.
+ */
+export function dispatchFailure(error: unknown, nodeId: string, attempt: number): WorkflowError {
+  const value = error instanceof Error ? error : new Error(String(error));
+  return { code: "workflow-dispatch-failed", message: value.message, retryable: true, nodeId, attempt };
+}
+
+export const RESTART_INTERRUPTED = "workflow-attempt-restart-interrupted";
+
+/**
+ * An attempt killed under the runtime. The turn was interrupted rather than
+ * judged, so like a timeout or a missing output block there is no verdict to
+ * honour and the phase re-runs.
+ *
+ * The cause decides what kind of interruption it was. A gateway restart is not a
+ * fault of the work at all — the process the attempt lived in went away — so its
+ * replacement is dispatched at once rather than parked on the node's backoff,
+ * and the count of these on a node is what bounds a restart loop. An operator
+ * stopping the attempt is the opposite: a decision ABOUT this attempt, which
+ * like a submitted failure earns no retry. Only an unexplained interruption
+ * keeps the old benefit of the doubt.
+ */
+export function interruptedAttemptFailure(message: string, nodeId: string, attempt: number,
+  cause?: WorkflowAttemptInterruptionCause): WorkflowError {
+  return { code: cause === "gateway-restart" ? RESTART_INTERRUPTED : "workflow-attempt-interrupted",
+    message, retryable: cause !== "attempt-stop", nodeId, attempt };
+}

--- a/packages/jimmy/src/workflows/git-landing-evidence.ts
+++ b/packages/jimmy/src/workflows/git-landing-evidence.ts
@@ -1,0 +1,52 @@
+import { execFile } from "node:child_process";
+import { loadConfig } from "../shared/config.js";
+import type { WorkflowLandingVerifier } from "./run-closure.js";
+
+export interface CanonicalGitTarget {
+  remote: string;
+  branch: string;
+}
+
+function git(checkout: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile("git", ["-C", checkout, ...args],
+      { timeout: 30_000, windowsHide: true }, (error) => error ? reject(error) : resolve());
+  });
+}
+
+function canonicalTarget(): CanonicalGitTarget {
+  const delivery = loadConfig().workflows?.delivery;
+  return { remote: delivery?.remote ?? "origin", branch: delivery?.branch ?? "main" };
+}
+
+/**
+ * Proof that a commit reached the freshly fetched canonical remote branch.
+ *
+ * An argument vector, never a shell string — both values come out of a phase's
+ * submitted output, so both are input. Exit 1 is git's answer, and everything
+ * else (no repository there any more, an object it never heard of) throws, so
+ * the caller can tell "no" apart from "could not ask".
+ */
+export function createGitLandingEvidence(target: CanonicalGitTarget): WorkflowLandingVerifier {
+  const trackingRef = `refs/remotes/${target.remote}/${target.branch}`;
+  return {
+    async mergedIntoMain({ commit, checkout }) {
+      await git(checkout, ["fetch", "--quiet", target.remote,
+        `+refs/heads/${target.branch}:${trackingRef}`]);
+      return new Promise((resolve, reject) => {
+        execFile("git", ["-C", checkout, "merge-base", "--is-ancestor", commit, trackingRef],
+          { timeout: 10_000, windowsHide: true }, (error) => {
+            if (!error) resolve(true);
+            else if (error.code === 1) resolve(false);
+            else reject(error);
+          });
+      });
+    },
+  };
+}
+
+export const gitLandingEvidence: WorkflowLandingVerifier = {
+  mergedIntoMain(input) {
+    return createGitLandingEvidence(canonicalTarget()).mergedIntoMain(input);
+  },
+};

--- a/packages/jimmy/src/workflows/import-v1.ts
+++ b/packages/jimmy/src/workflows/import-v1.ts
@@ -1,0 +1,276 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { logger } from "../shared/logger.js";
+import { resolveJinnHome } from "../shared/paths.js";
+import { workflowDefinitionSchema, type WorkflowDefinition, type WorkflowEdge, type WorkflowNode } from "./model.js";
+
+type LogLevel = "info" | "warn";
+type LegacyRecord = Record<string, unknown>;
+
+export interface LegacyWorkflowImportOptions {
+  legacyDirectory?: string;
+  legacyRunsDirectory?: string;
+  reportPath?: string;
+  now?: () => string;
+  log?: (level: LogLevel, message: string) => void;
+}
+
+export interface LegacyWorkflowImportResult {
+  imported: number;
+  failed: number;
+  skipped: boolean;
+}
+
+function record(value: unknown, subject: string): LegacyRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${subject} must be an object`);
+  return value as LegacyRecord;
+}
+
+function text(value: unknown, subject: string): string {
+  if (typeof value !== "string" || !value) throw new Error(`${subject} must be a non-empty string`);
+  return value;
+}
+
+function fixed<T extends string>(value: T) {
+  return { source: "fixed" as const, value };
+}
+
+function keysOutside(value: LegacyRecord, allowed: readonly string[]): string[] {
+  const accepted = new Set(allowed);
+  return Object.keys(value).filter((key) => !accepted.has(key));
+}
+
+function position(value: unknown): { x: number; y: number } {
+  const item = record(value, "node position");
+  if (typeof item.x !== "number" || !Number.isFinite(item.x)
+    || typeof item.y !== "number" || !Number.isFinite(item.y)) {
+    throw new Error("node position must contain finite x/y coordinates");
+  }
+  return { x: item.x, y: item.y };
+}
+
+function node(value: unknown): { node: WorkflowNode; position: { x: number; y: number } } {
+  const item = record(value, "node");
+  const id = text(item.id, "node id");
+  const name = text(item.label, `node ${id} label`);
+  const coordinates = position(item.position);
+  if (item.type === "trigger") {
+    const trigger = record(item.trigger, `trigger ${id}`);
+    if (trigger.kind !== "manual") throw new Error(`trigger ${id} uses unsupported kind ${String(trigger.kind)}`);
+    const unsupportedTriggerKeys = keysOutside(trigger, ["kind"]);
+    if (unsupportedTriggerKeys.length > 0) throw new Error(`trigger ${id} has unsupported fields: ${unsupportedTriggerKeys.join(", ")}`);
+    return { node: { id, type: "trigger", name, config: { kind: "manual" } }, position: coordinates };
+  }
+  if (item.type !== "step") throw new Error(`node ${id} uses unsupported type ${String(item.type)}`);
+  if (Array.isArray(item.gates) && item.gates.length > 0) throw new Error(`step ${id} has legacy gates that require manual review`);
+  if (item.optional !== undefined) throw new Error(`step ${id} uses unsupported optional semantics`);
+  if (item.switchMode !== undefined) throw new Error(`step ${id} uses unsupported switch semantics`);
+  const actor = record(item.actor, `step ${id} actor`);
+  const actorKind = text(actor.kind, `step ${id} actor kind`);
+  const actorRef = text(actor.ref, `step ${id} actor ref`);
+  if (actorKind !== "employee" && actorKind !== "engine") throw new Error(`step ${id} uses unsupported actor kind ${actorKind}`);
+  const options = item.options === undefined ? {} : record(item.options, `step ${id} options`);
+  const unsupportedOptions = keysOutside(options, ["model", "effort", "retry", "timeoutMinutes"]);
+  if (unsupportedOptions.length > 0) throw new Error(`step ${id} uses unsupported options: ${unsupportedOptions.join(", ")}`);
+  const retry = options.retry === undefined ? undefined : record(options.retry, `step ${id} retry`);
+  if (retry) {
+    const unsupportedRetry = keysOutside(retry, ["maxAttempts"]);
+    if (unsupportedRetry.length > 0) throw new Error(`step ${id} uses unsupported retry fields: ${unsupportedRetry.join(", ")}`);
+  }
+  const maxAttempts = retry?.maxAttempts;
+  const timeoutMinutes = options.timeoutMinutes;
+  if (options.effort !== undefined
+    && (typeof options.effort !== "string" || !["low", "medium", "high", "xhigh"].includes(options.effort))) {
+    throw new Error(`step ${id} uses unsupported effort ${String(options.effort)}`);
+  }
+  if (maxAttempts !== undefined && (!Number.isInteger(maxAttempts) || (maxAttempts as number) < 1)) {
+    throw new Error(`step ${id} has invalid retry maxAttempts`);
+  }
+  if (timeoutMinutes !== undefined && (!Number.isInteger(timeoutMinutes) || (timeoutMinutes as number) < 1)) {
+    throw new Error(`step ${id} has invalid timeoutMinutes`);
+  }
+  const effort = options.effort as "low" | "medium" | "high" | "xhigh" | undefined;
+  const config = {
+    employee: fixed(actorRef),
+    prompt: typeof item.instructions === "string" && item.instructions ? item.instructions : `Run ${name}.`,
+    ...(actorKind === "engine" ? { engine: fixed(actorRef) } : {}),
+    ...(typeof options.model === "string" ? { model: fixed(options.model) } : {}),
+    ...(effort ? { effort: fixed(effort) } : {}),
+    ...(Number.isInteger(maxAttempts) ? { retry: { attempts: maxAttempts as number, delaySeconds: 0, backoff: "fixed" as const } } : {}),
+    ...(Number.isInteger(timeoutMinutes) ? { timeoutMinutes: timeoutMinutes as number } : {}),
+  };
+  return { node: { id, type: "employee", name, config }, position: coordinates };
+}
+
+function edge(value: unknown): WorkflowEdge {
+  const item = record(value, "edge");
+  const id = text(item.id, "edge id");
+  if (item.when !== undefined) throw new Error(`edge ${id} uses a legacy condition that requires manual review`);
+  if (item.kind === "loop") throw new Error(`edge ${id} uses legacy loop semantics that require manual review`);
+  if (item.kind !== "sequence" && item.kind !== "handoff") {
+    throw new Error(`edge ${id} uses unsupported kind ${String(item.kind)}`);
+  }
+  const unsupported = keysOutside(item, ["id", "from", "to", "kind"]);
+  if (unsupported.length > 0) throw new Error(`edge ${id} uses unsupported fields: ${unsupported.join(", ")}`);
+  return {
+    id,
+    from: { nodeId: text(item.from, `edge ${id} source`), port: "success" },
+    to: { nodeId: text(item.to, `edge ${id} target`), port: "input" },
+  };
+}
+
+function convert(value: unknown): WorkflowDefinition {
+  const legacy = record(value, "legacy Workflow definition");
+  const id = text(legacy.id, "Workflow id");
+  const title = text(legacy.title, `Workflow ${id} title`);
+  if (!Array.isArray(legacy.nodes) || !Array.isArray(legacy.edges)) throw new Error("nodes and edges must be arrays");
+  const converted = legacy.nodes.map(node);
+  const stamp = typeof legacy.updatedAt === "string" ? legacy.updatedAt : new Date().toISOString();
+  const revision = Number.isInteger(legacy.version) && (legacy.version as number) > 0 ? legacy.version as number : 1;
+  const definition = {
+    schemaVersion: 1,
+    id,
+    title,
+    ...(typeof legacy.description === "string" ? { description: legacy.description } : {}),
+    revision,
+    enabled: false,
+    nodes: converted.map((item) => item.node),
+    edges: legacy.edges.map(edge),
+    // The v1 canvas was a hand-arranged surface, so its coordinates carry over
+    // as manual and the imported graph opens exactly where its author left it.
+    ui: { positions: Object.fromEntries(converted.map((item) => [item.node.id, item.position])), layout: "manual" as const },
+    createdAt: stamp,
+    updatedAt: stamp,
+  };
+  const parsed = workflowDefinitionSchema.safeParse(definition);
+  if (!parsed.success) throw new Error(parsed.error.issues[0]?.message ?? "converted definition is invalid");
+  return parsed.data;
+}
+
+interface DefinitionImportRecord {
+  file: string;
+  id: string;
+  sourceSha256: string;
+  outcome: "imported" | "preserved";
+  reason?: string;
+  definition?: WorkflowDefinition;
+}
+
+interface LegacyRunRecord {
+  file: string;
+  workflowId: string;
+  runId: string;
+  status: string;
+}
+
+function scanLegacyRuns(directory: string): { count: number; active: LegacyRunRecord[] } {
+  if (!existsSync(directory)) return { count: 0, active: [] };
+  const records: LegacyRunRecord[] = [];
+  let count = 0;
+  for (const workflow of readdirSync(directory, { withFileTypes: true })) {
+    if (!workflow.isDirectory()) continue;
+    const workflowDirectory = path.join(directory, workflow.name);
+    for (const file of readdirSync(workflowDirectory).filter((name) => name.endsWith(".json")).sort()) {
+      count += 1;
+      try {
+        const value = record(JSON.parse(readFileSync(path.join(workflowDirectory, file), "utf8")), "legacy run");
+        const status = typeof value.status === "string" ? value.status : "unknown";
+        if (!["running", "parked", "dispatched"].includes(status)) continue;
+        records.push({
+          file: `${workflow.name}/${file}`,
+          workflowId: typeof value.workflowId === "string" ? value.workflowId : workflow.name,
+          runId: typeof value.runId === "string" ? value.runId : file.replace(/\.json$/, ""),
+          status,
+        });
+      } catch {
+        // Malformed legacy evidence is still counted and remains untouched.
+      }
+    }
+  }
+  return { count, active: records };
+}
+
+function writeImportReport(reportPath: string, report: unknown): void {
+  mkdirSync(path.dirname(reportPath), { recursive: true, mode: 0o700 });
+  const temporary = `${reportPath}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, reportPath);
+}
+
+export function importLegacyWorkflowDefinitions(
+  db: Database.Database,
+  options: LegacyWorkflowImportOptions = {},
+): LegacyWorkflowImportResult {
+  const home = resolveJinnHome();
+  const directory = options.legacyDirectory ?? path.join(home, "workflow-evidence", "workflows");
+  const legacyRunsDirectory = options.legacyRunsDirectory ?? path.join(home, "workflow-evidence", "reports", "runs");
+  const reportPath = options.reportPath ?? path.join(home, "workflows", "legacy-v1-import-report.json");
+  if (existsSync(reportPath)) return { imported: 0, failed: 0, skipped: true };
+  if (!existsSync(directory)) return { imported: 0, failed: 0, skipped: true };
+  const files = readdirSync(directory).filter((name) => name.endsWith(".definition.json")).sort();
+  if (files.length === 0) return { imported: 0, failed: 0, skipped: true };
+  const log = options.log ?? ((level: LogLevel, message: string) => logger[level](message));
+  const records: DefinitionImportRecord[] = files.map((file) => {
+    const fallbackId = file.slice(0, -".definition.json".length);
+    const source = readFileSync(path.join(directory, file));
+    const sourceSha256 = createHash("sha256").update(source).digest("hex");
+    try {
+      const definition = convert(JSON.parse(source.toString("utf8")));
+      return { file, id: definition.id, sourceSha256, outcome: "imported", definition };
+    } catch (error) {
+      return {
+        file,
+        id: fallbackId,
+        sourceSha256,
+        outcome: "preserved",
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+  const insert = db.prepare(`INSERT INTO workflow_definitions
+    (id,title,revision,enabled,retired_at,definition_json,created_at,updated_at)
+    VALUES (@id,@title,@revision,0,NULL,@json,@createdAt,@updatedAt)`);
+  const existing = db.prepare("SELECT 1 FROM workflow_definitions WHERE id = ?");
+  db.transaction(() => {
+    for (const item of records) {
+      if (!item.definition) continue;
+      if (existing.get(item.definition.id)) {
+        item.outcome = "preserved";
+        item.reason = "a v2 Workflow with this id already exists";
+        delete item.definition;
+        continue;
+      }
+      const definition = item.definition;
+      insert.run({
+        id: definition.id,
+        title: definition.title,
+        revision: definition.revision,
+        json: JSON.stringify(definition),
+        createdAt: definition.createdAt,
+        updatedAt: definition.updatedAt,
+      });
+    }
+  }).immediate();
+  const legacyRuns = scanLegacyRuns(legacyRunsDirectory);
+  writeImportReport(reportPath, {
+    schemaVersion: 1,
+    createdAt: (options.now ?? (() => new Date().toISOString()))(),
+    legacyDefinitionDirectory: directory,
+    legacyRunDirectory: legacyRunsDirectory,
+    definitions: records.map(({ definition: _definition, ...item }) => item),
+    legacyRuns,
+  });
+  for (const item of records) {
+    if (item.outcome === "imported") log("info", `[workflows] imported legacy Workflow ${item.id} as a disabled v2 draft`);
+    else log("warn", `[workflows] preserved unsupported legacy Workflow ${item.id}: ${item.reason}`);
+  }
+  if (legacyRuns.active.length > 0) {
+    log("warn", `[workflows] found ${legacyRuns.active.length} active legacy Workflow run(s); source evidence remains unchanged and requires operator review`);
+  }
+  log("info", `[workflows] legacy Workflow import report written to ${reportPath}`);
+  const imported = records.filter((item) => item.outcome === "imported").length;
+  const failed = records.length - imported;
+  return { imported, failed, skipped: false };
+}

--- a/packages/jimmy/src/workflows/index.ts
+++ b/packages/jimmy/src/workflows/index.ts
@@ -1,0 +1,11 @@
+export { WorkflowRepository, WorkflowRepositoryError } from "./repository.js";
+export type {
+  CreateRunInput,
+  CreateWorkflowInput,
+  CursorPage,
+  DefinitionListQuery,
+  RunListQuery,
+  WorkflowDefinitionSummary,
+  WorkflowRunSummary,
+  WorkflowRunTransaction,
+} from "./repository.js";

--- a/packages/jimmy/src/workflows/issues.ts
+++ b/packages/jimmy/src/workflows/issues.ts
@@ -1,0 +1,51 @@
+/**
+ * The one shape every Workflow authoring surface reports a rejection with, and
+ * the one way it is rendered as text. A bare "Workflow definition is invalid."
+ * makes a large graph unauthorable — the author has to bisect it by hand — so
+ * HTTP returns these structured, and MCP and the CLI render them inline.
+ */
+export interface WorkflowValidationIssue {
+  code: string;
+  message: string;
+  nodeId?: string;
+  edgeId?: string;
+  path?: string;
+}
+
+/** Beyond this the list stops being a hint and starts being a wall of text. */
+const MAX_RENDERED_ISSUES = 10;
+
+function locator(issue: WorkflowValidationIssue): string {
+  if (issue.nodeId) return ` (node ${issue.nodeId})`;
+  if (issue.edgeId) return ` (edge ${issue.edgeId})`;
+  return issue.path ? ` (${issue.path})` : '';
+}
+
+/** `message` followed by one bullet per issue. Returns `message` unchanged when
+ *  the failure carried no issues, so every caller can render it the same way. */
+export function describeWorkflowIssues(message: string, issues: readonly WorkflowValidationIssue[] | undefined): string {
+  if (!issues?.length) return message;
+  const shown = issues.slice(0, MAX_RENDERED_ISSUES)
+    .map((issue) => `\n- ${issue.code}${locator(issue)}: ${issue.message}`);
+  const hidden = issues.length - shown.length;
+  return `${message}${shown.join('')}${hidden > 0 ? `\n- ... and ${hidden} more.` : ''}`;
+}
+
+/** Read an `issues` array off an untrusted error envelope (HTTP body, MCP
+ *  response), keeping only entries that carry a usable code and message. */
+export function parseWorkflowIssues(value: unknown): WorkflowValidationIssue[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const issues = value.flatMap((entry): WorkflowValidationIssue[] => {
+    if (!entry || typeof entry !== 'object') return [];
+    const { code, message, nodeId, edgeId, path } = entry as Record<string, unknown>;
+    if (typeof code !== 'string' || typeof message !== 'string') return [];
+    return [{
+      code,
+      message,
+      ...(typeof nodeId === 'string' ? { nodeId } : {}),
+      ...(typeof edgeId === 'string' ? { edgeId } : {}),
+      ...(typeof path === 'string' ? { path } : {}),
+    }];
+  });
+  return issues.length > 0 ? issues : undefined;
+}

--- a/packages/jimmy/src/workflows/json-schema.ts
+++ b/packages/jimmy/src/workflows/json-schema.ts
@@ -1,0 +1,116 @@
+import { isProxy } from 'node:util/types';
+import { z } from 'zod';
+
+/**
+ * What counts as data inside a Workflow definition, a run input, or a node
+ * output: plain JSON, with no accessors, no prototypes, no cycles, and no
+ * `__proto__`. Every schema in `model.ts` is wrapped in `normalizedSchema`, so
+ * this is the gate an untrusted definition passes through before any other rule
+ * reads it. It sits beside `model.ts` rather than inside it so the node schemas
+ * have room to grow.
+ */
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+const INVALID_INPUT = Symbol('invalid-workflow-input');
+
+/** One dot-separated step of a binding path, an output field name, or an input
+ *  key: an identifier that is safe to look up on a plain object. */
+export const pathSegmentSchema = z.string()
+  .max(256)
+  .regex(/^[A-Za-z_][A-Za-z0-9_-]*$/, 'Invalid path segment')
+  .refine((segment) => !FORBIDDEN_PATH_SEGMENTS.has(segment), 'Unsafe path segment');
+
+type OwnDescriptors = ReturnType<typeof Object.getOwnPropertyDescriptors>;
+
+/** The array's own length, but only for an array whose keys are exactly the
+ *  indexes `0..length-1` plus `length` — anything else is a hole, a getter, or
+ *  a stray property, and none of those survive a round trip through JSON. */
+function arrayLength(descriptors: OwnDescriptors): number | undefined {
+  const keys = Reflect.ownKeys(descriptors);
+  if (keys.some((key) => typeof key !== 'string' || (key !== 'length' && !/^(0|[1-9][0-9]*)$/.test(key)))) return undefined;
+  const descriptor = descriptors.length;
+  if (!descriptor || !('value' in descriptor) || !Number.isSafeInteger(descriptor.value)
+    || descriptor.value < 0 || keys.length !== descriptor.value + 1) return undefined;
+  return descriptor.value as number;
+}
+
+function normalizeArray(descriptors: OwnDescriptors, ancestors: WeakSet<object>): JsonValue | typeof INVALID_INPUT {
+  const length = arrayLength(descriptors);
+  if (length === undefined) return INVALID_INPUT;
+  const normalized: JsonValue[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) return INVALID_INPUT;
+    const child = normalizeJson(descriptor.value, ancestors);
+    if (child === INVALID_INPUT) return INVALID_INPUT;
+    normalized.push(child);
+  }
+  return normalized;
+}
+
+function normalizeRecord(descriptors: OwnDescriptors, ancestors: WeakSet<object>): JsonValue | typeof INVALID_INPUT {
+  const normalized: Record<string, JsonValue> = Object.create(null) as Record<string, JsonValue>;
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== 'string' || FORBIDDEN_PATH_SEGMENTS.has(key)) return INVALID_INPUT;
+    const descriptor = descriptors[key];
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) return INVALID_INPUT;
+    const child = normalizeJson(descriptor.value, ancestors);
+    if (child === INVALID_INPUT) return INVALID_INPUT;
+    Object.defineProperty(normalized, key, { value: child, enumerable: true, configurable: true, writable: true });
+  }
+  return normalized;
+}
+
+/** A container carrying nothing but its own kind: a plain array or a plain
+ *  object. Anything with a class, a subclass, or a swapped prototype is refused
+ *  rather than flattened, so a definition cannot smuggle behaviour in as data. */
+function plainContainer(value: object, array: boolean): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return array ? prototype === Array.prototype : prototype === Object.prototype || prototype === null;
+}
+
+/** Whatever this value is on its own, without descending: a JSON leaf, or not
+ *  data at all. `undefined` means it is a container and the caller keeps going. */
+function normalizeLeaf(value: unknown): JsonValue | typeof INVALID_INPUT | undefined {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : INVALID_INPUT;
+  return typeof value === 'object' ? undefined : INVALID_INPUT;
+}
+
+function normalizeJson(value: unknown, ancestors: WeakSet<object>): JsonValue | typeof INVALID_INPUT {
+  const leaf = normalizeLeaf(value);
+  if (leaf !== undefined) return leaf;
+  const container = value as object;
+  if (isProxy(container) || ancestors.has(container)) return INVALID_INPUT;
+  const array = Array.isArray(container);
+  if (!plainContainer(container, array)) return INVALID_INPUT;
+  const descriptors = Object.getOwnPropertyDescriptors(container);
+  ancestors.add(container);
+  try {
+    return array
+      ? normalizeArray(descriptors, ancestors)
+      : normalizeRecord(descriptors, ancestors);
+  } finally {
+    ancestors.delete(container);
+  }
+}
+
+function normalizeInput(value: unknown): unknown {
+  try {
+    return normalizeJson(value, new WeakSet<object>());
+  } catch {
+    return INVALID_INPUT;
+  }
+}
+
+export function normalizedSchema<T extends z.ZodType>(schema: T) {
+  return z.preprocess(normalizeInput, schema);
+}
+
+export const jsonValueSchema = normalizedSchema(z.custom<JsonValue>(
+  (value) => value !== INVALID_INPUT,
+  { message: 'Value must be bounded, accessor-free JSON data' },
+));

--- a/packages/jimmy/src/workflows/model.ts
+++ b/packages/jimmy/src/workflows/model.ts
@@ -1,0 +1,323 @@
+import { z } from 'zod';
+import { nodeFallbackSchema } from './engine-chain.js';
+import { jsonValueSchema, normalizedSchema, pathSegmentSchema } from './json-schema.js';
+import type { JsonValue } from './json-schema.js';
+import { triggerConfigSchema } from './trigger-config-schema.js';
+
+export { jsonValueSchema } from './json-schema.js';
+export type { JsonPrimitive, JsonValue } from './json-schema.js';
+
+const MAX_DEFINITION_BYTES = 256 * 1024;
+const MAX_PROMPT_BYTES = 32 * 1024;
+/** A round costs a whole child run, so the ceiling is deliberately low: past
+ *  this an author wants a different Workflow, not a longer loop. It also keeps
+ *  an iterating node inside the reconcile budget in `runner.ts`. */
+export const MAX_ITERATION_ROUNDS = 20;
+const SOURCE_ROOT_SEGMENTS = new Set(['input', 'trigger', 'run', 'nodes']);
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+const finiteNumberSchema = z.number().finite();
+export const workflowIdSchema = z.string()
+  .regex(/^[a-z][a-z0-9-]{0,63}$/, 'Invalid workflow ID')
+  .refine((id) => id !== 'events', 'Reserved workflow ID');
+export const nodeIdSchema = z.string().regex(/^[a-z][a-z0-9_-]{0,63}$/, 'Invalid node ID');
+const promptSchema = z.string().refine((value) => utf8Bytes(value) <= MAX_PROMPT_BYTES, 'Prompt must be at most 32 KiB');
+const edgeIdSchema = z.string().min(1).max(128);
+const portSchema = z.string().min(1);
+
+const bindingPathSchema = z.string().min(1).max(256).superRefine((path, context) => {
+  const segments = path.split('.');
+  if (segments.length > 16) context.addIssue({ code: 'custom', message: 'Binding path may contain at most 16 segments' });
+  if (segments.length > 1 && SOURCE_ROOT_SEGMENTS.has(segments[0]!)) {
+    context.addIssue({ code: 'custom', message: 'Binding paths are relative to their source' });
+  }
+  for (const [index, segment] of segments.entries()) {
+    const result = pathSegmentSchema.safeParse(segment);
+    if (!result.success) context.addIssue({ code: 'custom', message: result.error.issues[0]!.message, path: [index] });
+  }
+});
+
+function bindingWithFixed<T extends z.ZodType>(fixedValueSchema: T) {
+  return z.discriminatedUnion('source', [
+    z.strictObject({ source: z.literal('fixed'), value: fixedValueSchema }),
+    z.strictObject({ source: z.literal('input'), path: bindingPathSchema }),
+    z.strictObject({ source: z.literal('trigger'), path: bindingPathSchema }),
+    z.strictObject({ source: z.literal('run'), path: bindingPathSchema }),
+    z.strictObject({ source: z.literal('node'), nodeId: nodeIdSchema, path: bindingPathSchema }),
+  ]);
+}
+
+export const bindingSchema = bindingWithFixed(jsonValueSchema);
+const stringBindingSchema = bindingWithFixed(z.string());
+const effortBindingSchema = bindingWithFixed(z.enum(['low', 'medium', 'high', 'xhigh']));
+const concurrencySchema = finiteNumberSchema.int().min(1).max(16);
+type InferredBinding = z.infer<typeof bindingSchema>;
+export type Binding<T extends JsonValue = JsonValue> =
+  | (Omit<Extract<InferredBinding, { source: 'fixed' }>, 'value'> & { value: T })
+  | Exclude<InferredBinding, { source: 'fixed' }>;
+const workflowOutputFieldSchema = z.strictObject({
+  type: z.enum(['string', 'number', 'boolean', 'string[]', 'attachment', 'attachment[]']),
+  required: z.boolean(),
+  description: z.string().optional(),
+});
+const workflowOutputSchema = z.strictObject({
+  fields: z.record(pathSegmentSchema, workflowOutputFieldSchema),
+  allowAdditionalFields: z.boolean(),
+});
+const workflowRetrySchema = z.strictObject({
+  attempts: z.number().int().min(1).max(5),
+  delaySeconds: finiteNumberSchema.int().nonnegative(),
+  backoff: z.enum(['fixed', 'exponential']),
+});
+const triggerNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('trigger'),
+  name: z.string().min(1).max(80),
+  config: triggerConfigSchema,
+});
+const employeeNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('employee'),
+  name: z.string().min(1).max(80),
+  config: z.strictObject({
+    employee: stringBindingSchema,
+    prompt: promptSchema,
+    /** Continue the engine session of a completed attempt of `nodeId` instead of dispatching cold; naming this node itself continues its own previous run for the same Todo. Its `prompt` replaces the one above whenever a continuation is found, so it carries the delta rather than the whole brief. */
+    continueFrom: z.strictObject({ nodeId: nodeIdSchema, prompt: promptSchema }).optional(),
+    engine: stringBindingSchema.optional(), model: stringBindingSchema.optional(), effort: effortBindingSchema.optional(), fallback: nodeFallbackSchema.optional(),
+    output: workflowOutputSchema.optional(), retry: workflowRetrySchema.optional(), timeoutMinutes: finiteNumberSchema.int().min(1).max(1440).optional(), mutex: z.string().min(1).max(60).optional(), // one live node at a time per mutex key, held only while a node run carrying it is live (node-mutex.ts)
+  }),
+});
+const conditionPredicateSchema = z.strictObject({
+  left: bindingSchema,
+  operator: z.enum(['equals', 'not-equals', 'exists', 'not-exists', 'contains', 'gt', 'gte', 'lt', 'lte', 'in']),
+  right: bindingSchema.optional(),
+});
+const workflowIterationSchema = z.strictObject({
+  /** The ceiling on rounds, and the whole reason iteration is safe to have. A
+   *  literal, never a binding: a number that only exists once the run is under
+   *  way is not a bound anyone can read off the definition. Optional here only
+   *  so that omitting it still parses and so reaches `validateExecutableWorkflow`,
+   *  which rejects it as `unbounded-iteration` naming the node — a definition
+   *  that fails to parse can only say "invalid". */
+  maxRounds: z.number().int().min(1).max(MAX_ITERATION_ROUNDS).optional(),
+  /** Another round runs only while every predicate holds against the round that
+   *  just finished. While these are read the node stands for its own latest
+   *  round, so `{ source: 'node', nodeId: <this node> }` asks what it returned. */
+  continueWhile: z.array(conditionPredicateSchema).min(1).max(10),
+});
+const workflowCallNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('workflow-call'),
+  name: z.string().min(1).max(80),
+  config: z.strictObject({
+    workflowId: stringBindingSchema,
+    items: bindingSchema.optional(),
+    input: z.record(pathSegmentSchema, bindingSchema).optional(),
+    concurrency: z.union([concurrencySchema, bindingWithFixed(concurrencySchema)]).default(2), // children at once: a number, or a binding a planner node fills in; clamped at run time by `systemConcurrencyCeiling` (capacity.ts)
+    /** Call the target again, up to `maxRounds` times, while the round that just
+     *  finished still asks for another. Each round is its own child run, so it
+     *  keeps its own status, output and sessions. Mutually exclusive with `items`:
+     *  fan-out is width decided up front, iteration is depth decided as it goes. */
+    iterate: workflowIterationSchema.optional(),
+  }),
+});
+const conditionCaseSchema = z.strictObject({
+  port: portSchema,
+  label: z.string(),
+  all: z.array(conditionPredicateSchema).max(10),
+});
+const conditionConfigSchema = z.strictObject({
+  cases: z.array(conditionCaseSchema).max(10),
+  defaultPort: portSchema,
+}).superRefine((config, context) => {
+  const ports = new Set<string>();
+  for (const [index, item] of config.cases.entries()) {
+    if (ports.has(item.port)) context.addIssue({ code: 'custom', message: 'Duplicate Condition port', path: ['cases', index, 'port'] });
+    ports.add(item.port);
+  }
+  if (ports.has(config.defaultPort)) context.addIssue({ code: 'custom', message: 'Condition default port must be unique', path: ['defaultPort'] });
+});
+const conditionNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('condition'),
+  name: z.string().min(1).max(80),
+  config: conditionConfigSchema,
+});
+const mergeNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('merge'),
+  name: z.string().min(1).max(80),
+  config: z.strictObject({ mode: z.literal('wait-all') }),
+});
+const approvalNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('approval'),
+  name: z.string().min(1).max(80),
+  config: z.strictObject({
+    description: z.string(),
+    approver: stringBindingSchema.optional(),
+    // Reserves the gate for the human operator. Default routing sends an
+    // approval up the org hierarchy to its root, which means the COO can
+    // approve a pipeline the COO started — fine for ordinary gates, a
+    // governance hole for one that authorizes something irreversible.
+    operatorOnly: z.boolean().optional(),
+    // Variant-picking: the labels mirror onto the bound Todo's approval and the
+    // pick reads back as `{{ node.<id>.choice }}`. Fixed labels, not bindings, and
+    // trimmed as the mirror trims — two spellings is a gate neither door can decide.
+    options: z.array(z.string().trim().min(1).max(80)).min(2).max(8)
+      .refine((values) => new Set(values).size === values.length, 'Approval options must be unique').optional(),
+  }).refine((config) => !(config.operatorOnly && config.approver !== undefined),
+    'An operator-only approval cannot also name an approver.'),
+});
+const waitConfigSchema = z.discriminatedUnion('mode', [
+  z.strictObject({ mode: z.literal('duration'), minutes: finiteNumberSchema.int().min(1).max(43_200) }),
+  z.strictObject({ mode: z.literal('until'), timestamp: stringBindingSchema }),
+  // Parks a Todo-bound run until the operator comments on that Todo. The
+  // timeout is a ceiling, not a schedule: a reply resumes the node early, and
+  // the default gives a conversation a working week to happen in.
+  z.strictObject({ mode: z.literal('todo-comment'),
+    timeoutMinutes: finiteNumberSchema.int().min(1).max(43_200).default(10_080) }),
+]);
+const waitNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('wait'),
+  name: z.string().min(1).max(80),
+  config: waitConfigSchema,
+});
+/** What a success End demands of the work it authorizes before a bound Todo may close: the output field the named node has to have reported the landed commit in, and optionally the node field naming the checkout that commit must be on `main` in. Reaching an End is not evidence that anything landed; this is. */
+const landingRequirementSchema = z.strictObject({ nodeId: nodeIdSchema, field: pathSegmentSchema, commitIn: z.strictObject({ nodeId: nodeIdSchema, field: pathSegmentSchema }).optional() });
+const endNodeSchema = z.strictObject({
+  id: nodeIdSchema,
+  type: z.literal('end'),
+  name: z.string().min(1).max(80),
+  config: z.strictObject({ result: z.enum(['success', 'failure']), message: z.string().optional(), output: bindingSchema.optional(), requires: landingRequirementSchema.optional() }),
+});
+const rawWorkflowNodeSchema = z.discriminatedUnion('type', [
+  triggerNodeSchema,
+  employeeNodeSchema,
+  workflowCallNodeSchema,
+  conditionNodeSchema,
+  mergeNodeSchema,
+  approvalNodeSchema,
+  waitNodeSchema,
+  endNodeSchema,
+]);
+export const workflowNodeSchema = normalizedSchema(rawWorkflowNodeSchema);
+const workflowEdgeSchema = z.strictObject({
+  id: edgeIdSchema,
+  from: z.strictObject({ nodeId: nodeIdSchema, port: portSchema }),
+  to: z.strictObject({ nodeId: nodeIdSchema, port: z.literal('input') }),
+});
+const workflowInputFieldSchema = z.strictObject({
+  key: pathSegmentSchema,
+  label: z.string(),
+  type: z.enum(['string', 'number', 'boolean', 'employee', 'engine', 'model']),
+  required: z.boolean(),
+  default: z.union([z.string(), finiteNumberSchema, z.boolean(), z.null()]).optional(),
+  description: z.string().optional(),
+});
+const workflowUiSchema = z.strictObject({
+  positions: z.record(nodeIdSchema, z.strictObject({ x: finiteNumberSchema, y: finiteNumberSchema })),
+  /** Set only by the editor, when a person arranged the canvas. Positions
+   *  authored any other way are a guess, so absence means "lay this out". */
+  layout: z.literal('manual').optional(),
+});
+const graphShape = {
+  inputs: z.array(workflowInputFieldSchema).optional(),
+  nodes: z.array(rawWorkflowNodeSchema).max(100),
+  edges: z.array(workflowEdgeSchema).max(300),
+  ui: workflowUiSchema.optional(),
+} as const;
+type GraphValue = {
+  inputs?: Array<{ key: string }>;
+  nodes: Array<{ id: string }>;
+  edges: Array<{ id: string }>;
+};
+
+function addDuplicateIssues(value: GraphValue, context: z.RefinementCtx): void {
+  for (const [items, label, path] of [
+    [value.nodes, 'node ID', 'nodes'],
+    [value.edges, 'edge ID', 'edges'],
+    [value.inputs ?? [], 'input key', 'inputs'],
+  ] as const) {
+    const seen = new Set<string>();
+    for (const [index, item] of items.entries()) {
+      const key = 'key' in item ? item.key : item.id;
+      if (seen.has(key)) context.addIssue({ code: 'custom', message: `Duplicate ${label}: ${key}`, path: [path, index] });
+      seen.add(key);
+    }
+  }
+}
+
+function addSizeIssue(value: unknown, context: z.RefinementCtx, label: string): void {
+  let bytes: number;
+  try {
+    bytes = utf8Bytes(JSON.stringify(value));
+  } catch {
+    context.addIssue({ code: 'custom', message: `${label} must be serializable JSON` });
+    return;
+  }
+  if (bytes > MAX_DEFINITION_BYTES) {
+    context.addIssue({ code: 'custom', message: `${label} must be at most 256 KiB` });
+  }
+}
+
+const rawWorkflowDraftSchema = z.strictObject(graphShape).superRefine((value, context) => {
+  addDuplicateIssues(value, context);
+  addSizeIssue(value, context, 'Workflow draft');
+});
+export const workflowDraftSchema = normalizedSchema(rawWorkflowDraftSchema);
+
+const rawWorkflowDefinitionSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  id: workflowIdSchema,
+  title: z.string().min(1).max(120),
+  description: z.string().optional(),
+  revision: z.number().int().min(1),
+  enabled: z.boolean(),
+  retiredAt: z.string().optional(),
+  ...graphShape,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}).superRefine((value, context) => {
+  addDuplicateIssues(value, context);
+  if (value.enabled && value.retiredAt !== undefined) {
+    context.addIssue({ code: 'custom', message: 'A retired Workflow cannot be enabled', path: ['enabled'] });
+  }
+  addSizeIssue(value, context, 'Workflow definition');
+});
+export const workflowDefinitionSchema = normalizedSchema(rawWorkflowDefinitionSchema);
+
+export type WorkflowOutputSchema = z.infer<typeof workflowOutputSchema>;
+export type WorkflowInputField = z.infer<typeof workflowInputFieldSchema>;
+export type TriggerNode = z.infer<typeof triggerNodeSchema>;
+export type EmployeeNode = z.infer<typeof employeeNodeSchema>;
+export type WorkflowCallNode = z.infer<typeof workflowCallNodeSchema>;
+export type ConditionPredicate = z.infer<typeof conditionPredicateSchema>;
+export type WorkflowIteration = z.infer<typeof workflowIterationSchema>;
+export type ConditionNode = z.infer<typeof conditionNodeSchema>;
+export type MergeNode = z.infer<typeof mergeNodeSchema>;
+export type ApprovalNode = z.infer<typeof approvalNodeSchema>;
+export type WaitNode = z.infer<typeof waitNodeSchema>;
+export type EndNode = z.infer<typeof endNodeSchema>;
+export type WorkflowNode = z.infer<typeof workflowNodeSchema>;
+export type WorkflowEdge = z.infer<typeof workflowEdgeSchema>;
+export type WorkflowDraft = z.infer<typeof workflowDraftSchema>;
+export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema>;
+export type WorkflowId = WorkflowDefinition['id'];
+
+export interface WorkflowNodeOutput {
+  text: string;
+  fields: Record<string, JsonValue>;
+  /** The option picked on an Approval node that offered a choice — read
+   *  downstream as `{{ node.<approvalNodeId>.choice }}`. */
+  choice?: string;
+  employeeId?: string;
+  engine?: string;
+  model?: string;
+  sessionId?: string;
+}

--- a/packages/jimmy/src/workflows/node-dispatch.ts
+++ b/packages/jimmy/src/workflows/node-dispatch.ts
@@ -1,0 +1,209 @@
+import type { Employee, ModelRegistry } from "../shared/types.js";
+import { interpolateWorkflowPrompt, resolveBinding, type WorkflowBindingContext } from "./bindings.js";
+import { continuationPrompt, resolveEmployeeContinuation } from "./employee-continuation.js";
+import { readEngineHealth, recordEngineUnavailable } from "../shared/engine-health.js";
+import { engineAvailabilityFailure, selectSubstituteEngine, type EngineChainSource, type EngineSubstitution,
+  type SubstituteDeps } from "./engine-chain.js";
+import type { EmployeeNode } from "./model.js";
+import type { WorkflowRepository } from "./repository.js";
+import type { ResolvedEmployeeConfig, WorkflowError, WorkflowRunDetail } from "./runtime.js";
+import type { WorkflowSessionExecutor } from "./session-executor.js";
+import type { WorkflowTodoDispatchOverride } from "./todo-ports.js";
+
+/**
+ * What a run's bindings see, and what an Employee node's attempt actually runs
+ * on. Both are read once per attempt, immediately before dispatch, so an
+ * override set while an earlier attempt was in flight lands on the next one.
+ */
+
+const DEFAULT_ATTEMPT_TIMEOUT_MINUTES = 180;
+
+/** The narrow slice of the runner's options this resolution needs. Declared
+ *  here rather than imported from `runner.ts` so the dependency runs one way. */
+export interface DispatchResolutionDeps {
+  employees: () => ReadonlyMap<string, Employee>;
+  models: () => ModelRegistry;
+  repository: WorkflowRepository;
+  executor: Pick<WorkflowSessionExecutor, "resumableEngineSession">;
+  todoDispatch?: WorkflowTodoDispatchOverride;
+  /** The configured `engines.<name>.fallback` chains, so an attempt whose engine
+   *  could not serve the turn re-dispatches on one that can. Absent = no chains,
+   *  and a run that freezes on the failure exactly as it did before. */
+  engineFallback?: EngineChainSource;
+}
+
+export function bindingContext(run: WorkflowRunDetail): WorkflowBindingContext {
+  const itemIndex = run.trigger.payload.itemIndex;
+  return {
+    input: run.input,
+    trigger: {
+      kind: run.trigger.kind,
+      payload: run.trigger.payload,
+      ...(Number.isInteger(itemIndex) ? { itemIndex: itemIndex as number } : {}),
+    },
+    run: { id: run.id, startedAt: run.startedAt, ...(run.trigger.todoId ? { todoId: run.trigger.todoId } : {}) },
+    nodes: Object.fromEntries(run.nodeRuns.map((node) => [node.nodeId, {
+      status: node.status, output: node.output ?? null, error: node.error ?? null,
+    }])),
+  };
+}
+
+export function resolveString(
+  binding: Parameters<typeof resolveBinding<string>>[0],
+  context: WorkflowBindingContext,
+  label: string,
+): string {
+  const value = resolveBinding(binding, context);
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must resolve to a nonempty string.`);
+  return value;
+}
+
+type Override = { engine: string | null; model: string | null } | undefined;
+
+/** Whatever pinned this attempt away from the employee's own defaults, in the
+ *  order that wins: the bound Todo first, then the node's own configuration.
+ *  `undefined` on either side means nothing pinned it and the employee decides. */
+function pinnedSelection(node: EmployeeNode, context: WorkflowBindingContext, override: Override): {
+  engine: string | undefined;
+  model: string | undefined;
+} {
+  if (override?.engine) return { engine: override.engine, model: override.model ?? undefined };
+  return {
+    engine: node.config.engine ? resolveString(node.config.engine, context, "Engine") : undefined,
+    model: node.config.model ? resolveString(node.config.model, context, "Model") : undefined,
+  };
+}
+
+type ModelInfo = ModelRegistry[string]["models"][number];
+
+/** The engine this attempt runs on and the model it runs with, given whatever
+ *  pinned it. A pinned engine with no model of its own takes THAT engine's
+ *  default, never the employee's model, which it would not be registered for. */
+function resolveTarget(
+  pinned: { engine: string | undefined; model: string | undefined },
+  employee: Employee,
+  models: () => ModelRegistry,
+): { engine: string; model: string; modelInfo: ModelInfo } {
+  const engine = pinned.engine ?? employee.engine;
+  const registry = models()[engine];
+  if (!registry?.available) throw new Error(`Workflow engine "${engine}" is not available.`);
+  const model = pinned.model ?? (pinned.engine ? registry.defaultModel : employee.model || registry.defaultModel);
+  const modelInfo = registry.models.find((candidate) => candidate.id === model);
+  if (!modelInfo) throw new Error(`Workflow model "${model}" is not available for engine "${engine}".`);
+  return { engine, model, modelInfo };
+}
+
+/** The employee's configured effort only applies while the employee's own
+ *  engine and model do: a pin can land on a model that does not know it. An
+ *  effort the node asked for explicitly still has to be one the model has. */
+function resolveEffort(
+  node: EmployeeNode,
+  context: WorkflowBindingContext,
+  employee: Employee,
+  pinned: boolean,
+  modelInfo: ModelInfo,
+): ResolvedEmployeeConfig["effort"] {
+  const effort = (node.config.effort
+    ? resolveString(node.config.effort, context, "Effort")
+    : pinned ? undefined : employee.effortLevel) as ResolvedEmployeeConfig["effort"];
+  if (effort && (!modelInfo.supportsEffort || !modelInfo.effortLevels.includes(effort))) {
+    throw new Error(`Workflow effort "${effort}" is not available for model "${modelInfo.id}".`);
+  }
+  return effort;
+}
+
+/** The walk's dependencies with the live health reading filled in. The store is
+ *  gateway-side and global, so unlike the chain source there is nothing upstream
+ *  has to supply — and both callers of the walk read it the same way. */
+function substituteDeps(options: DispatchResolutionDeps): SubstituteDeps {
+  return { ...options, engineHealth: readEngineHealth };
+}
+
+/** What the failure that settled an attempt says about the engine that actually
+ *  ran it — the stand-in on a substituted attempt, not the engine it stood in
+ *  for. Recorded here rather than inside the walk because `hasSubstitute` asks
+ *  that walk repeatedly at the retry boundary, and one failure is one
+ *  observation. */
+function recordAttemptHealth(attempt: WorkflowRunDetail["attempts"][number] | undefined): void {
+  if (!attempt) return;
+  const availability = engineAvailabilityFailure(attempt.error);
+  if (!availability) return;
+  recordEngineUnavailable(attempt.resolvedConfig.engine, availability.reason, availability.resetsAt);
+}
+
+/**
+ * What this attempt actually runs on, and whether that is something other than
+ * the employee's own defaults.
+ *
+ * PLA-149: the engine the node resolved to may be the very one that could not
+ * serve this node's last attempt. When a chain covers for it, the attempt runs
+ * on the stand-in instead — on THAT engine's own default model, since it is not
+ * registered for the first's, and never with an effort the employee configured
+ * for an engine it is no longer on.
+ */
+function dispatchTarget(
+  run: WorkflowRunDetail,
+  node: EmployeeNode,
+  employee: Employee,
+  pinned: { engine: string | undefined; model: string | undefined },
+  options: DispatchResolutionDeps,
+): { engine: string; model: string; modelInfo: ModelInfo; pinned: boolean; substitutedFrom?: EngineSubstitution } {
+  const base = resolveTarget(pinned, employee, options.models);
+  const failed = run.attempts.filter((attempt) => attempt.nodeId === node.id).at(-1);
+  recordAttemptHealth(failed);
+  const substitutedFrom = selectSubstituteEngine(run, node.id, base.engine, failed?.error, substituteDeps(options));
+  const own = Boolean(pinned.engine || pinned.model);
+  if (!substitutedFrom) return { ...base, pinned: own };
+  const stood = resolveTarget({ engine: substitutedFrom.engine, model: undefined }, employee, options.models);
+  return { ...stood, pinned: true, substitutedFrom };
+}
+
+/** What the next walk covers for: the engine this node's own precedence resolved
+ *  to, which on an already-substituted attempt is the one it stood in for rather
+ *  than the stand-in. */
+function substitutionBase(attempt: WorkflowRunDetail["attempts"][number]): string {
+  return attempt.resolvedConfig.substitutedFrom?.engine ?? attempt.resolvedConfig.engine;
+}
+
+/** Whether a chain would carry this node's next attempt past the failure that
+ *  just settled — the retry boundary's half of the same question `dispatchTarget`
+ *  answers, asked through the same walk so the two cannot disagree about whether
+ *  a run is out of options. */
+export function hasSubstitute(
+  run: WorkflowRunDetail,
+  attempt: WorkflowRunDetail["attempts"][number],
+  failure: WorkflowError,
+  options: DispatchResolutionDeps,
+): boolean {
+  return selectSubstituteEngine(run, attempt.nodeId, substitutionBase(attempt), failure, substituteDeps(options)) !== undefined;
+}
+
+export function resolveDispatch(
+  run: WorkflowRunDetail,
+  node: EmployeeNode,
+  options: DispatchResolutionDeps,
+): ResolvedEmployeeConfig {
+  const context = bindingContext(run);
+  const employeeId = resolveString(node.config.employee, context, "Employee");
+  const employee = options.employees().get(employeeId);
+  if (!employee) throw new Error(`Workflow employee "${employeeId}" is not available.`);
+  // ICI-733: the bound Todo's override outranks the node's own engine/model. It
+  // exists to move a Todo whose attempts keep failing onto a different engine,
+  // and a workflow that pinned the failing one would otherwise defeat it.
+  const override = run.trigger.todoId ? options.todoDispatch?.read(run.trigger.todoId) : undefined;
+  const target = dispatchTarget(run, node, employee, pinnedSelection(node, context, override), options);
+  const { engine, model, substitutedFrom } = target;
+  const effort = resolveEffort(node, context, employee, target.pinned, target.modelInfo);
+  const continuedFrom = resolveEmployeeContinuation(run, node, engine, {
+    repository: options.repository,
+    resumableEngineSession: (id, target) => options.executor.resumableEngineSession(id, target),
+  });
+  // Only the prompt going out: an unused delta must not fail a cold round over a binding it never reads.
+  interpolateWorkflowPrompt(continuationPrompt(node, Boolean(continuedFrom)), context);
+  return {
+    employeeId, engine, model, ...(effort ? { effort } : {}), ...(continuedFrom ? { continuedFrom } : {}),
+    ...(substitutedFrom ? { substitutedFrom: { engine: substitutedFrom.from, reason: substitutedFrom.reason } } : {}),
+    retry: node.config.retry ?? { attempts: 1, delaySeconds: 0, backoff: "fixed" },
+    timeoutMinutes: node.config.timeoutMinutes ?? DEFAULT_ATTEMPT_TIMEOUT_MINUTES,
+  };
+}

--- a/packages/jimmy/src/workflows/node-mutex.ts
+++ b/packages/jimmy/src/workflows/node-mutex.ts
@@ -1,0 +1,65 @@
+/** Serializing employee nodes that must not be live at the same time.
+ *
+ *  A node authors `mutex: "<key>"` and then dispatches only while no other node
+ *  carrying that key is live. The lock is derived rather than stored — see
+ *  repository-mutex.ts, which reads it. Waiting is unbounded here on purpose: the
+ *  holder's own `timeoutMinutes` is what ends it, and a second clock could only
+ *  disagree with the first. */
+
+import { logger } from '../shared/logger.js';
+import type { EmployeeNode } from './model.js';
+import type { WorkflowMutexNodeRun } from './repository-mutex.js';
+import type { WorkflowRepository } from './repository.js';
+import { nodeRun } from './run-graph.js';
+import type { WorkflowRunDetail } from './runtime.js';
+
+/** Whoever is live on this node's key, if it is not this node itself. A `pending`
+ *  node run is another node standing off the same key rather than a holder, so two
+ *  waiters never block each other into a deadlock neither can leave. */
+export function mutexHolder(repository: WorkflowRepository, run: WorkflowRunDetail,
+  node: EmployeeNode): WorkflowMutexNodeRun | null {
+  const key = node.config.mutex;
+  if (!key) return null;
+  return repository.listMutexNodeRuns().find((candidate) => candidate.mutexKey === key
+    && candidate.status !== 'pending' && !(candidate.runId === run.id && candidate.nodeId === node.id)) ?? null;
+}
+
+/** Write why the run is parked where the operator reads the run, not only into the
+ *  log: the key it wants and who holds it. Called once the run has nothing else it
+ *  could be doing, so it names the real reason, and only when the holder changes, so
+ *  a node standing off for an hour writes once. The record is transient by
+ *  construction: dispatching replaces `resolvedConfig` with the config it dispatched. */
+export function recordMutexWaits(repository: WorkflowRepository, run: WorkflowRunDetail): void {
+  for (const node of run.definition.nodes) {
+    if (node.type !== 'employee') continue;
+    const runtime = nodeRun(run, node.id);
+    if (!runtime.activated || runtime.status !== 'pending') continue;
+    const holder = mutexHolder(repository, run, node);
+    if (!holder) continue;
+    const waiting = { mutexKey: holder.mutexKey, mutexHeldBy: `${holder.runId}:${holder.nodeId}` };
+    if (runtime.resolvedConfig?.mutexKey === waiting.mutexKey
+      && runtime.resolvedConfig?.mutexHeldBy === waiting.mutexHeldBy) continue;
+    const current = repository.getRun(run.workflowId, run.id)!;
+    repository.mutateRun(current.id, current.revision, (tx) => {
+      tx.setNodeStatus(node.id, runtime.status, { resolvedConfig: { ...runtime.resolvedConfig, ...waiting } });
+    });
+    logger.info(`Workflow run ${run.id} node ${node.id} is waiting on mutex ${waiting.mutexKey} held by ${waiting.mutexHeldBy}.`);
+  }
+}
+
+/** A key lives only as long as the node run carrying it, so the moment that node goes
+ *  terminal every run standing off the key has a different answer waiting for it — and
+ *  nothing else would re-drive them: they are parked on no timer and no child, only on
+ *  this. Fired and forgotten, the way a workflow-call caller is woken. */
+export function wakeMutexWaiters(repository: WorkflowRepository, run: WorkflowRunDetail, nodeId: string,
+  advance: (workflowId: string, runId: string) => Promise<unknown>): void {
+  const node = run.definition.nodes.find((candidate) => candidate.id === nodeId);
+  const key = node?.type === 'employee' ? node.config.mutex : undefined;
+  if (!key) return;
+  for (const waiter of repository.listMutexNodeRuns()) {
+    if (waiter.mutexKey !== key || waiter.status !== 'pending' || waiter.runId === run.id) continue;
+    void advance(waiter.workflowId, waiter.runId).catch((error) => {
+      logger.warn(`Workflow run ${waiter.runId} could not resume on mutex ${key}: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+}

--- a/packages/jimmy/src/workflows/output.ts
+++ b/packages/jimmy/src/workflows/output.ts
@@ -1,0 +1,250 @@
+import { Buffer } from 'node:buffer';
+import { isProxy } from 'node:util/types';
+import { ATTACHMENT_REF_SHAPE, isAttachmentRef } from './attachment-ref.js';
+import {
+  jsonValueSchema,
+  type JsonValue,
+  type WorkflowNodeOutput,
+  type WorkflowOutputSchema,
+} from './model.js';
+import type { WorkflowFanoutChildSummary } from './runtime.js';
+
+type WorkflowOutputCode =
+  | 'multiple-blocks'
+  | 'invalid-json'
+  | 'invalid-shape'
+  | 'missing-field'
+  | 'type-mismatch'
+  | 'too-large';
+
+type OutputField = WorkflowOutputSchema['fields'][string];
+
+interface ParsedSchema {
+  fields: Record<string, OutputField>;
+  allowAdditionalFields: boolean;
+}
+
+interface FenceScan {
+  openerCount: number;
+  blockStart?: number;
+  payloadStart?: number;
+  payloadEnd?: number;
+  blockEnd?: number;
+}
+
+const MAX_PAYLOAD_BYTES = 262_144;
+const FIELD_NAME = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const FIELD_TYPES = new Set(['string', 'number', 'boolean', 'string[]', 'attachment', 'attachment[]']);
+const FORBIDDEN_FIELDS = new Set(['__proto__', 'prototype', 'constructor']);
+const MESSAGES: Record<WorkflowOutputCode, string> = {
+  'multiple-blocks': 'Employee output must contain at most one jinn-output block.',
+  'invalid-json': 'Employee output block must contain valid JSON.',
+  'invalid-shape': 'Employee output has an invalid shape.',
+  'missing-field': 'Employee output is missing a required field.',
+  'type-mismatch': 'Employee output field has the wrong type.',
+  'too-large': 'Employee output block exceeds 262144 UTF-8 bytes.',
+};
+
+export class WorkflowOutputError extends Error {
+  readonly code: WorkflowOutputCode;
+
+  constructor(code: WorkflowOutputCode, message = MESSAGES[code]) {
+    super(message);
+    this.name = 'WorkflowOutputError';
+    this.code = code;
+  }
+}
+
+function fail(code: WorkflowOutputCode, message?: string): never {
+  throw new WorkflowOutputError(code, message);
+}
+
+function matchesLine(text: string, start: number, end: number, marker: string): boolean {
+  if (end - start < marker.length || text.slice(start, start + marker.length) !== marker) return false;
+  for (let index = start + marker.length; index < end; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code !== 9 && code !== 32) return false;
+  }
+  return true;
+}
+
+function scanFences(text: string): FenceScan {
+  const scan: FenceScan = { openerCount: 0 };
+  for (let start = 0; start <= text.length;) {
+    const newline = text.indexOf('\n', start);
+    const lineEnd = newline === -1 ? text.length : newline;
+    const contentEnd = lineEnd > start && text.charCodeAt(lineEnd - 1) === 13 ? lineEnd - 1 : lineEnd;
+    const next = newline === -1 ? text.length : newline + 1;
+    if (matchesLine(text, start, contentEnd, '```jinn-output')) {
+      scan.openerCount += 1;
+      if (scan.openerCount === 1) {
+        scan.blockStart = start;
+        scan.payloadStart = next;
+      }
+    } else if (scan.openerCount >= 1 && scan.payloadEnd === undefined
+      && matchesLine(text, start, contentEnd, '```')) {
+      scan.payloadEnd = start;
+      scan.blockEnd = next;
+    }
+    if (newline === -1) break;
+    start = next;
+  }
+  return scan;
+}
+
+function readDataRecord(value: unknown): Record<string, unknown> | undefined {
+  try {
+    if (value === null || typeof value !== 'object' || isProxy(value)) return undefined;
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return undefined;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const record = Object.create(null) as Record<string, unknown>;
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (typeof key !== 'string') return undefined;
+      const descriptor = descriptors[key];
+      if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return undefined;
+      Object.defineProperty(record, key, { value: descriptor.value, enumerable: true, configurable: true, writable: true });
+    }
+    return record;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasExactKeys(record: Record<string, unknown>, required: string[], optional: string[] = []): boolean {
+  const keys = Object.keys(record);
+  return required.every((key) => Object.hasOwn(record, key))
+    && keys.every((key) => required.includes(key) || optional.includes(key));
+}
+
+function parseSchema(value: unknown): ParsedSchema | undefined {
+  const root = readDataRecord(value);
+  if (!root || !hasExactKeys(root, ['fields', 'allowAdditionalFields'])
+    || typeof root.allowAdditionalFields !== 'boolean') return undefined;
+  const rawFields = readDataRecord(root.fields);
+  if (!rawFields) return undefined;
+  const fields = Object.create(null) as Record<string, OutputField>;
+  for (const [name, value] of Object.entries(rawFields)) {
+    if (!FIELD_NAME.test(name) || FORBIDDEN_FIELDS.has(name)) return undefined;
+    const field = readDataRecord(value);
+    if (!field || !hasExactKeys(field, ['type', 'required'], ['description'])
+      || typeof field.type !== 'string' || !FIELD_TYPES.has(field.type)
+      || typeof field.required !== 'boolean'
+      || (Object.hasOwn(field, 'description') && typeof field.description !== 'string')) return undefined;
+    Object.defineProperty(fields, name, { value: field as OutputField, enumerable: true, configurable: true, writable: true });
+  }
+  return { fields, allowAdditionalFields: root.allowAdditionalFields };
+}
+
+function emptyFields(): Record<string, JsonValue> {
+  return Object.create(null) as Record<string, JsonValue>;
+}
+
+function normalizeFields(value: unknown): Record<string, JsonValue> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) fail('invalid-shape');
+  try {
+    const result = jsonValueSchema.safeParse(value);
+    if (!result.success || result.data === null || Array.isArray(result.data) || typeof result.data !== 'object') fail('invalid-shape');
+    return result.data as Record<string, JsonValue>;
+  } catch (error) {
+    if (error instanceof WorkflowOutputError) throw error;
+    return fail('invalid-shape');
+  }
+}
+
+function matchesType(value: JsonValue, type: OutputField['type']): boolean {
+  switch (type) {
+    case 'string': return typeof value === 'string';
+    case 'number': return typeof value === 'number' && Number.isFinite(value);
+    case 'boolean': return typeof value === 'boolean';
+    case 'string[]': return Array.isArray(value) && value.every((item) => typeof item === 'string');
+    case 'attachment': return isAttachmentRef(value);
+    case 'attachment[]': return Array.isArray(value) && value.every(isAttachmentRef);
+  }
+}
+
+/** An attachment field fails for a reason the employee can act on: it submitted
+ *  something that is not a ref, and a ref is not a filename it can invent. */
+function typeMismatchMessage(name: string, type: OutputField['type']): string {
+  const declared = `Output field "${name}" does not match declared type "${type}".`;
+  return type === 'attachment' || type === 'attachment[]'
+    ? `${declared} Attach the file to the Todo first, then submit the ref it returns: ${ATTACHMENT_REF_SHAPE}`
+    : declared;
+}
+
+function validateFields(fields: Record<string, JsonValue>, schema: ParsedSchema): Record<string, JsonValue> {
+  for (const [name, field] of Object.entries(schema.fields)) {
+    if (field.required && !Object.hasOwn(fields, name)) {
+      fail('missing-field', `Required output field "${name}" is missing.`);
+    }
+  }
+  for (const [name, field] of Object.entries(schema.fields)) {
+    if (Object.hasOwn(fields, name) && !matchesType(fields[name]!, field.type)) {
+      fail('type-mismatch', typeMismatchMessage(name, field.type));
+    }
+  }
+  if (!schema.allowAdditionalFields) {
+    for (const name of Object.keys(fields)) {
+      if (!Object.hasOwn(schema.fields, name)) fail('invalid-shape', `Output field "${name}" is not declared.`);
+    }
+  }
+  if (schema.allowAdditionalFields) return fields;
+  const selected = emptyFields();
+  for (const name of Object.keys(schema.fields)) {
+    if (Object.hasOwn(fields, name)) Object.defineProperty(selected, name, {
+      value: fields[name], enumerable: true, configurable: true, writable: true,
+    });
+  }
+  return selected;
+}
+
+export function validateSubmittedFields(
+  fields: unknown,
+  schema?: WorkflowOutputSchema,
+): Record<string, JsonValue> {
+  const normalized = fields === undefined ? emptyFields() : normalizeFields(fields);
+  if (schema === undefined) return normalized;
+  const parsedSchema = parseSchema(schema);
+  if (!parsedSchema) fail('invalid-shape');
+  return validateFields(normalized, parsedSchema);
+}
+
+export function parseWorkflowOutput(finalText: string, schema?: WorkflowOutputSchema): WorkflowNodeOutput {
+  if (typeof finalText !== 'string') fail('invalid-shape');
+  const scan = scanFences(finalText);
+  if (scan.openerCount > 1) fail('multiple-blocks');
+  if (scan.openerCount === 1 && scan.payloadEnd === undefined) fail('invalid-shape');
+  let text = finalText;
+  let fields = emptyFields();
+  if (scan.openerCount === 1) {
+    const payload = finalText.slice(scan.payloadStart!, scan.payloadEnd!);
+    if (Buffer.byteLength(payload, 'utf8') > MAX_PAYLOAD_BYTES) fail('too-large');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      fail('invalid-json');
+    }
+    fields = normalizeFields(parsed);
+    text = finalText.slice(0, scan.blockStart) + finalText.slice(scan.blockEnd);
+  }
+  return { text, fields: validateSubmittedFields(fields, schema) };
+}
+
+/** The other way a node output comes to exist: a Workflow Call node joins its
+ *  children into one, so a downstream Condition can route on the batch. */
+export function fanoutOutput(children: readonly WorkflowFanoutChildSummary[]): WorkflowNodeOutput {
+  const outcomes = children.map((child) => ({
+    index: child.itemIndex,
+    runId: child.runId,
+    workflowId: child.workflowId,
+    status: child.status === 'completed' ? 'succeeded' : child.status,
+    fields: child.endOutput ?? {},
+  }));
+  const succeeded = outcomes.filter((outcome) => outcome.status === 'succeeded').length;
+  const failed = outcomes.filter((outcome) => outcome.status === 'failed').length;
+  const cancelled = outcomes.filter((outcome) => outcome.status === 'cancelled').length;
+  const total = outcomes.length;
+  const summary = total > 0 && succeeded === total ? 'all-succeeded' : succeeded > 0 ? 'partial' : 'none-succeeded';
+  return { text: '', fields: { total, succeeded, failed, cancelled, summary, outcomes } };
+}

--- a/packages/jimmy/src/workflows/predicates.ts
+++ b/packages/jimmy/src/workflows/predicates.ts
@@ -1,0 +1,53 @@
+import { isDeepStrictEqual } from "node:util";
+import { resolveBinding, WorkflowBindingError, type WorkflowBindingContext } from "./bindings.js";
+import type { ConditionPredicate, JsonValue } from "./model.js";
+
+/**
+ * Evaluating the predicate language. A Condition node routes on it, and a
+ * Workflow Call node with `iterate` asks it whether the round that just finished
+ * wants another one — so it lives here rather than in `runner.ts`, which now has
+ * two callers instead of one.
+ */
+
+function resolved(binding: ConditionPredicate["left"], context: WorkflowBindingContext): { exists: boolean; value?: JsonValue } {
+  try { return { exists: true, value: resolveBinding(binding, context) }; }
+  catch (error) {
+    if (error instanceof WorkflowBindingError && error.code === "missing-value") return { exists: false };
+    throw error;
+  }
+}
+
+/** `contains` and `in` are the same test read from opposite ends: does the
+ *  haystack hold the needle, for a substring or for an array member. */
+function holds(haystack: JsonValue | undefined, needle: JsonValue | undefined): boolean {
+  if (typeof haystack === "string") return typeof needle === "string" && haystack.includes(needle);
+  return Array.isArray(haystack) && haystack.some((item) => isDeepStrictEqual(item, needle));
+}
+
+/** Ordering, which only numbers have. Anything else compares false rather than
+ *  falling back to JavaScript's coercion, which would order "10" before "9". */
+function ordered(operator: ConditionPredicate["operator"], left: JsonValue | undefined, right: JsonValue | undefined): boolean {
+  if (typeof left !== "number" || typeof right !== "number") return false;
+  return operator === "gt" ? left > right
+    : operator === "gte" ? left >= right
+      : operator === "lt" ? left < right : left <= right;
+}
+
+export function predicateMatches(predicate: ConditionPredicate, context: WorkflowBindingContext): boolean {
+  const left = resolved(predicate.left, context);
+  if (predicate.operator === "exists") return left.exists;
+  if (predicate.operator === "not-exists") return !left.exists;
+  if (!left.exists || !predicate.right) return false;
+  const right = resolved(predicate.right, context);
+  if (!right.exists) return false;
+  if (predicate.operator === "equals") return isDeepStrictEqual(left.value, right.value);
+  if (predicate.operator === "not-equals") return !isDeepStrictEqual(left.value, right.value);
+  if (predicate.operator === "contains") return holds(left.value, right.value);
+  if (predicate.operator === "in") return holds(right.value, left.value);
+  return ordered(predicate.operator, left.value, right.value);
+}
+
+/** Every predicate in `all` has to hold, and the first case that does wins. */
+export function predicatesHold(all: readonly ConditionPredicate[], context: WorkflowBindingContext): boolean {
+  return all.every((predicate) => predicateMatches(predicate, context));
+}

--- a/packages/jimmy/src/workflows/rearm-target.ts
+++ b/packages/jimmy/src/workflows/rearm-target.ts
@@ -1,0 +1,29 @@
+import type { TriggerNode, WorkflowDefinition } from "./model.js";
+import type { WorkflowRearmTarget } from "./todo-ports.js";
+
+/**
+ * Where a re-armed Todo has to land, read off the CURRENT definition rather than
+ * the snapshot a run started with: a workflow disabled or retired since then
+ * fires nothing, and a Todo left sitting at its trigger status would look queued
+ * forever. The status comes from the trigger, never from a hardcoded default —
+ * every Todo-triggered workflow gets this, not one of them.
+ *
+ * Two callers now read the same trigger: a rejection sending work round again,
+ * and the availability sweep bringing a quota-parked Todo back.
+ */
+export function resolveRearmTarget(
+  definition: WorkflowDefinition | null,
+  workflowId: string,
+): WorkflowRearmTarget {
+  if (!definition) return { unavailable: `workflow \`${workflowId}\` no longer exists` };
+  if (definition.retiredAt !== undefined) return { unavailable: `workflow \`${workflowId}\` is retired` };
+  if (!definition.enabled) return { unavailable: `workflow \`${workflowId}\` is disabled` };
+  const trigger = definition.nodes.find((node): node is TriggerNode =>
+    node.type === "trigger" && node.config.kind === "todo-status");
+  if (trigger?.config.kind !== "todo-status") {
+    return { unavailable: `workflow \`${workflowId}\` has no Todo trigger to re-arm` };
+  }
+  return { status: trigger.config.status,
+    ...(trigger.config.actor !== undefined ? { actor: trigger.config.actor } : {}),
+    ...(trigger.config.label !== undefined ? { label: trigger.config.label } : {}) };
+}

--- a/packages/jimmy/src/workflows/reminder-ladder.ts
+++ b/packages/jimmy/src/workflows/reminder-ladder.ts
@@ -1,0 +1,82 @@
+import type { WorkflowRepository } from "./repository.js";
+import type { WorkflowAttemptRecord, WorkflowRunDetail } from "./runtime.js";
+import type { WorkflowSessionExecutor } from "./session-executor.js";
+
+/**
+ * The time half of "this attempt has not submitted anything yet": three rungs at
+ * 5, 15 and 30 minutes, each one a real turn in the attempt's own session, and
+ * after the last one the runner settles the attempt as `workflow-no-output`.
+ *
+ * A rung is only spent on a session that is idle with no running children. A
+ * busy one is deferred five minutes without consuming a rung, because the point
+ * is to wake a stalled step, not to interrupt a working one.
+ */
+const REMINDER_TEXT = "Workflow reminder: if you have finished this step, call `workflow_submit_output` now. If you are still working or waiting on delegated work, continue.";
+const FINAL_REMINDER_TEXT = `${REMINDER_TEXT} This is the final reminder. If you genuinely need more time, call \`workflow_extend_deadline\`.`;
+
+export const REMINDER_RUNGS_MINUTES = [5, 15, 30] as const;
+
+export function addMinutes(at: string, minutes: number): string {
+  return new Date(Date.parse(at) + minutes * 60_000).toISOString();
+}
+
+export function hasWorkflowOutputBlock(text: string): boolean {
+  return /(?:^|\n)```jinn-output[ \t]*(?:\r?\n|$)/.test(text);
+}
+
+/** What the sweep borrows from the runner: the two collaborators it reads, plus
+ *  the run lookup and change notification the runner owns privately. */
+export interface ReminderLadderPorts {
+  repository: WorkflowRepository;
+  executor: WorkflowSessionExecutor;
+  activeRun: (attempt: WorkflowAttemptRecord) => WorkflowRunDetail;
+  changed: (run: WorkflowRunDetail) => void;
+}
+
+/** A rung is owed only to a running attempt that still holds a session and whose
+ *  scheduled moment has actually arrived. */
+function isDue(attempt: WorkflowAttemptRecord | null, now: string): attempt is DueAttempt {
+  return Boolean(attempt && attempt.status === "running" && attempt.sessionId
+    && attempt.nextReminderAt && attempt.nextReminderAt <= now);
+}
+
+type DueAttempt = WorkflowAttemptRecord & { sessionId: string; nextReminderAt: string };
+
+/** The third rung is the last one, so it carries the deadline-extension escape.
+ *  An output block that failed to parse is quoted back ahead of it. */
+function rungText(attempt: WorkflowAttemptRecord, rung: number): string {
+  const reminder = rung === 3 ? FINAL_REMINDER_TEXT : REMINDER_TEXT;
+  return attempt.pendingOutputError
+    ? `Your previous output block was invalid: ${attempt.pendingOutputError}\n\n${reminder}`
+    : reminder;
+}
+
+export async function remindDueAttempts(now: string, ports: ReminderLadderPorts): Promise<void> {
+  for (const due of ports.repository.listDueReminders(now, 100)) {
+    const current = ports.repository.getAttempt(due.runId, due.nodeId, due.attempt);
+    if (!isDue(current, now)) continue;
+    const run = ports.activeRun(current);
+    const state = ports.executor.attemptState(current.sessionId);
+    if (!state?.idle || state.runningChildren > 0) {
+      ports.repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.setAttemptReminder(current.nodeId, current.attempt, { nextReminderAt: addMinutes(now, 5) });
+      });
+      ports.changed(run);
+      continue;
+    }
+    const rung = current.remindersSent + 1;
+    await ports.executor.remind({ sessionId: current.sessionId, text: rungText(current, rung) });
+    const refreshed = ports.activeRun(current);
+    const latest = refreshed.attempts.find((candidate) => candidate.nodeId === current.nodeId
+      && candidate.attempt === current.attempt);
+    if (!latest || latest.status !== "running") continue;
+    ports.repository.mutateRun(refreshed.id, refreshed.revision, (tx) => {
+      tx.setAttemptReminder(latest.nodeId, latest.attempt, {
+        remindersSent: rung,
+        nextReminderAt: null,
+        pendingOutputError: null,
+      });
+    });
+    ports.changed(refreshed);
+  }
+}

--- a/packages/jimmy/src/workflows/repository-continuation.ts
+++ b/packages/jimmy/src/workflows/repository-continuation.ts
@@ -1,0 +1,34 @@
+import type { WorkflowAttemptRecord } from './runtime.js';
+import { decodeAttempt, type AttemptRow } from './repository-runs.js';
+
+type WorkflowSqliteConnection = ConstructorParameters<typeof import('./repository.js').WorkflowRepository>[0];
+
+export interface ContinuationAttemptQuery {
+  workflowId: string;
+  nodeId: string;
+  /** The Todo this run is bound to. Runs bound to any other Todo — or to none —
+   *  are invisible here, so a continuation can never cross Todos. */
+  todoId: string;
+  /** This run's own id and start. Only runs that began strictly before it are
+   *  candidates: two runs of the same Workflow can be in flight on one Todo, and
+   *  a run must never pick up a thread from one that started after it. */
+  runId: string;
+  runStartedAt: string;
+}
+
+/**
+ * The newest completed attempt of `nodeId` from an EARLIER run of the same
+ * Workflow for the same Todo. This is what lets a re-armed run pick up the
+ * engine session its predecessor left behind instead of starting cold.
+ */
+export function readContinuationAttempt(
+  db: WorkflowSqliteConnection,
+  query: ContinuationAttemptQuery,
+): WorkflowAttemptRecord | null {
+  const row = db.prepare(`SELECT a.* FROM workflow_attempts a JOIN workflow_runs r ON r.id = a.run_id
+    WHERE r.workflow_id = @workflowId AND (r.started_at, r.id) < (@runStartedAt, @runId)
+      AND json_extract(r.trigger_json, '$.todoId') = @todoId
+      AND a.node_id = @nodeId AND a.status = 'completed' AND a.session_id IS NOT NULL
+    ORDER BY a.started_at DESC, a.run_id DESC, a.attempt DESC LIMIT 1`).get(query) as AttemptRow | undefined;
+  return row ? decodeAttempt(row) : null;
+}

--- a/packages/jimmy/src/workflows/repository-integrity.ts
+++ b/packages/jimmy/src/workflows/repository-integrity.ts
@@ -1,0 +1,50 @@
+import { repositoryError } from './repository-support.js';
+
+type WorkflowSqliteConnection = ConstructorParameters<typeof import('./repository.js').WorkflowRepository>[0];
+
+/* Every invariant the run tables are meant to hold, asserted in SQL before a read trusts them. */
+const RUN_INTEGRITY = `SELECT 1 FROM workflow_runs r WHERE r.workflow_id=? AND (
+  r.status NOT IN ('pending','running','waiting','completed','failed','cancelled') OR r.revision<1
+  OR strftime('%Y-%m-%dT%H:%M:%fZ',r.started_at) IS NOT r.started_at
+  OR NOT json_valid(r.definition_json) OR NOT json_valid(r.input_json) OR NOT json_valid(r.trigger_json)
+  OR (r.error_json IS NOT NULL AND (NOT json_valid(r.error_json) OR json_type(r.error_json,'$.code') IS NOT 'text'
+    OR json_type(r.error_json,'$.message') IS NOT 'text' OR json_type(r.error_json,'$.retryable') NOT IN ('true','false')))
+  OR CASE WHEN json_valid(r.definition_json) AND json_valid(r.trigger_json) THEN
+    json_type(r.definition_json) IS NOT 'object' OR json_type(r.input_json) IS NOT 'object' OR json_type(r.trigger_json) IS NOT 'object'
+    OR json_extract(r.definition_json,'$.schemaVersion') IS NOT 1 OR json_type(r.definition_json,'$.nodes') IS NOT 'array'
+    OR json_extract(r.definition_json,'$.id') IS NOT r.workflow_id
+    OR json_extract(r.definition_json,'$.title') IS NOT r.workflow_title
+    OR json_extract(r.definition_json,'$.revision') IS NOT r.definition_revision
+    OR json_extract(r.trigger_json,'$.kind') NOT IN ('manual','schedule','event','todo-status','workflow-call') ELSE 0 END
+) LIMIT 1`;
+const CHILD_INTEGRITY = `SELECT 1 FROM workflow_runs r WHERE r.workflow_id=? AND (
+  (SELECT count(*) FROM workflow_node_runs n WHERE n.run_id=r.id) != json_array_length(r.definition_json,'$.nodes')
+  OR NOT EXISTS (SELECT 1 FROM json_each(r.definition_json,'$.nodes') j WHERE j.value->>'$.id'=json_extract(r.trigger_json,'$.nodeId')
+    AND j.value->>'$.type'='trigger' AND j.value->>'$.config.kind'=json_extract(r.trigger_json,'$.kind'))
+  OR EXISTS (SELECT 1 FROM workflow_node_runs n WHERE n.run_id=r.id AND (n.status NOT IN
+    ('pending','ready','dispatching','running','waiting','completed','failed','skipped','cancelled') OR n.activated NOT IN (0,1)
+    OR (n.resolved_config_json IS NOT NULL AND NOT json_valid(n.resolved_config_json)) OR (n.input_json IS NOT NULL AND NOT json_valid(n.input_json))
+    OR (n.output_json IS NOT NULL AND (NOT json_valid(n.output_json) OR json_type(n.output_json,'$.text') IS NOT 'text'
+      OR json_type(n.output_json,'$.fields') IS NOT 'object')) OR (n.error_json IS NOT NULL AND NOT json_valid(n.error_json))
+    OR NOT EXISTS (SELECT 1 FROM json_each(r.definition_json,'$.nodes') j WHERE j.value->>'$.id'=n.node_id AND j.value->>'$.type'=n.node_type)))
+  OR EXISTS (SELECT 1 FROM workflow_attempts a WHERE a.run_id=r.id AND (a.status NOT IN
+    ('dispatching','running','completed','failed','timed-out','cancelled') OR NOT json_valid(a.resolved_config_json) OR NOT json_valid(a.input_json)
+    OR json_type(a.resolved_config_json,'$.employeeId') IS NOT 'text' OR strftime('%Y-%m-%dT%H:%M:%fZ',a.started_at) IS NOT a.started_at
+    OR (a.output_json IS NOT NULL AND NOT json_valid(a.output_json)) OR (a.error_json IS NOT NULL AND NOT json_valid(a.error_json))
+    OR (a.status='dispatching' AND (a.session_id IS NOT NULL OR a.output_json IS NOT NULL OR a.error_json IS NOT NULL OR a.ended_at IS NOT NULL))
+    OR (a.status='running' AND (a.session_id IS NULL OR a.output_json IS NOT NULL OR a.error_json IS NOT NULL OR a.ended_at IS NOT NULL))
+    OR (a.status='completed' AND (a.session_id IS NULL OR a.output_json IS NULL OR a.error_json IS NOT NULL OR a.ended_at IS NULL))
+    OR (a.status IN ('failed','timed-out','cancelled') AND (a.error_json IS NULL OR a.output_json IS NOT NULL OR a.ended_at IS NULL))
+    OR (a.session_id IS NOT NULL AND EXISTS (SELECT 1 FROM workflow_attempts d WHERE d.session_id=a.session_id AND d.rowid<>a.rowid))
+    OR NOT EXISTS (SELECT 1 FROM json_each(r.definition_json,'$.nodes') j WHERE j.value->>'$.id'=a.node_id AND j.value->>'$.type'='employee')))
+  OR EXISTS (SELECT 1 FROM workflow_approvals a WHERE a.run_id=r.id AND (a.status NOT IN ('pending','approved','rejected')
+    OR (a.status='pending' AND (a.decided_at IS NOT NULL OR a.decided_by IS NOT NULL OR a.decision IS NOT NULL OR a.reason IS NOT NULL))
+    OR (a.status<>'pending' AND (a.decided_at IS NULL OR a.decided_by IS NULL OR a.decision<>CASE a.status WHEN 'approved' THEN 'approve' ELSE 'reject' END))
+    OR NOT EXISTS (SELECT 1 FROM json_each(r.definition_json,'$.nodes') j WHERE j.value->>'$.id'=a.node_id AND j.value->>'$.type'='approval')))
+) LIMIT 1`;
+
+export function assertHistoryIntegrity(db: WorkflowSqliteConnection, workflowId: string): void {
+  let corrupt = false;
+  try { corrupt = [RUN_INTEGRITY, CHILD_INTEGRITY].some((sql) => db.prepare(sql).get(workflowId) !== undefined); } catch { corrupt = true; }
+  if (corrupt) repositoryError('corrupt-record', `Workflow ${workflowId} run history is invalid.`);
+}

--- a/packages/jimmy/src/workflows/repository-migrations.ts
+++ b/packages/jimmy/src/workflows/repository-migrations.ts
@@ -1,0 +1,300 @@
+import { closeSync, constants, fchmodSync, fstatSync, lstatSync, mkdirSync, openSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import Database from 'better-sqlite3';
+import { WORKFLOWS_DB_PATH } from '../shared/paths.js';
+
+export const WORKFLOW_DB_SCHEMA_VERSION = 4;
+export const WORKFLOW_DB_PHYSICAL_SCHEMA_VERSIONS = [1, 2, 3, 4] as const;
+export const WORKFLOW_DB_MIGRATION_SOURCE_VERSIONS = [0, 1, 2, 3] as const;
+
+const UNSUPPORTED_SCHEMA_ERROR = 'Unsupported workflow database schema version.';
+const MALFORMED_SCHEMA_ERROR = 'Malformed workflow database schema version.';
+const SYMLINK_ERROR = 'Workflow database default store must not contain symbolic links.';
+const NO_FOLLOW_ERROR = 'Workflow database no-follow protection is unavailable.';
+
+const CREATE_SCHEMA_TABLE_SQL = `
+CREATE TABLE workflow_schema (
+  version INTEGER NOT NULL
+);
+`;
+
+const CREATE_DOMAIN_SCHEMA_V1_SQL = `
+CREATE TABLE workflow_definitions (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 0,
+  retired_at TEXT,
+  definition_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE workflow_runs (
+  id TEXT PRIMARY KEY,
+  workflow_id TEXT NOT NULL REFERENCES workflow_definitions(id),
+  workflow_title TEXT NOT NULL,
+  definition_revision INTEGER NOT NULL,
+  definition_json TEXT NOT NULL,
+  input_json TEXT NOT NULL,
+  trigger_json TEXT NOT NULL,
+  status TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  idempotency_key TEXT,
+  invocation_session_id TEXT,
+  cancel_requested_at TEXT,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  error_json TEXT,
+  UNIQUE(workflow_id, idempotency_key)
+);
+
+CREATE TABLE workflow_node_runs (
+  run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+  node_id TEXT NOT NULL,
+  node_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  activated INTEGER NOT NULL DEFAULT 0,
+  resolved_config_json TEXT,
+  input_json TEXT,
+  output_json TEXT,
+  error_json TEXT,
+  resume_at TEXT,
+  started_at TEXT,
+  ended_at TEXT,
+  PRIMARY KEY(run_id, node_id)
+);
+
+CREATE TABLE workflow_attempts (
+  run_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  attempt INTEGER NOT NULL,
+  session_id TEXT,
+  status TEXT NOT NULL,
+  resolved_config_json TEXT NOT NULL,
+  input_json TEXT NOT NULL,
+  output_json TEXT,
+  error_json TEXT,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  PRIMARY KEY(run_id, node_id, attempt),
+  FOREIGN KEY(run_id, node_id) REFERENCES workflow_node_runs(run_id, node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE workflow_approvals (
+  run_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  requested_at TEXT NOT NULL,
+  approver_ref TEXT,
+  decided_at TEXT,
+  decided_by TEXT,
+  decision TEXT,
+  reason TEXT,
+  PRIMARY KEY(run_id, node_id),
+  FOREIGN KEY(run_id, node_id) REFERENCES workflow_node_runs(run_id, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX workflow_runs_by_workflow_started ON workflow_runs(workflow_id, started_at DESC, id DESC);
+CREATE INDEX workflow_runs_by_status_started ON workflow_runs(status, started_at DESC, id DESC);
+CREATE INDEX workflow_attempts_by_session ON workflow_attempts(session_id);
+CREATE INDEX workflow_approvals_pending ON workflow_approvals(status, requested_at);
+CREATE INDEX workflow_node_runs_due ON workflow_node_runs(status, resume_at);
+`;
+
+const MIGRATE_V1_TO_V2_SQL = `
+ALTER TABLE workflow_attempts ADD COLUMN retry_idempotency_key TEXT;
+CREATE UNIQUE INDEX workflow_attempts_retry_key
+  ON workflow_attempts(run_id, retry_idempotency_key)
+  WHERE retry_idempotency_key IS NOT NULL;
+`;
+
+const MIGRATE_V2_TO_V3_SQL = `
+ALTER TABLE workflow_attempts ADD COLUMN reminders_sent INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workflow_attempts ADD COLUMN next_reminder_at TEXT;
+ALTER TABLE workflow_attempts ADD COLUMN extensions INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workflow_attempts ADD COLUMN last_extension_reason TEXT;
+ALTER TABLE workflow_attempts ADD COLUMN pending_output_error TEXT;
+ALTER TABLE workflow_attempts ADD COLUMN last_processed_turn INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workflow_attempts ADD COLUMN prompt_text TEXT;
+CREATE INDEX workflow_attempts_due_reminder ON workflow_attempts(status, next_reminder_at);
+`;
+
+const CREATE_DOMAIN_SCHEMA_V2_SQL = CREATE_DOMAIN_SCHEMA_V1_SQL
+  .replace('  ended_at TEXT,\n  PRIMARY KEY(run_id, node_id, attempt),',
+    '  ended_at TEXT,\n  retry_idempotency_key TEXT,\n  PRIMARY KEY(run_id, node_id, attempt),')
+  .replace('CREATE INDEX workflow_attempts_by_session ON workflow_attempts(session_id);',
+    `CREATE INDEX workflow_attempts_by_session ON workflow_attempts(session_id);
+CREATE UNIQUE INDEX workflow_attempts_retry_key
+  ON workflow_attempts(run_id, retry_idempotency_key)
+  WHERE retry_idempotency_key IS NOT NULL;`);
+
+const CREATE_DOMAIN_SCHEMA_V3_SQL = CREATE_DOMAIN_SCHEMA_V2_SQL
+  .replace('  retry_idempotency_key TEXT,\n  PRIMARY KEY(run_id, node_id, attempt),',
+    `  retry_idempotency_key TEXT,
+  reminders_sent INTEGER NOT NULL DEFAULT 0,
+  next_reminder_at TEXT,
+  extensions INTEGER NOT NULL DEFAULT 0,
+  last_extension_reason TEXT,
+  pending_output_error TEXT,
+  last_processed_turn INTEGER NOT NULL DEFAULT 0,
+  prompt_text TEXT,
+  PRIMARY KEY(run_id, node_id, attempt),`)
+  .replace('CREATE INDEX workflow_approvals_pending ON workflow_approvals(status, requested_at);',
+    `CREATE INDEX workflow_approvals_pending ON workflow_approvals(status, requested_at);
+CREATE INDEX workflow_attempts_due_reminder ON workflow_attempts(status, next_reminder_at);`);
+
+const MIGRATE_V3_TO_V4_SQL = 'ALTER TABLE workflow_attempts ADD COLUMN stop_nudges_sent INTEGER NOT NULL DEFAULT 0;';
+const CREATE_DOMAIN_SCHEMA_V4_SQL = CREATE_DOMAIN_SCHEMA_V3_SQL.replace('  prompt_text TEXT,', '  prompt_text TEXT,\n  stop_nudges_sent INTEGER NOT NULL DEFAULT 0,');
+
+function normalizeSql(sql: string): string {
+  return sql.toLowerCase().replace(/\s+/g, ' ').replace(/\s*([(),])\s*/g, '$1').trim().replace(/;$/, '');
+}
+
+function schemaStatements(sql: string): string[] {
+  return sql.split(/;\s*(?:\n|$)/).map(normalizeSql).filter(Boolean).sort();
+}
+
+const SCHEMA_TABLE_SQL = normalizeSql(CREATE_SCHEMA_TABLE_SQL);
+const VERSION_ZERO_SCHEMA = [SCHEMA_TABLE_SQL];
+const SCHEMA_V1 = schemaStatements(CREATE_SCHEMA_TABLE_SQL + CREATE_DOMAIN_SCHEMA_V1_SQL);
+const SCHEMA_V2 = schemaStatements(CREATE_SCHEMA_TABLE_SQL + CREATE_DOMAIN_SCHEMA_V2_SQL);
+const SCHEMA_V3 = schemaStatements(CREATE_SCHEMA_TABLE_SQL + CREATE_DOMAIN_SCHEMA_V3_SQL);
+const SCHEMA_V4 = schemaStatements(CREATE_SCHEMA_TABLE_SQL + CREATE_DOMAIN_SCHEMA_V4_SQL);
+
+interface SchemaState {
+  exists: boolean;
+  version: number;
+}
+
+function assertSchema(db: Database.Database, expected: string[]): void {
+  const actual = (db.prepare(
+    'SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY type, name',
+  ).pluck().all() as string[]).map(normalizeSql).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error(MALFORMED_SCHEMA_ERROR);
+}
+
+function readSchemaState(db: Database.Database): SchemaState {
+  const schemaSql = db.prepare(
+    "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'workflow_schema' COLLATE NOCASE",
+  ).pluck().get();
+  if (schemaSql === undefined) {
+    assertSchema(db, []);
+    return { exists: false, version: 0 };
+  }
+  if (typeof schemaSql !== 'string' || normalizeSql(schemaSql) !== SCHEMA_TABLE_SQL) {
+    throw new Error(MALFORMED_SCHEMA_ERROR);
+  }
+
+  const rows = db.prepare('SELECT version FROM workflow_schema').pluck().all();
+  const version = rows[0];
+  if (rows.length !== 1 || typeof version !== 'number' || !Number.isInteger(version) || version < 0) {
+    throw new Error(MALFORMED_SCHEMA_ERROR);
+  }
+  if (version > WORKFLOW_DB_SCHEMA_VERSION) throw new Error(UNSUPPORTED_SCHEMA_ERROR);
+  const expected = [VERSION_ZERO_SCHEMA, SCHEMA_V1, SCHEMA_V2, SCHEMA_V3, SCHEMA_V4][version];
+  if (!expected) throw new Error(UNSUPPORTED_SCHEMA_ERROR);
+  assertSchema(db, expected);
+  return { exists: true, version };
+}
+
+function existingNonSymlink(path: string): boolean {
+  try {
+    if (lstatSync(path).isSymbolicLink()) throw new Error(SYMLINK_ERROR);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function enforceModeNoFollow(path: string, flags: number, mode: number, error: string): void {
+  if (typeof constants.O_NOFOLLOW !== 'number') throw new Error(NO_FOLLOW_ERROR);
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(path, flags | constants.O_NOFOLLOW, mode);
+    fchmodSync(descriptor, mode);
+    if ((fstatSync(descriptor).mode & 0o777) !== mode) throw new Error(error);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ELOOP') throw new Error(SYMLINK_ERROR);
+    throw cause;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function prepareDefaultStore(databasePath: string): void {
+  const parent = dirname(databasePath);
+  const files = [databasePath, `${databasePath}-wal`, `${databasePath}-shm`];
+  existingNonSymlink(parent);
+  for (const path of files) existingNonSymlink(path);
+  mkdirSync(parent, { recursive: true, mode: 0o700 });
+  enforceModeNoFollow(parent, constants.O_RDONLY, 0o700, 'Workflow database directory must have mode 0700.');
+  enforceModeNoFollow(databasePath, constants.O_RDWR | constants.O_CREAT, 0o600,
+    'Workflow database files must have mode 0600.');
+}
+
+function enforceDefaultStorePermissions(databasePath: string): void {
+  const parent = dirname(databasePath);
+  enforceModeNoFollow(parent, constants.O_RDONLY, 0o700, 'Workflow database directory must have mode 0700.');
+  for (const path of [databasePath, `${databasePath}-wal`, `${databasePath}-shm`]) {
+    if (existingNonSymlink(path)) {
+      enforceModeNoFollow(path, constants.O_RDWR, 0o600, 'Workflow database files must have mode 0600.');
+    }
+  }
+}
+
+function ensureDatabaseDirectory(databasePath: string, defaultStore: boolean): void {
+  if (defaultStore && process.platform !== 'win32') prepareDefaultStore(databasePath);
+  else mkdirSync(dirname(databasePath), { recursive: true });
+}
+
+export function migrateWorkflowDatabase(db: Database.Database): void {
+  const migrate = db.transaction(() => {
+    let state = readSchemaState(db);
+    if (state.version === WORKFLOW_DB_SCHEMA_VERSION) return;
+    if (state.version === 0) {
+      if (!state.exists) db.exec(CREATE_SCHEMA_TABLE_SQL);
+      db.exec(CREATE_DOMAIN_SCHEMA_V1_SQL);
+      db.prepare('DELETE FROM workflow_schema').run();
+      db.prepare('INSERT INTO workflow_schema (version) VALUES (1)').run();
+      state = readSchemaState(db);
+    }
+    if (state.version === 1) {
+      db.exec(MIGRATE_V1_TO_V2_SQL);
+      db.prepare('UPDATE workflow_schema SET version = 2').run();
+      state = readSchemaState(db);
+    }
+    if (state.version === 2) {
+      db.exec(MIGRATE_V2_TO_V3_SQL);
+      db.prepare('UPDATE workflow_schema SET version = 3').run();
+      state = readSchemaState(db);
+    }
+    if (state.version === 3) {
+      db.exec(MIGRATE_V3_TO_V4_SQL);
+      db.prepare('UPDATE workflow_schema SET version = 4').run();
+      state = readSchemaState(db);
+    }
+    if (state.version !== WORKFLOW_DB_SCHEMA_VERSION) throw new Error(UNSUPPORTED_SCHEMA_ERROR);
+  });
+  migrate.immediate();
+}
+
+export function openWorkflowDatabase(databasePath = WORKFLOWS_DB_PATH): Database.Database {
+  const resolvedPath = resolve(databasePath);
+  const defaultStore = resolvedPath === resolve(WORKFLOWS_DB_PATH);
+  ensureDatabaseDirectory(resolvedPath, defaultStore);
+  const db = new Database(resolvedPath);
+  try {
+    db.pragma('busy_timeout = 5000');
+    db.pragma('foreign_keys = ON');
+    migrateWorkflowDatabase(db);
+    db.pragma('journal_mode = WAL');
+    db.prepare('SELECT version FROM workflow_schema LIMIT 1').get();
+    if (defaultStore && process.platform !== 'win32') enforceDefaultStorePermissions(resolvedPath);
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}

--- a/packages/jimmy/src/workflows/repository-mutex.ts
+++ b/packages/jimmy/src/workflows/repository-mutex.ts
@@ -1,0 +1,41 @@
+/** Reading who holds a node mutex, straight off each run's own definition snapshot.
+ *
+ *  There is no lock table on purpose: a key is held for exactly as long as a node run
+ *  carrying it is live, so a holder that crashed cannot leave a stale lock behind —
+ *  the thing that represents the lock is the thing that died. What the runner does
+ *  with the answer lives in node-mutex.ts; this file only reads.
+ *
+ *  Nothing here may reach the logger. The repository is imported before a test or a
+ *  CLI has set `JINN_HOME`, and `logger.ts` resolves its log directory from it once,
+ *  at import: pulling it into this graph would freeze the wrong home. */
+
+import { z } from 'zod';
+import { repositoryError } from './repository-support.js';
+import { WORKFLOW_NODE_RUN_STATUSES } from './runtime.js';
+
+type WorkflowSqliteConnection = ConstructorParameters<typeof import('./repository.js').WorkflowRepository>[0];
+
+const mutexNodeRunSchema = z.strictObject({
+  workflowId: z.string(), runId: z.string(), nodeId: z.string(), mutexKey: z.string(),
+  status: z.enum(WORKFLOW_NODE_RUN_STATUSES),
+});
+/** An employee node run of a live run that authors a mutex key. `pending` is a node
+ *  standing off the key; every other status here is a node live enough to hold it. */
+export type WorkflowMutexNodeRun = z.infer<typeof mutexNodeRunSchema>;
+
+export function readMutexNodeRuns(db: WorkflowSqliteConnection): WorkflowMutexNodeRun[] {
+  const rows = db.prepare(`SELECT r.workflow_id AS workflowId, n.run_id AS runId, n.node_id AS nodeId,
+      n.status AS status, j.value->>'$.config.mutex' AS mutexKey
+    FROM workflow_node_runs n
+      JOIN workflow_runs r ON r.id = n.run_id
+      JOIN json_each(r.definition_json, '$.nodes') j ON j.value->>'$.id' = n.node_id
+    WHERE n.node_type = 'employee' AND n.activated = 1
+      AND n.status IN ('pending', 'dispatching', 'running', 'waiting')
+      AND r.status IN ('pending', 'running', 'waiting')
+      AND j.value->>'$.config.mutex' IS NOT NULL
+    ORDER BY n.run_id, n.node_id`).all() as unknown[];
+  return rows.map((row) => {
+    const result = mutexNodeRunSchema.safeParse(row);
+    return result.success ? result.data : repositoryError('corrupt-record', 'Workflow mutex node run is invalid.');
+  });
+}

--- a/packages/jimmy/src/workflows/repository-run-transaction.ts
+++ b/packages/jimmy/src/workflows/repository-run-transaction.ts
@@ -1,0 +1,276 @@
+import type { JsonValue } from './model.js';
+import type { WorkflowRunTransaction } from './repository.js';
+import {
+  decodeApproval,
+  jsonColumn,
+  readAttempt,
+  readNode,
+  readRun,
+  validateMutationValue,
+} from './repository-runs.js';
+import {
+  assertExactKeys,
+  canonicalJson,
+  canonicalStamp,
+  parseJsonRecord,
+  parseNodeId,
+  repositoryError,
+} from './repository-support.js';
+import {
+  WORKFLOW_NODE_RUN_STATUSES,
+  WORKFLOW_RUN_STATUSES,
+  type WorkflowApprovalRecord,
+  type WorkflowAttemptRecord,
+  type WorkflowNodeRunRecord,
+  type WorkflowRunRecord,
+} from './runtime.js';
+
+type WorkflowSqliteConnection = ConstructorParameters<typeof import('./repository.js').WorkflowRepository>[0];
+
+function normalizedRecord(value: unknown, allowed: readonly string[], message: string): Record<string, JsonValue> {
+  const record = parseJsonRecord(value, message);
+  assertExactKeys(record, allowed, message);
+  return record;
+}
+
+function recordChanged(before: object, after: object): boolean {
+  return canonicalJson(before as JsonValue) !== canonicalJson(after as JsonValue);
+}
+
+function requireStatus<T extends string>(value: unknown, values: readonly T[], message: string): T {
+  if (typeof value !== 'string' || !values.includes(value as T)) repositoryError('bad-input', message);
+  return value as T;
+}
+
+function optionalInstant(record: Record<string, JsonValue>, key: string): void {
+  if (Object.hasOwn(record, key)) canonicalStamp(record[key]);
+}
+
+export class RunMutation implements WorkflowRunTransaction {
+  private didChange = false;
+  private closed = false;
+
+  constructor(
+    private readonly db: WorkflowSqliteConnection,
+    private readonly runId: string,
+    private readonly stamp: string,
+  ) {}
+
+  get changed(): boolean {
+    return this.didChange;
+  }
+  close(): void { this.closed = true; }
+  private assertOpen(): void {
+    if (this.closed) repositoryError('bad-input', 'Workflow run mutation is closed.');
+  }
+
+  setRunStatus(status: WorkflowRunRecord['status'], patch: Parameters<WorkflowRunTransaction['setRunStatus']>[1] = {}): WorkflowRunRecord {
+    this.assertOpen();
+    const nextStatus = requireStatus(status, WORKFLOW_RUN_STATUSES, 'Workflow run status is invalid.');
+    const values = normalizedRecord(patch, ['cancelRequestedAt', 'endedAt', 'error'], 'Workflow run patch is invalid.');
+    optionalInstant(values, 'cancelRequestedAt');
+    optionalInstant(values, 'endedAt');
+    if (values.error !== undefined) validateMutationValue('error', values.error);
+    const current = readRun(this.db, this.runId);
+    if (!current) repositoryError('not-found', `Workflow run ${this.runId} was not found.`);
+    const next = { ...current, status: nextStatus, ...values } as WorkflowRunRecord;
+    if (!recordChanged(current, next)) return current;
+    this.db.prepare(`UPDATE workflow_runs SET status = @status, cancel_requested_at = @cancel,
+      ended_at = @ended, error_json = @error WHERE id = @id`).run({
+      id: this.runId, status: next.status, cancel: next.cancelRequestedAt ?? null,
+      ended: next.endedAt ?? null, error: jsonColumn(next.error),
+    });
+    this.didChange = true;
+    return readRun(this.db, this.runId)!;
+  }
+
+  setNodeStatus(
+    nodeId: string,
+    status: WorkflowNodeRunRecord['status'],
+    patch: Parameters<WorkflowRunTransaction['setNodeStatus']>[2] = {},
+  ): WorkflowNodeRunRecord {
+    this.assertOpen();
+    const id = parseNodeId(nodeId);
+    const nextStatus = requireStatus(status, WORKFLOW_NODE_RUN_STATUSES, 'Workflow node status is invalid.');
+    const keys = ['activated', 'resolvedConfig', 'input', 'output', 'error', 'resumeAt', 'startedAt', 'endedAt'];
+    const values = normalizedRecord(patch, keys, 'Workflow node patch is invalid.');
+    for (const key of ['resumeAt', 'startedAt', 'endedAt']) optionalInstant(values, key);
+    if (Object.hasOwn(values, 'activated') && typeof values.activated !== 'boolean') {
+      repositoryError('bad-input', 'Workflow node patch is invalid.');
+    }
+    if (values.resolvedConfig !== undefined) parseJsonRecord(values.resolvedConfig, 'Workflow node config is invalid.');
+    if (values.output !== undefined) validateMutationValue('output', values.output);
+    if (values.error !== undefined) validateMutationValue('error', values.error);
+    const current = readNode(this.db, this.runId, id);
+    if (!current) repositoryError('not-found', `Workflow node ${id} was not found.`);
+    const next = { ...current, status: nextStatus, ...values } as WorkflowNodeRunRecord;
+    if (!recordChanged(current, next)) return current;
+    this.db.prepare(`UPDATE workflow_node_runs SET status = @status, activated = @activated,
+      resolved_config_json = @config, input_json = @input, output_json = @output, error_json = @error,
+      resume_at = @resume, started_at = @started, ended_at = @ended WHERE run_id = @runId AND node_id = @nodeId`).run({
+      runId: this.runId, nodeId: id, status: next.status, activated: next.activated ? 1 : 0,
+      config: jsonColumn(next.resolvedConfig), input: jsonColumn(next.input), output: jsonColumn(next.output),
+      error: jsonColumn(next.error), resume: next.resumeAt ?? null, started: next.startedAt ?? null, ended: next.endedAt ?? null,
+    });
+    this.didChange = true;
+    return readNode(this.db, this.runId, id)!;
+  }
+
+  createAttempt(input: Parameters<WorkflowRunTransaction['createAttempt']>[0]): WorkflowAttemptRecord {
+    this.assertOpen();
+    const value = normalizedRecord(input, ['nodeId', 'resolvedConfig', 'input', 'promptText', 'retryIdempotencyKey'], 'Workflow attempt input is invalid.');
+    const nodeId = parseNodeId(value.nodeId);
+    const retryKey = value.retryIdempotencyKey;
+    if (retryKey !== undefined && (typeof retryKey !== 'string' || retryKey.length < 1 || retryKey.length > 128)) {
+      repositoryError('bad-input', 'Workflow retry idempotency key is invalid.');
+    }
+    const promptText = value.promptText;
+    if (promptText !== undefined && (typeof promptText !== 'string' || promptText.length < 1)) {
+      repositoryError('bad-input', 'Workflow attempt prompt is invalid.');
+    }
+    validateMutationValue('resolved', value.resolvedConfig);
+    const node = readNode(this.db, this.runId, nodeId);
+    if (!node) repositoryError('not-found', `Workflow node ${nodeId} was not found.`);
+    if (node.nodeType !== 'employee') repositoryError('bad-input', `Workflow node ${nodeId} cannot own attempts.`);
+    const attempt = (this.db.prepare(`SELECT COALESCE(MAX(attempt), 0) + 1 FROM workflow_attempts
+      WHERE run_id = ? AND node_id = ?`).pluck().get(this.runId, nodeId) as number);
+    this.db.prepare(`INSERT INTO workflow_attempts
+      (run_id, node_id, attempt, status, resolved_config_json, input_json, prompt_text, started_at, retry_idempotency_key)
+      VALUES (?, ?, ?, 'dispatching', ?, ?, ?, ?, ?)`).run(
+      this.runId, nodeId, attempt, canonicalJson(value.resolvedConfig!), canonicalJson(value.input!),
+      promptText ?? null, this.stamp, retryKey,
+    );
+    this.didChange = true;
+    return readAttempt(this.db, this.runId, nodeId, attempt)!;
+  }
+  settleAttempt(
+    nodeId: string,
+    attempt: number,
+    patch: Parameters<WorkflowRunTransaction['settleAttempt']>[2],
+  ): WorkflowAttemptRecord {
+    this.assertOpen();
+    const id = parseNodeId(nodeId);
+    if (!Number.isInteger(attempt) || attempt < 1) repositoryError('bad-input', 'Workflow attempt number is invalid.');
+    const value = normalizedRecord(patch, ['status', 'sessionId', 'output', 'error', 'endedAt'], 'Workflow attempt patch is invalid.');
+    const status = requireStatus(value.status, ['running', 'completed', 'failed', 'timed-out', 'cancelled'], 'Workflow attempt status is invalid.');
+    const expected = status === 'running' ? ['sessionId', 'status']
+      : status === 'completed' ? ['endedAt', 'output', 'sessionId', 'status']
+        : ['endedAt', 'error', 'sessionId', 'status'];
+    const required = status === 'running' ? ['sessionId'] : status === 'completed' ? ['endedAt', 'output'] : ['endedAt', 'error'];
+    if (Object.keys(value).some((key) => !expected.includes(key)) || required.some((key) => !Object.hasOwn(value, key))
+      || (value.sessionId !== undefined && (typeof value.sessionId !== 'string' || value.sessionId.length < 1 || value.sessionId.length > 256))) {
+      repositoryError('bad-input', 'Workflow attempt patch is invalid.');
+    }
+    if (status !== 'running') optionalInstant(value, 'endedAt');
+    if (value.output !== undefined) validateMutationValue('output', value.output);
+    if (value.error !== undefined) validateMutationValue('error', value.error);
+    const current = readAttempt(this.db, this.runId, id, attempt);
+    if (!current) repositoryError('not-found', `Workflow attempt ${id}:${attempt} was not found.`);
+    const next = { ...current, ...value } as WorkflowAttemptRecord;
+    if (!recordChanged(current, next)) return current;
+    if (current.sessionId && value.sessionId !== undefined && value.sessionId !== current.sessionId) {
+      repositoryError('bad-input', 'Workflow attempt session does not match its owner.');
+    }
+    if (value.sessionId !== undefined && this.db.prepare(`SELECT 1 FROM workflow_attempts WHERE session_id=?
+      AND NOT (run_id=? AND node_id=? AND attempt=?) LIMIT 1`).get(value.sessionId, this.runId, id, attempt)) {
+      repositoryError('bad-input', 'Workflow attempt session is already owned.');
+    }
+    const legal = status === 'running' ? current.status === 'dispatching'
+      : current.status === 'running' || (current.status === 'dispatching' && status !== 'completed' && value.sessionId === undefined);
+    if (!legal) repositoryError('bad-input', 'Workflow attempt transition is invalid.');
+    this.db.prepare(`UPDATE workflow_attempts SET session_id = @sessionId, status = @status,
+      output_json = @output, error_json = @error, ended_at = @ended
+      WHERE run_id = @runId AND node_id = @nodeId AND attempt = @attempt`).run({
+      runId: this.runId, nodeId: id, attempt, sessionId: next.sessionId ?? null, status: next.status,
+      output: jsonColumn(next.output), error: jsonColumn(next.error), ended: next.endedAt ?? null,
+    });
+    this.didChange = true;
+    return readAttempt(this.db, this.runId, id, attempt)!;
+  }
+  setAttemptReminder(
+    nodeId: string,
+    attempt: number,
+    patch: Parameters<WorkflowRunTransaction['setAttemptReminder']>[2],
+  ): WorkflowAttemptRecord {
+    this.assertOpen();
+    const id = parseNodeId(nodeId);
+    if (!Number.isInteger(attempt) || attempt < 1) repositoryError('bad-input', 'Workflow attempt number is invalid.');
+    const keys = ['remindersSent', 'stopNudgesSent', 'nextReminderAt', 'extensions', 'lastExtensionReason', 'pendingOutputError', 'lastProcessedTurn'];
+    const values = normalizedRecord(patch, keys, 'Workflow attempt reminder patch is invalid.');
+    for (const key of ['remindersSent', 'stopNudgesSent', 'extensions', 'lastProcessedTurn'] as const) {
+      if (values[key] !== undefined && (!Number.isInteger(values[key]) || (values[key] as number) < 0)) {
+        repositoryError('bad-input', 'Workflow attempt reminder patch is invalid.');
+      }
+    }
+    if (values.nextReminderAt !== undefined && values.nextReminderAt !== null) canonicalStamp(values.nextReminderAt);
+    for (const key of ['lastExtensionReason', 'pendingOutputError'] as const) {
+      if (values[key] !== undefined && values[key] !== null && typeof values[key] !== 'string') {
+        repositoryError('bad-input', 'Workflow attempt reminder patch is invalid.');
+      }
+    }
+    const current = readAttempt(this.db, this.runId, id, attempt);
+    if (!current) repositoryError('not-found', `Workflow attempt ${id}:${attempt} was not found.`);
+    if (current.status !== 'running') repositoryError('bad-input', 'Workflow attempt reminder state requires a running attempt.');
+    const next = { ...current } as WorkflowAttemptRecord;
+    if (values.remindersSent !== undefined) next.remindersSent = values.remindersSent as number;
+    if (values.stopNudgesSent !== undefined) next.stopNudgesSent = values.stopNudgesSent as number;
+    if (Object.hasOwn(values, 'nextReminderAt')) {
+      if (values.nextReminderAt === null) delete next.nextReminderAt;
+      else next.nextReminderAt = values.nextReminderAt as string;
+    }
+    if (values.extensions !== undefined) next.extensions = values.extensions as number;
+    if (Object.hasOwn(values, 'lastExtensionReason')) {
+      if (values.lastExtensionReason === null) delete next.lastExtensionReason;
+      else next.lastExtensionReason = values.lastExtensionReason as string;
+    }
+    if (Object.hasOwn(values, 'pendingOutputError')) {
+      if (values.pendingOutputError === null) delete next.pendingOutputError;
+      else next.pendingOutputError = values.pendingOutputError as string;
+    }
+    if (values.lastProcessedTurn !== undefined) next.lastProcessedTurn = values.lastProcessedTurn as number;
+    if (!recordChanged(current, next)) return current;
+    this.db.prepare(`UPDATE workflow_attempts SET reminders_sent = @remindersSent,
+      stop_nudges_sent = @stopNudgesSent,
+      next_reminder_at = @nextReminderAt, extensions = @extensions,
+      last_extension_reason = @lastExtensionReason, pending_output_error = @pendingOutputError,
+      last_processed_turn = @lastProcessedTurn
+      WHERE run_id = @runId AND node_id = @nodeId AND attempt = @attempt`).run({
+      runId: this.runId,
+      nodeId: id,
+      attempt,
+      remindersSent: next.remindersSent,
+      stopNudgesSent: next.stopNudgesSent,
+      nextReminderAt: next.nextReminderAt ?? null,
+      extensions: next.extensions,
+      lastExtensionReason: next.lastExtensionReason ?? null,
+      pendingOutputError: next.pendingOutputError ?? null,
+      lastProcessedTurn: next.lastProcessedTurn,
+    });
+    this.didChange = true;
+    return readAttempt(this.db, this.runId, id, attempt)!;
+  }
+  putApproval(input: Omit<WorkflowApprovalRecord, 'runId'>): WorkflowApprovalRecord {
+    this.assertOpen();
+    const keys = ['nodeId', 'status', 'requestedAt', 'approverRef', 'decidedAt', 'decidedBy', 'decision', 'reason'];
+    const value = normalizedRecord(input, keys, 'Workflow approval input is invalid.');
+    const nodeId = parseNodeId(value.nodeId);
+    const candidate = { runId: this.runId, nodeId, ...value } as WorkflowApprovalRecord;
+    validateMutationValue('approval', candidate);
+    if (!readNode(this.db, this.runId, nodeId)) repositoryError('not-found', `Workflow node ${nodeId} was not found.`);
+    const row = this.db.prepare('SELECT * FROM workflow_approvals WHERE run_id = ? AND node_id = ?')
+      .get(this.runId, nodeId) as Parameters<typeof decodeApproval>[0] | undefined;
+    const current = row ? decodeApproval(row) : null;
+    if (current && !recordChanged(current, candidate)) return current;
+    this.db.prepare(`INSERT INTO workflow_approvals
+      (run_id, node_id, status, requested_at, approver_ref, decided_at, decided_by, decision, reason)
+      VALUES (@runId, @nodeId, @status, @requestedAt, @approverRef, @decidedAt, @decidedBy, @decision, @reason)
+      ON CONFLICT(run_id, node_id) DO UPDATE SET status=excluded.status, requested_at=excluded.requested_at,
+      approver_ref=excluded.approver_ref, decided_at=excluded.decided_at, decided_by=excluded.decided_by,
+      decision=excluded.decision, reason=excluded.reason`).run({
+      ...candidate, approverRef: candidate.approverRef ?? null, decidedAt: candidate.decidedAt ?? null,
+      decidedBy: candidate.decidedBy ?? null, decision: candidate.decision ?? null, reason: candidate.reason ?? null,
+    });
+    this.didChange = true;
+    return candidate;
+  }
+}

--- a/packages/jimmy/src/workflows/repository-runs.ts
+++ b/packages/jimmy/src/workflows/repository-runs.ts
@@ -1,0 +1,431 @@
+import { z } from 'zod';
+import {
+  jsonValueSchema,
+  workflowDefinitionSchema,
+  type JsonValue,
+  type WorkflowNodeOutput,
+} from './model.js';
+import {
+  WORKFLOW_ATTEMPT_STATUSES, WORKFLOW_NODE_RUN_STATUSES, WORKFLOW_RUN_STATUSES,
+  type ResolvedEmployeeConfig, type WorkflowApprovalRecord, type WorkflowAttemptRecord, type WorkflowError,
+  type WorkflowChildRunSummary, type WorkflowNodeRunRecord, type WorkflowRunDetail, type WorkflowRunRecord,
+} from './runtime.js';
+import { assertHistoryIntegrity } from './repository-integrity.js';
+import { canonicalJson, isCanonicalInstant, isRunId, parseStoredJson, repositoryError } from './repository-support.js';
+import type { WorkflowRunSummary } from './repository.js';
+type WorkflowSqliteConnection = ConstructorParameters<typeof import('./repository.js').WorkflowRepository>[0];
+const instantSchema = z.string().refine(isCanonicalInstant);
+const errorSchema = z.strictObject({
+  code: z.string(), message: z.string(), retryable: z.boolean(), nodeId: z.string().optional(),
+  attempt: z.number().int().positive().optional(), details: z.record(z.string(), jsonValueSchema).optional(),
+});
+const outputSchema = z.strictObject({
+  text: z.string(), fields: z.record(z.string(), jsonValueSchema), employeeId: z.string().optional(),
+  engine: z.string().optional(), model: z.string().optional(), sessionId: z.string().optional(),
+  choice: z.string().optional(),
+});
+const resolvedSchema = z.strictObject({
+  employeeId: z.string(), engine: z.string(), model: z.string().optional(),
+  effort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
+  retry: z.strictObject({ attempts: z.number().int().min(1), delaySeconds: z.number().int().nonnegative(), backoff: z.enum(['fixed', 'exponential']) }),
+  timeoutMinutes: z.number().int().positive().optional(), continuedFrom: z.strictObject({ sessionId: z.string(), engineSessionId: z.string() }).optional(), substitutedFrom: z.strictObject({ engine: z.string(), reason: z.string() }).optional(),
+});
+const triggerSchema = z.strictObject({
+  nodeId: z.string(), kind: z.enum(['manual', 'schedule', 'event', 'todo-status', 'workflow-call']),
+  fireId: z.string().optional(), payload: z.record(z.string(), jsonValueSchema), todoId: z.string().optional(),
+});
+const nodeRecordSchema = z.strictObject({
+  runId: z.string(), nodeId: z.string(),
+  nodeType: z.enum(['trigger', 'employee', 'workflow-call', 'condition', 'merge', 'approval', 'wait', 'end']),
+  status: z.enum(WORKFLOW_NODE_RUN_STATUSES), activated: z.boolean(),
+  resolvedConfig: z.record(z.string(), jsonValueSchema).optional(), input: jsonValueSchema.optional(),
+  output: outputSchema.optional(), error: errorSchema.optional(), resumeAt: instantSchema.optional(),
+  startedAt: instantSchema.optional(), endedAt: instantSchema.optional(),
+});
+const attemptRecordSchema = z.strictObject({
+  runId: z.string(), nodeId: z.string(), attempt: z.number().int().positive(), sessionId: z.string().optional(),
+  status: z.enum(WORKFLOW_ATTEMPT_STATUSES), resolvedConfig: resolvedSchema, input: jsonValueSchema,
+  promptText: z.string().optional(),
+  output: outputSchema.optional(), error: errorSchema.optional(), startedAt: instantSchema, endedAt: instantSchema.optional(),
+  remindersSent: z.number().int().nonnegative(), stopNudgesSent: z.number().int().nonnegative(), nextReminderAt: instantSchema.optional(),
+  extensions: z.number().int().nonnegative(), lastExtensionReason: z.string().optional(),
+  pendingOutputError: z.string().optional(), lastProcessedTurn: z.number().int().nonnegative(),
+});
+const approvalRecordSchema = z.strictObject({
+  runId: z.string(), nodeId: z.string(), status: z.enum(['pending', 'approved', 'rejected']),
+  requestedAt: instantSchema, approverRef: z.string().optional(), decidedAt: instantSchema.optional(),
+  decidedBy: z.string().optional(), decision: z.enum(['approve', 'reject']).optional(), reason: z.string().optional(),
+}).superRefine((record, context) => {
+  if (record.status === 'pending' && (record.decidedAt || record.decidedBy || record.decision || record.reason)) {
+    context.addIssue({ code: 'custom', message: 'Pending approval has decision audit.' });
+  }
+  if (record.status !== 'pending' && (!record.decidedAt || !record.decidedBy
+    || record.decision !== (record.status === 'approved' ? 'approve' : 'reject'))) {
+    context.addIssue({ code: 'custom', message: 'Approval decision audit is incomplete.' });
+  }
+});
+const mutationSchemas = { error: errorSchema, output: outputSchema, resolved: resolvedSchema, approval: approvalRecordSchema } as const;
+export function validateMutationValue(kind: keyof typeof mutationSchemas, value: unknown): void {
+  if (!mutationSchemas[kind].safeParse(value).success) repositoryError('bad-input', `Workflow ${kind} input is invalid.`);
+}
+export interface RunRow {
+  id: unknown; workflow_id: unknown; workflow_title: unknown; definition_revision: unknown;
+  definition_json: unknown; input_json: unknown; trigger_json: unknown; status: unknown; revision: unknown;
+  idempotency_key: unknown; invocation_session_id: unknown; cancel_requested_at: unknown;
+  started_at: unknown; ended_at: unknown; error_json: unknown;
+}
+interface NodeRow {
+  run_id: unknown; node_id: unknown; node_type: unknown; status: unknown; activated: unknown;
+  resolved_config_json: unknown; input_json: unknown; output_json: unknown; error_json: unknown;
+  resume_at: unknown; started_at: unknown; ended_at: unknown;
+}
+export interface AttemptRow {
+  run_id: unknown; node_id: unknown; attempt: unknown; session_id: unknown; status: unknown;
+  resolved_config_json: unknown; input_json: unknown; output_json: unknown; error_json: unknown;
+  started_at: unknown; ended_at: unknown; reminders_sent: unknown; stop_nudges_sent: unknown; next_reminder_at: unknown;
+  extensions: unknown; last_extension_reason: unknown; pending_output_error: unknown; last_processed_turn: unknown;
+  prompt_text: unknown;
+}
+interface ApprovalRow {
+  run_id: unknown; node_id: unknown; status: unknown; requested_at: unknown; approver_ref: unknown;
+  decided_at: unknown; decided_by: unknown; decision: unknown; reason: unknown;
+}
+export interface NormalizedRunListQuery {
+  limit: number;
+  cursor?: { startedAt: string; id: string };
+  status?: string;
+  triggerKind?: string;
+  startedFrom?: string;
+  startedTo?: string;
+  text?: string;
+}
+function optionalJson(value: unknown, subject: string): JsonValue | undefined {
+  return value === null ? undefined : parseStoredJson(value, subject);
+}
+function optionalString(value: unknown): string | undefined {
+  return value === null ? undefined : typeof value === 'string' ? value : repositoryError('corrupt-record', 'Workflow record is invalid.');
+}
+function parsed<T>(schema: z.ZodType<T>, value: unknown, subject: string): T {
+  const result = schema.safeParse(value);
+  if (!result.success) repositoryError('corrupt-record', `${subject} is invalid.`);
+  return result.data;
+}
+export function decodeRun(row: RunRow): WorkflowRunRecord {
+  const definition = parsed(workflowDefinitionSchema, parseStoredJson(row.definition_json, 'Workflow run definition'), 'Workflow run definition');
+  const input = parsed(z.record(z.string(), jsonValueSchema), parseStoredJson(row.input_json, 'Workflow run input'), 'Workflow run input');
+  const trigger = parsed(triggerSchema, parseStoredJson(row.trigger_json, 'Workflow run trigger'), 'Workflow run trigger');
+  const run = {
+    id: row.id, workflowId: row.workflow_id, workflowTitle: row.workflow_title,
+    definitionRevision: row.definition_revision, definition, input, trigger, status: row.status, revision: row.revision,
+    ...(row.idempotency_key === null ? {} : { idempotencyKey: row.idempotency_key }),
+    ...(row.invocation_session_id === null ? {} : { invocationSessionId: row.invocation_session_id }),
+    ...(row.cancel_requested_at === null ? {} : { cancelRequestedAt: row.cancel_requested_at }),
+    startedAt: row.started_at, ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
+    ...(row.error_json === null ? {} : { error: optionalJson(row.error_json, 'Workflow run error') }),
+  };
+  const runSchema = z.strictObject({
+    id: z.string().refine(isRunId), workflowId: z.string(), workflowTitle: z.string(),
+    definitionRevision: z.number().int().positive(), definition: workflowDefinitionSchema,
+    input: z.record(z.string(), jsonValueSchema), trigger: triggerSchema, status: z.enum(WORKFLOW_RUN_STATUSES),
+    revision: z.number().int().positive(), idempotencyKey: z.string().optional(), invocationSessionId: z.string().optional(),
+    cancelRequestedAt: instantSchema.optional(), startedAt: instantSchema, endedAt: instantSchema.optional(), error: errorSchema.optional(),
+  });
+  const decoded = parsed(runSchema, run, `Workflow run ${String(row.id)}`);
+  if (decoded.workflowId !== definition.id || decoded.workflowTitle !== definition.title
+    || decoded.definitionRevision !== definition.revision) {
+    repositoryError('corrupt-record', `Workflow run ${decoded.id} metadata does not match its definition.`);
+  }
+  const triggerNode = definition.nodes.find((node) => node.id === decoded.trigger.nodeId);
+  if (!triggerNode || triggerNode.type !== 'trigger' || triggerNode.config.kind !== decoded.trigger.kind) {
+    repositoryError('corrupt-record', `Workflow run ${decoded.id} has an invalid trigger.`);
+  }
+  return decoded;
+}
+export function decodeNode(row: NodeRow): WorkflowNodeRunRecord {
+  if (row.activated !== 0 && row.activated !== 1) {
+    repositoryError('corrupt-record', `Workflow node ${String(row.node_id)} is invalid.`);
+  }
+  return parsed(nodeRecordSchema, {
+    runId: row.run_id, nodeId: row.node_id, nodeType: row.node_type, status: row.status,
+    activated: row.activated === 1,
+    ...(row.resolved_config_json === null ? {} : { resolvedConfig: optionalJson(row.resolved_config_json, 'Workflow node config') }),
+    ...(row.input_json === null ? {} : { input: optionalJson(row.input_json, 'Workflow node input') }),
+    ...(row.output_json === null ? {} : { output: optionalJson(row.output_json, 'Workflow node output') }),
+    ...(row.error_json === null ? {} : { error: optionalJson(row.error_json, 'Workflow node error') }),
+    ...(row.resume_at === null ? {} : { resumeAt: row.resume_at }),
+    ...(row.started_at === null ? {} : { startedAt: row.started_at }),
+    ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
+  }, `Workflow node ${String(row.node_id)}`);
+}
+export function decodeAttempt(row: AttemptRow): WorkflowAttemptRecord {
+  const record = parsed(attemptRecordSchema, {
+    runId: row.run_id, nodeId: row.node_id, attempt: row.attempt,
+    ...(row.session_id === null ? {} : { sessionId: row.session_id }), status: row.status,
+    resolvedConfig: parseStoredJson(row.resolved_config_json, 'Workflow attempt config'),
+    input: parseStoredJson(row.input_json, 'Workflow attempt input'),
+    ...(row.prompt_text === null ? {} : { promptText: row.prompt_text }),
+    ...(row.output_json === null ? {} : { output: optionalJson(row.output_json, 'Workflow attempt output') }),
+    ...(row.error_json === null ? {} : { error: optionalJson(row.error_json, 'Workflow attempt error') }),
+    startedAt: row.started_at, ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
+    remindersSent: row.reminders_sent, stopNudgesSent: row.stop_nudges_sent,
+    ...(row.next_reminder_at === null ? {} : { nextReminderAt: row.next_reminder_at }),
+    extensions: row.extensions,
+    ...(row.last_extension_reason === null ? {} : { lastExtensionReason: row.last_extension_reason }),
+    ...(row.pending_output_error === null ? {} : { pendingOutputError: row.pending_output_error }),
+    lastProcessedTurn: row.last_processed_turn,
+  }, `Workflow attempt ${String(row.node_id)}:${String(row.attempt)}`);
+  const terminal = ['completed', 'failed', 'timed-out', 'cancelled'].includes(record.status);
+  if ((record.status === 'dispatching' && (record.sessionId || record.output || record.error || record.endedAt))
+    || (record.status === 'running' && (!record.sessionId || record.output || record.error || record.endedAt))
+    || (terminal && (!record.endedAt || (record.status === 'completed' ? !record.sessionId || !record.output || record.error : !record.error || record.output)))) {
+    repositoryError('corrupt-record', `Workflow attempt ${String(row.node_id)}:${String(row.attempt)} is invalid.`);
+  }
+  return record;
+}
+export function decodeApproval(row: ApprovalRow): WorkflowApprovalRecord {
+  return parsed(approvalRecordSchema, {
+    runId: row.run_id, nodeId: row.node_id, status: row.status, requestedAt: row.requested_at,
+    ...(row.approver_ref === null ? {} : { approverRef: optionalString(row.approver_ref) }),
+    ...(row.decided_at === null ? {} : { decidedAt: optionalString(row.decided_at) }),
+    ...(row.decided_by === null ? {} : { decidedBy: optionalString(row.decided_by) }),
+    ...(row.decision === null ? {} : { decision: optionalString(row.decision) }),
+    ...(row.reason === null ? {} : { reason: optionalString(row.reason) }),
+  }, `Workflow approval ${String(row.node_id)}`);
+}
+export function readRun(db: WorkflowSqliteConnection, runId: string): WorkflowRunRecord | null {
+  const row = db.prepare('SELECT * FROM workflow_runs WHERE id = ?').get(runId) as RunRow | undefined;
+  return row ? decodeRun(row) : null;
+}
+export function readNode(db: WorkflowSqliteConnection, runId: string, nodeId: string): WorkflowNodeRunRecord | null {
+  const row = db.prepare('SELECT * FROM workflow_node_runs WHERE run_id = ? AND node_id = ?')
+    .get(runId, nodeId) as NodeRow | undefined;
+  return row ? decodeNode(row) : null;
+}
+export function readRunByIdempotency(db: WorkflowSqliteConnection, workflowId: string, key: string): WorkflowRunRecord | null {
+  const row = db.prepare('SELECT * FROM workflow_runs WHERE workflow_id = ? AND idempotency_key = ?')
+    .get(workflowId, key) as RunRow | undefined;
+  return row ? decodeRun(row) : null;
+}
+export function readWorkflowCallByIdempotency(db: WorkflowSqliteConnection, key: string): WorkflowRunRecord | null {
+  const row = db.prepare("SELECT * FROM workflow_runs WHERE idempotency_key = ? AND json_extract(trigger_json, '$.kind') = 'workflow-call' ORDER BY started_at, id LIMIT 1")
+    .get(key) as RunRow | undefined;
+  return row ? decodeRun(row) : null;
+}
+export function equivalentRun(run: WorkflowRunRecord, input: Record<string, JsonValue>, trigger: WorkflowRunRecord['trigger'], invocation?: string): boolean {
+  return canonicalJson(run.input) === canonicalJson(input) && canonicalJson(run.trigger) === canonicalJson(trigger)
+    && run.invocationSessionId === invocation;
+}
+export function insertRun(db: WorkflowSqliteConnection, run: WorkflowRunRecord): void {
+  db.prepare(`INSERT INTO workflow_runs
+    (id, workflow_id, workflow_title, definition_revision, definition_json, input_json, trigger_json,
+      status, revision, idempotency_key, invocation_session_id, cancel_requested_at, started_at, ended_at, error_json)
+    VALUES (@id, @workflowId, @workflowTitle, @definitionRevision, @definition, @input, @trigger,
+      @status, @revision, @idempotencyKey, @invocationSessionId, NULL, @startedAt, NULL, NULL)`).run({
+    ...run, definition: JSON.stringify(run.definition), input: canonicalJson(run.input), trigger: canonicalJson(run.trigger),
+    idempotencyKey: run.idempotencyKey ?? null, invocationSessionId: run.invocationSessionId ?? null,
+  });
+  const insert = db.prepare(`INSERT INTO workflow_node_runs
+    (run_id, node_id, node_type, status, activated) VALUES (?, ?, ?, 'pending', 0)`);
+  for (const node of run.definition.nodes) insert.run(run.id, node.id, node.type);
+}
+function orderedNodes(db: WorkflowSqliteConnection, run: WorkflowRunRecord): WorkflowNodeRunRecord[] {
+  const rows = db.prepare('SELECT * FROM workflow_node_runs WHERE run_id = ?').all(run.id) as NodeRow[];
+  const byId = new Map(rows.map((row) => {
+    const node = decodeNode(row);
+    return [node.nodeId, node];
+  }));
+  if (byId.size !== rows.length || rows.length !== run.definition.nodes.length) {
+    repositoryError('corrupt-record', `Workflow run ${run.id} has invalid node rows.`);
+  }
+  return run.definition.nodes.map((node) => {
+    const record = byId.get(node.id);
+    if (!record || record.nodeType !== node.type) repositoryError('corrupt-record', `Workflow run ${run.id} has invalid node rows.`);
+    return record;
+  });
+}
+export function readRunDetail(db: WorkflowSqliteConnection, workflowId: string, runId: string): WorkflowRunDetail | null {
+  const run = readRun(db, runId);
+  if (!run || run.workflowId !== workflowId) return null;
+  const nodeRuns = orderedNodes(db, run);
+  const order = new Map(run.definition.nodes.map((node, index) => [node.id, index]));
+  const attempts = (db.prepare('SELECT * FROM workflow_attempts WHERE run_id = ?').all(run.id) as AttemptRow[])
+    .map(decodeAttempt).sort((a, b) => (order.get(a.nodeId)! - order.get(b.nodeId)!) || a.attempt - b.attempt);
+  const approvals = (db.prepare('SELECT * FROM workflow_approvals WHERE run_id = ?').all(run.id) as ApprovalRow[])
+    .map(decodeApproval).sort((a, b) => order.get(a.nodeId)! - order.get(b.nodeId)!);
+  const sessions = attempts.flatMap((attempt) => attempt.sessionId ? [attempt.sessionId] : []);
+  if (attempts.some((attempt) => !order.has(attempt.nodeId) || run.definition.nodes[order.get(attempt.nodeId)!]?.type !== 'employee')
+    || approvals.some((approval) => !order.has(approval.nodeId) || run.definition.nodes[order.get(approval.nodeId)!]?.type !== 'approval')
+    || sessions.length !== new Set(sessions).size) {
+    repositoryError('corrupt-record', `Workflow run ${run.id} has foreign history rows.`);
+  }
+  const childRuns = run.definition.nodes
+    .filter((node) => node.type === 'workflow-call' || node.type === 'employee')
+    .flatMap((node) => readRunsByCaller(db, run.id, node.id));
+  return { ...run, nodeRuns, attempts, approvals, childRuns };
+}
+
+const CHILD_SESSION = 'SELECT session_id FROM workflow_attempts WHERE run_id = ? AND session_id IS NOT NULL ORDER BY rowid DESC LIMIT 1';
+export function readRunsByCaller(
+  db: WorkflowSqliteConnection,
+  parentRunId: string,
+  nodeId: string,
+): WorkflowChildRunSummary[] {
+  let rows: RunRow[];
+  try {
+    // Only manual and workflow-call payloads are ours to write, so a `caller` under any other kind is the fire's own data.
+    rows = db.prepare(`SELECT * FROM workflow_runs WHERE json_extract(trigger_json, '$.kind') IN ('manual', 'workflow-call')
+        AND json_extract(trigger_json, '$.payload.caller.runId') = ? AND json_extract(trigger_json, '$.payload.caller.nodeId') = ?
+      ORDER BY json_extract(trigger_json, '$.payload.itemIndex'), started_at, id`).all(parentRunId, nodeId) as RunRow[];
+  } catch (error) {
+    if (error instanceof Error && /malformed JSON/i.test(error.message)) {
+      repositoryError('corrupt-record', `Workflow child runs for ${parentRunId}:${nodeId} contain invalid JSON.`);
+    }
+    throw error;
+  }
+  const seen = new Set<number>();
+  return rows.map((row) => {
+    const run = decodeRun(row);
+    const itemIndex = run.trigger.payload.itemIndex;
+    // An index means one item of a fan-out batch; a direct call and a session-started run are single spawns and carry none.
+    if (itemIndex !== undefined && (!Number.isInteger(itemIndex) || (itemIndex as number) < 0 || seen.has(itemIndex as number))) {
+      repositoryError('corrupt-record', `Workflow child runs for ${parentRunId}:${nodeId} have invalid item indexes.`);
+    }
+    if (itemIndex !== undefined) seen.add(itemIndex as number);
+    const nodes = orderedNodes(db, run);
+    const end = nodes.find((candidate) => candidate.nodeType === 'end' && candidate.status === 'completed');
+    // The session this child ran in. Only a completed node writes it into its output, so a running or failed round reads it off its attempt row.
+    const session = nodes.filter((candidate) => candidate.output?.sessionId).at(-1)?.output?.sessionId
+      ?? (db.prepare(CHILD_SESSION).get(run.id) as { session_id: string } | undefined)?.session_id;
+    return {
+      runId: run.id,
+      workflowId: run.workflowId,
+      nodeId,
+      ...(itemIndex === undefined ? {} : { itemIndex: itemIndex as number }),
+      status: run.status,
+      startedAt: run.startedAt,
+      ...(run.endedAt ? { endedAt: run.endedAt } : {}),
+      ...(end?.output ? { endOutput: end.output.fields } : {}),
+      ...(session ? { sessionId: session } : {}),
+      ...(run.error ? { error: run.error } : {}),
+    };
+  });
+}
+function summary(db: WorkflowSqliteConnection, run: WorkflowRunRecord): WorkflowRunSummary {
+  const nodeRuns = orderedNodes(db, run);
+  const failing = nodeRuns.find((node) => node.status === 'failed');
+  const current = failing ?? nodeRuns.find((node) => ['ready', 'dispatching', 'running', 'waiting'].includes(node.status));
+  const authored = current ? run.definition.nodes.find((node) => node.id === current.nodeId)! : undefined;
+  const fixedEmployee = authored?.type === 'employee' && authored.config.employee.source === 'fixed'
+    ? authored.config.employee.value : undefined;
+  const employeeId = authored?.type === 'employee' ? current?.resolvedConfig?.employeeId : undefined;
+  return {
+    id: run.id, workflowId: run.workflowId, workflowTitle: run.workflowTitle,
+    definitionRevision: run.definitionRevision, status: run.status,
+    trigger: { nodeId: run.trigger.nodeId, kind: run.trigger.kind }, startedAt: run.startedAt,
+    endedAt: run.endedAt ?? null,
+    currentOrFailingNode: current && authored ? {
+      nodeId: current.nodeId, label: authored.name,
+      employeeId: typeof employeeId === 'string' ? employeeId : fixedEmployee ?? null,
+      state: failing ? 'failing' : 'current',
+    } : null,
+  };
+}
+export function listRunSummaries(db: WorkflowSqliteConnection, workflowId: string, query: NormalizedRunListQuery): WorkflowRunSummary[] {
+  assertHistoryIntegrity(db, workflowId);
+  const clauses = ['r.workflow_id = @workflowId'];
+  const values: Record<string, string | number> = { workflowId, limit: query.limit + 1 };
+  if (query.status) { clauses.push('r.status = @status'); values.status = query.status; }
+  if (query.triggerKind) { clauses.push("json_extract(r.trigger_json, '$.kind') = @triggerKind"); values.triggerKind = query.triggerKind; }
+  if (query.startedFrom) { clauses.push('r.started_at >= @startedFrom'); values.startedFrom = query.startedFrom; }
+  if (query.startedTo) { clauses.push('r.started_at <= @startedTo'); values.startedTo = query.startedTo; }
+  if (query.text) { clauses.push(`(instr(lower(r.workflow_title), @text)>0 OR instr(lower(r.id), @text)>0 OR EXISTS
+    (SELECT 1 FROM workflow_node_runs n JOIN json_each(r.definition_json,'$.nodes') j ON j.value->>'$.id'=n.node_id
+      WHERE n.run_id=r.id AND n.status IN ('ready','dispatching','running','waiting','failed') AND instr(lower(j.value->>'$.name'),@text)>0))`); values.text = query.text; }
+  if (query.cursor) {
+    clauses.push('(r.started_at < @cursorAt OR (r.started_at = @cursorAt AND r.id < @cursorId))');
+    values.cursorAt = query.cursor.startedAt; values.cursorId = query.cursor.id;
+  }
+  let rows: RunRow[];
+  try {
+    rows = db.prepare(`SELECT r.* FROM workflow_runs r WHERE ${clauses.join(' AND ')}
+      ORDER BY r.started_at DESC, r.id DESC LIMIT @limit`).all(values) as RunRow[];
+  } catch (error) {
+    if (error instanceof Error && /malformed JSON/i.test(error.message)) {
+      repositoryError('corrupt-record', 'Workflow run trigger contains invalid JSON.');
+    }
+    throw error;
+  }
+  return rows.map(decodeRun).map((run) => summary(db, run));
+}
+export function readAttempt(db: WorkflowSqliteConnection, runId: string, nodeId: string, attempt: number): WorkflowAttemptRecord | null {
+  const row = db.prepare('SELECT * FROM workflow_attempts WHERE run_id = ? AND node_id = ? AND attempt = ?')
+    .get(runId, nodeId, attempt) as AttemptRow | undefined;
+  return row ? decodeAttempt(row) : null;
+}
+export function readAttempts(db: WorkflowSqliteConnection, runId: string, nodeId: string): WorkflowAttemptRecord[] {
+  return (db.prepare('SELECT * FROM workflow_attempts WHERE run_id = ? AND node_id = ? ORDER BY attempt')
+    .all(runId, nodeId) as AttemptRow[]).map(decodeAttempt);
+}
+export function readAttemptBySession(db: WorkflowSqliteConnection, sessionId: string): WorkflowAttemptRecord | null {
+  const rows = db.prepare('SELECT * FROM workflow_attempts WHERE session_id = ? LIMIT 2').all(sessionId) as AttemptRow[];
+  if (rows.length > 1) repositoryError('corrupt-record', `Workflow session ${sessionId} owns multiple attempts.`);
+  return rows[0] ? decodeAttempt(rows[0]) : null;
+}
+export function readAttemptByRetryKey(db: WorkflowSqliteConnection, runId: string, key: string): WorkflowAttemptRecord | null {
+  const rows = db.prepare('SELECT * FROM workflow_attempts WHERE run_id = ? AND retry_idempotency_key = ? LIMIT 2')
+    .all(runId, key) as AttemptRow[];
+  if (rows.length > 1) repositoryError('corrupt-record', `Workflow retry key ${key} owns multiple attempts.`);
+  return rows[0] ? decodeAttempt(rows[0]) : null;
+}
+
+export function readDueReminders(db: WorkflowSqliteConnection, now: string, limit: number): WorkflowAttemptRecord[] {
+  return (db.prepare(`SELECT * FROM workflow_attempts WHERE status = 'running' AND next_reminder_at <= ?
+    ORDER BY next_reminder_at, run_id, node_id, attempt LIMIT ?`).all(now, limit) as AttemptRow[]).map(decodeAttempt);
+}
+
+export function readNextDueReminder(db: WorkflowSqliteConnection): {
+  runId: string; nodeId: string; attempt: number; nextReminderAt: string;
+} | null {
+  const row = db.prepare(`SELECT * FROM workflow_attempts WHERE status = 'running' AND next_reminder_at IS NOT NULL
+    ORDER BY next_reminder_at, run_id, node_id, attempt LIMIT 1`).get() as AttemptRow | undefined;
+  if (!row) return null;
+  const attempt = decodeAttempt(row);
+  return {
+    runId: attempt.runId,
+    nodeId: attempt.nodeId,
+    attempt: attempt.attempt,
+    nextReminderAt: attempt.nextReminderAt!,
+  };
+}
+
+export function readNextDueTimeout(db: WorkflowSqliteConnection): string | null {
+  const row = db.prepare(`SELECT * FROM workflow_attempts
+    WHERE status = 'running' AND json_extract(resolved_config_json, '$.timeoutMinutes') IS NOT NULL
+    ORDER BY julianday(started_at) + json_extract(resolved_config_json, '$.timeoutMinutes') / 1440.0,
+      run_id, node_id, attempt LIMIT 1`).get() as AttemptRow | undefined;
+  if (!row) return null;
+  const attempt = decodeAttempt(row);
+  const timeoutMinutes = attempt.resolvedConfig.timeoutMinutes;
+  if (timeoutMinutes === undefined) repositoryError('corrupt-record', 'Workflow attempt timeout is invalid.');
+  return new Date(Date.parse(attempt.startedAt) + timeoutMinutes * 60_000).toISOString();
+}
+
+export function readRecoverableRuns(db: WorkflowSqliteConnection): WorkflowRunRecord[] {
+  return (db.prepare("SELECT * FROM workflow_runs WHERE status IN ('pending','running','waiting') ORDER BY started_at, id")
+    .all() as RunRow[]).map(decodeRun);
+}
+
+export function readDueWaits(db: WorkflowSqliteConnection, now: string, limit: number): WorkflowNodeRunRecord[] {
+  return (db.prepare(`SELECT * FROM workflow_node_runs WHERE status = 'waiting' AND resume_at <= ?
+    ORDER BY resume_at, run_id, node_id LIMIT ?`).all(now, limit) as NodeRow[]).map(decodeNode);
+}
+
+export function readNextDueWait(db: WorkflowSqliteConnection): WorkflowNodeRunRecord | null {
+  const row = db.prepare(`SELECT * FROM workflow_node_runs WHERE status = 'waiting' AND resume_at IS NOT NULL
+    ORDER BY resume_at, run_id, node_id LIMIT 1`).get() as NodeRow | undefined;
+  return row ? decodeNode(row) : null;
+}
+
+export function jsonColumn(value: JsonValue | WorkflowNodeOutput | WorkflowError | ResolvedEmployeeConfig | undefined): string | null {
+  return value === undefined ? null : canonicalJson(value as JsonValue);
+}

--- a/packages/jimmy/src/workflows/repository-support.ts
+++ b/packages/jimmy/src/workflows/repository-support.ts
@@ -1,0 +1,200 @@
+import { Buffer } from 'node:buffer';
+import { randomUUID } from 'node:crypto';
+import { isProxy } from 'node:util/types';
+import type { WorkflowValidationIssue } from './issues.js';
+import { jsonValueSchema, nodeIdSchema, workflowIdSchema, type JsonValue } from './model.js';
+
+export type WorkflowRepositoryErrorCode =
+  | 'not-found'
+  | 'id-conflict'
+  | 'revision-conflict'
+  | 'idempotency-conflict'
+  | 'retired'
+  | 'bad-cursor'
+  | 'bad-input'
+  | 'already-submitted'
+  | 'corrupt-record';
+
+export class WorkflowRepositoryError extends Error {
+  readonly code: WorkflowRepositoryErrorCode;
+  /** What exactly was wrong. Authoring a 20-node graph against a bare
+   *  "definition is invalid" means bisecting it by hand, so every surface
+   *  that can name a node, edge, or field path does. */
+  readonly issues?: readonly WorkflowValidationIssue[];
+
+  constructor(code: WorkflowRepositoryErrorCode, message: string, issues?: readonly WorkflowValidationIssue[]) {
+    super(message);
+    this.name = 'WorkflowRepositoryError';
+    this.code = code;
+    if (issues) this.issues = issues;
+  }
+}
+
+export function repositoryError(code: WorkflowRepositoryErrorCode, message: string, issues?: readonly WorkflowValidationIssue[]): never {
+  throw new WorkflowRepositoryError(code, message, issues);
+}
+
+export function isCanonicalInstant(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const instant = new Date(value);
+  return !Number.isNaN(instant.getTime()) && instant.toISOString() === value;
+}
+
+export function canonicalStamp(value: unknown, stored = false): string {
+  if (!isCanonicalInstant(value)) {
+    repositoryError(stored ? 'corrupt-record' : 'bad-input', `Workflow repository ${stored ? 'record' : 'clock'} is invalid.`);
+  }
+  return value;
+}
+
+export function parseWorkflowId(value: unknown): string {
+  if (typeof value !== 'string') repositoryError('bad-input', 'Workflow definition ID is invalid.');
+  const parsed = workflowIdSchema.safeParse(value);
+  if (!parsed.success) repositoryError('bad-input', 'Workflow definition ID is invalid.');
+  return parsed.data;
+}
+
+export function parseNodeId(value: unknown): string {
+  if (typeof value !== 'string') repositoryError('bad-input', 'Workflow node ID is invalid.');
+  const parsed = nodeIdSchema.safeParse(value);
+  if (!parsed.success) repositoryError('bad-input', 'Workflow node ID is invalid.');
+  return parsed.data;
+}
+
+export function isRunId(value: unknown): value is string {
+  return typeof value === 'string'
+    && /^run_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value);
+}
+
+export function parseRunId(value: unknown): string {
+  if (!isRunId(value)) repositoryError('bad-input', 'Workflow run ID is invalid.');
+  return value;
+}
+
+export function newRunId(): string {
+  return `run_${randomUUID()}`;
+}
+
+export function parseExpectedRevision(subject: string, value: unknown): number {
+  if (!Number.isInteger(value) || (value as number) < 1) {
+    repositoryError('revision-conflict', `${subject} revision does not match.`);
+  }
+  return value as number;
+}
+
+export function parseLimit(value: JsonValue | undefined, subject: string): number {
+  const limit = value ?? 50;
+  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 1 || limit > 100) {
+    repositoryError('bad-input', `${subject} limit must be an integer from 1 through 100.`);
+  }
+  return limit;
+}
+
+export function parseBoundedString(value: JsonValue | undefined, label: string, max = 256): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length < 1 || value.length > max) repositoryError('bad-input', `${label} is invalid.`);
+  return value;
+}
+
+export function isThenable(value: unknown): boolean {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return false;
+  if (isProxy(value)) return true;
+  for (let target: object | null = value; target; target = Object.getPrototypeOf(target) as object | null) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, 'then');
+    if (descriptor) return !Object.hasOwn(descriptor, 'value') || typeof descriptor.value === 'function';
+  }
+  return false;
+}
+
+export function parseJsonRecord(value: unknown, message: string): Record<string, JsonValue> {
+  if (unsafeJson(value)) repositoryError('bad-input', message);
+  const parsed = jsonValueSchema.safeParse(value);
+  if (!parsed.success || parsed.data === null || typeof parsed.data !== 'object' || Array.isArray(parsed.data)) {
+    repositoryError('bad-input', message);
+  }
+  return parsed.data as Record<string, JsonValue>;
+}
+
+function unsafeJson(value: unknown, seen = new Set<object>()): boolean {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return false;
+  if (isProxy(value) || seen.has(value)) return true;
+  seen.add(value);
+  const unsafe = Reflect.ownKeys(value).some((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
+    return !Object.hasOwn(descriptor, 'value') || unsafeJson(descriptor.value, seen);
+  });
+  seen.delete(value);
+  return unsafe;
+}
+
+export function assertExactKeys(value: Record<string, JsonValue>, allowed: readonly string[], message: string): void {
+  if (Object.keys(value).some((key) => !allowed.includes(key))) repositoryError('bad-input', message);
+}
+
+export function parseStoredJson(value: unknown, subject: string): JsonValue {
+  if (typeof value !== 'string') repositoryError('corrupt-record', `${subject} contains invalid JSON.`);
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value);
+  } catch {
+    repositoryError('corrupt-record', `${subject} contains invalid JSON.`);
+  }
+  const parsed = jsonValueSchema.safeParse(decoded);
+  if (!parsed.success) repositoryError('corrupt-record', `${subject} contains invalid JSON.`);
+  return parsed.data;
+}
+
+function canonicalValue(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.keys(value).sort().map((key) => [key, canonicalValue(value[key]!)] as const);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+export function canonicalJson(value: JsonValue): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
+interface CursorSpec {
+  endpoint: string;
+  instantKey: 'updatedAt' | 'startedAt';
+  validateId: (value: unknown) => string;
+}
+
+export function encodeCursor(spec: CursorSpec, instant: string, id: string): string {
+  return Buffer.from(JSON.stringify({ version: 1, endpoint: spec.endpoint, [spec.instantKey]: instant, id }), 'utf8')
+    .toString('base64url');
+}
+
+export function decodeCursor(value: unknown, spec: CursorSpec): { instant: string; id: string } {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]+$/.test(value)) {
+    repositoryError('bad-cursor', 'Workflow cursor is malformed.');
+  }
+  let decoded: unknown;
+  try {
+    const bytes = Buffer.from(value, 'base64url');
+    if (bytes.toString('base64url') !== value) repositoryError('bad-cursor', 'Workflow cursor is malformed.');
+    decoded = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    repositoryError('bad-cursor', 'Workflow cursor is malformed.');
+  }
+  if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    repositoryError('bad-cursor', 'Workflow cursor is malformed.');
+  }
+  const cursor = decoded as Record<string, unknown>;
+  if (Object.keys(cursor).sort().join(',') !== `endpoint,id,${spec.instantKey},version`
+    || cursor.version !== 1 || cursor.endpoint !== spec.endpoint || !isCanonicalInstant(cursor[spec.instantKey])) {
+    repositoryError('bad-cursor', 'Workflow cursor is invalid.');
+  }
+  let id: string;
+  try {
+    id = spec.validateId(cursor.id);
+  } catch {
+    repositoryError('bad-cursor', 'Workflow cursor is invalid.');
+  }
+  const instant = cursor[spec.instantKey] as string;
+  if (encodeCursor(spec, instant, id) !== value) repositoryError('bad-cursor', 'Workflow cursor is invalid.');
+  return { instant, id };
+}

--- a/packages/jimmy/src/workflows/repository.ts
+++ b/packages/jimmy/src/workflows/repository.ts
@@ -1,0 +1,385 @@
+import type Database from 'better-sqlite3';
+import { isDeepStrictEqual } from 'node:util';
+import { isProxy } from 'node:util/types';
+import {
+  workflowDefinitionSchema,
+  type JsonValue,
+  type WorkflowDefinition,
+  type WorkflowId,
+  type WorkflowNodeOutput,
+} from './model.js';
+import { readContinuationAttempt, type ContinuationAttemptQuery } from './repository-continuation.js';
+import { RunMutation } from './repository-run-transaction.js';
+import { readMutexNodeRuns, type WorkflowMutexNodeRun } from './repository-mutex.js';
+import {
+  equivalentRun, insertRun, listRunSummaries, readAttempt, readAttemptByRetryKey, readAttemptBySession,
+  readAttempts, readDueReminders, readDueWaits, readNextDueReminder, readNextDueTimeout, readNextDueWait, readRecoverableRuns,
+  readRun, readRunByIdempotency, readRunsByCaller, readWorkflowCallByIdempotency, readRunDetail, type NormalizedRunListQuery,
+} from './repository-runs.js';
+import {
+  WorkflowRepositoryError, assertExactKeys, canonicalStamp, decodeCursor, encodeCursor, isThenable, newRunId,
+  parseBoundedString, parseExpectedRevision, parseJsonRecord, parseLimit, parseNodeId, parseRunId, parseStoredJson,
+  parseWorkflowId, repositoryError,
+} from './repository-support.js';
+import {
+  WORKFLOW_RUN_STATUSES,
+  type ResolvedEmployeeConfig,
+  type WorkflowApprovalRecord,
+  type WorkflowAttemptRecord,
+  type WorkflowChildRunSummary,
+  type WorkflowError,
+  type WorkflowNodeRunRecord,
+  type WorkflowNodeRunStatus,
+  type WorkflowRunDetail,
+  type WorkflowRunRecord,
+  type WorkflowRunStatus,
+} from './runtime.js';
+
+export { WorkflowRepositoryError };
+
+export interface CreateWorkflowInput { id: string; title: string; description?: string }
+export interface DefinitionListQuery { cursor?: string; limit?: number; enabled?: boolean; retired?: boolean }
+export interface CursorPage<T> { items: T[]; nextCursor: string | null }
+import type { WorkflowDefinitionSummary, WorkflowRunSummary } from './wire.js';
+export type { WorkflowDefinitionSummary, WorkflowRunSummary };
+
+export interface CreateRunInput {
+  workflowId: string; input: Record<string, JsonValue>;
+  trigger: {
+    nodeId: string; kind: 'manual' | 'schedule' | 'event' | 'todo-status' | 'workflow-call';
+    fireId?: string; payload: Record<string, JsonValue>;
+  };
+  idempotencyKey?: string; invocationSessionId?: string;
+}
+
+export interface RunListQuery {
+  cursor?: string; limit?: number; status?: WorkflowRunStatus;
+  triggerKind?: WorkflowRunRecord['trigger']['kind']; startedFrom?: string; startedTo?: string; text?: string;
+}
+
+
+
+export interface WorkflowRunTransaction {
+  setRunStatus(status: WorkflowRunStatus, patch?: {
+    cancelRequestedAt?: string; endedAt?: string; error?: WorkflowError;
+  }): WorkflowRunRecord;
+  setNodeStatus(nodeId: string, status: WorkflowNodeRunStatus, patch?: Partial<Pick<
+    WorkflowNodeRunRecord,
+    'activated' | 'resolvedConfig' | 'input' | 'output' | 'error' | 'resumeAt' | 'startedAt' | 'endedAt'
+  >>): WorkflowNodeRunRecord;
+  createAttempt(input: { nodeId: string; resolvedConfig: ResolvedEmployeeConfig; input: JsonValue;
+    promptText?: string; retryIdempotencyKey?: string }): WorkflowAttemptRecord;
+  settleAttempt(nodeId: string, attempt: number, patch:
+    | { status: 'running'; sessionId: string }
+    | { status: 'completed'; sessionId?: string; output: WorkflowNodeOutput; endedAt: string }
+    | { status: 'failed' | 'timed-out' | 'cancelled'; sessionId?: string; error: WorkflowError; endedAt: string }
+  ): WorkflowAttemptRecord;
+  setAttemptReminder(nodeId: string, attempt: number, patch: {
+    remindersSent?: number; stopNudgesSent?: number;
+    nextReminderAt?: string | null;
+    extensions?: number;
+    lastExtensionReason?: string | null;
+    pendingOutputError?: string | null;
+    lastProcessedTurn?: number;
+  }): WorkflowAttemptRecord;
+  putApproval(input: Omit<WorkflowApprovalRecord, 'runId'>): WorkflowApprovalRecord;
+}
+
+interface DefinitionRow { id: string; title: string; revision: number; enabled: number; retired_at: string | null;
+  definition_json: string; created_at: string; updated_at: string }
+interface NormalizedDefinitionQuery {
+  limit: number; cursor?: { updatedAt: string; id: string }; enabled?: boolean; retired?: boolean;
+}
+
+const DEFINITION_CURSOR = { endpoint: 'workflow-definitions', instantKey: 'updatedAt', validateId: parseWorkflowId } as const;
+const RUN_CURSOR = { endpoint: 'workflow-runs', instantKey: 'startedAt', validateId: parseRunId } as const;
+const TRIGGER_KINDS = ['manual', 'schedule', 'event', 'todo-status', 'workflow-call'] as const;
+const VALIDATION_STAMP = '1970-01-01T00:00:00.000Z';
+function parseInputDefinition(value: unknown): WorkflowDefinition {
+  const parsed = workflowDefinitionSchema.safeParse(value);
+  if (!parsed.success) {
+    // The schema failure names the field; without it a large graph can only be
+    // debugged by bisecting the JSON by hand.
+    repositoryError('bad-input', 'Workflow definition is invalid.', parsed.error.issues.map((issue) => ({
+      code: 'schema',
+      message: issue.message,
+      ...(issue.path.length > 0 ? { path: issue.path.join('.') } : {}),
+    })));
+  }
+  return parsed.data;
+}
+function parseDefinitionInput(value: unknown, description: boolean): CreateWorkflowInput {
+  const input = parseJsonRecord(value, 'Workflow definition input is invalid.');
+  assertExactKeys(input, description ? ['id', 'title', 'description'] : ['id', 'title'], 'Workflow definition input is invalid.');
+  if (typeof input.id !== 'string' || typeof input.title !== 'string'
+    || (input.description !== undefined && typeof input.description !== 'string')) {
+    repositoryError('bad-input', 'Workflow definition input is invalid.');
+  }
+  return { id: input.id, title: input.title, ...(input.description === undefined ? {} : { description: input.description }) };
+}
+function parseStoredDefinition(row: DefinitionRow): WorkflowDefinition {
+  const parsed = workflowDefinitionSchema.safeParse(parseStoredJson(row.definition_json, `Workflow definition ${row.id}`));
+  if (!parsed.success) repositoryError('corrupt-record', `Workflow definition ${row.id} is invalid.`);
+  const value = parsed.data;
+  if ((row.enabled !== 0 && row.enabled !== 1) || value.id !== row.id || value.title !== row.title
+    || value.revision !== row.revision || value.enabled !== Boolean(row.enabled)
+    || (value.retiredAt ?? null) !== row.retired_at || value.createdAt !== row.created_at || value.updatedAt !== row.updated_at) {
+    repositoryError('corrupt-record', `Workflow definition ${row.id} metadata does not match its JSON.`);
+  }
+  return value;
+}
+function initialDefinition(input: CreateWorkflowInput, stamp: string): WorkflowDefinition {
+  return parseInputDefinition({ schemaVersion: 1, ...input, revision: 1, enabled: false,
+    nodes: [], edges: [], createdAt: stamp, updatedAt: stamp });
+}
+function editableDefinition(requested: WorkflowDefinition, current: WorkflowDefinition, stamp: string, revision: number): WorkflowDefinition {
+  const { retiredAt: _retiredAt, ...authored } = requested;
+  return parseInputDefinition({ ...authored, id: current.id, revision, enabled: current.enabled,
+    ...(current.retiredAt === undefined ? {} : { retiredAt: current.retiredAt }),
+    createdAt: current.createdAt, updatedAt: stamp });
+}
+/** True when a save moves only canvas positions (or nothing at all). Dragging a
+ *  node is not an edit of the workflow, so charging it a revision would flood
+ *  the history and invalidate every `expectedRevision` a caller is holding. */
+function graphUnchanged(candidate: WorkflowDefinition, current: WorkflowDefinition): boolean {
+  const graph = ({ ui: _ui, revision: _revision, updatedAt: _updatedAt, ...rest }: WorkflowDefinition) => rest;
+  return isDeepStrictEqual(graph(candidate), graph(current));
+}
+function definitionSummary(value: WorkflowDefinition): WorkflowDefinitionSummary {
+  return { id: value.id, title: value.title, description: value.description ?? null, revision: value.revision,
+    enabled: value.enabled, retiredAt: value.retiredAt ?? null, createdAt: value.createdAt, updatedAt: value.updatedAt };
+}
+function parseDefinitionQuery(value: unknown): NormalizedDefinitionQuery {
+  const query = parseJsonRecord(value, 'Workflow definition query is invalid.');
+  assertExactKeys(query, ['cursor', 'enabled', 'limit', 'retired'], 'Workflow definition query is invalid.');
+  if (query.enabled !== undefined && typeof query.enabled !== 'boolean') repositoryError('bad-input', 'Enabled filter must be boolean.');
+  if (query.retired !== undefined && typeof query.retired !== 'boolean') repositoryError('bad-input', 'Retired filter must be boolean.');
+  return { limit: parseLimit(query.limit, 'Workflow definition'),
+    ...(query.cursor === undefined ? {} : { cursor: (() => { const cursor = decodeCursor(query.cursor, DEFINITION_CURSOR);
+      return { updatedAt: cursor.instant, id: cursor.id }; })() }),
+    ...(query.enabled === undefined ? {} : { enabled: query.enabled }),
+    ...(query.retired === undefined ? {} : { retired: query.retired }) };
+}
+function parseCreateRun(value: unknown): CreateRunInput {
+  const input = parseJsonRecord(value, 'Workflow run input is invalid.');
+  assertExactKeys(input, ['workflowId', 'input', 'trigger', 'idempotencyKey', 'invocationSessionId'], 'Workflow run input is invalid.');
+  const trigger = parseJsonRecord(input.trigger, 'Workflow run trigger is invalid.');
+  assertExactKeys(trigger, ['nodeId', 'kind', 'fireId', 'payload', 'todoId'], 'Workflow run trigger is invalid.');
+  if (typeof trigger.kind !== 'string' || !TRIGGER_KINDS.includes(trigger.kind as typeof TRIGGER_KINDS[number])) {
+    repositoryError('bad-input', 'Workflow run trigger is invalid.');
+  }
+  return {
+    workflowId: parseWorkflowId(input.workflowId), input: parseJsonRecord(input.input, 'Workflow run input is invalid.'),
+    trigger: { nodeId: parseNodeId(trigger.nodeId), kind: trigger.kind as CreateRunInput['trigger']['kind'],
+      ...(trigger.fireId === undefined ? {} : { fireId: parseBoundedString(trigger.fireId, 'Workflow trigger fire ID', 128)! }),
+      ...(trigger.todoId === undefined ? {} : { todoId: parseBoundedString(trigger.todoId, 'Workflow trigger Todo ID', 64)! }),
+      payload: parseJsonRecord(trigger.payload, 'Workflow trigger payload is invalid.') },
+    ...(input.idempotencyKey === undefined ? {} : { idempotencyKey: parseBoundedString(input.idempotencyKey,
+      'Workflow idempotency key', trigger.kind === 'workflow-call' ? 128 : 256)! }),
+    ...(input.invocationSessionId === undefined ? {} : { invocationSessionId: parseBoundedString(input.invocationSessionId, 'Workflow invocation session ID')! }),
+  };
+}
+
+function parseRunQuery(value: unknown): NormalizedRunListQuery {
+  const query = parseJsonRecord(value, 'Workflow run query is invalid.');
+  assertExactKeys(query, ['cursor', 'limit', 'status', 'triggerKind', 'startedFrom', 'startedTo', 'text'], 'Workflow run query is invalid.');
+  if (query.status !== undefined && (typeof query.status !== 'string' || !WORKFLOW_RUN_STATUSES.includes(query.status as WorkflowRunStatus))) {
+    repositoryError('bad-input', 'Workflow run status filter is invalid.');
+  }
+  if (query.triggerKind !== undefined && (typeof query.triggerKind !== 'string'
+    || !TRIGGER_KINDS.includes(query.triggerKind as typeof TRIGGER_KINDS[number]))) {
+    repositoryError('bad-input', 'Workflow trigger filter is invalid.');
+  }
+  for (const key of ['startedFrom', 'startedTo'] as const) if (query[key] !== undefined) canonicalStamp(query[key]);
+  if (typeof query.startedFrom === 'string' && typeof query.startedTo === 'string' && query.startedFrom > query.startedTo) {
+    repositoryError('bad-input', 'Workflow run date range is invalid.');
+  }
+  if (query.text !== undefined && (typeof query.text !== 'string' || query.text.length > 120)) repositoryError('bad-input', 'Workflow run text filter is invalid.');
+  const cursor = query.cursor === undefined ? undefined : decodeCursor(query.cursor, RUN_CURSOR);
+  return { limit: parseLimit(query.limit, 'Workflow run'), ...(cursor ? { cursor: { startedAt: cursor.instant, id: cursor.id } } : {}),
+    ...(query.status === undefined ? {} : { status: query.status as string }),
+    ...(query.triggerKind === undefined ? {} : { triggerKind: query.triggerKind as string }),
+    ...(query.startedFrom === undefined ? {} : { startedFrom: query.startedFrom as string }),
+    ...(query.startedTo === undefined ? {} : { startedTo: query.startedTo as string }),
+    ...(query.text === undefined || query.text === '' ? {} : { text: query.text.toLowerCase() }) };
+}
+
+export class WorkflowRepository {
+  private mutating = false;
+
+  constructor(private readonly db: Database.Database, private readonly now: () => string = () => new Date().toISOString()) {}
+
+  private transactionStamp(): string { return canonicalStamp(this.now()); }
+  private row(id: string): DefinitionRow | undefined {
+    return this.db.prepare('SELECT * FROM workflow_definitions WHERE id = ?').get(id) as DefinitionRow | undefined;
+  }
+  private requireDefinition(id: string): WorkflowDefinition {
+    const row = this.row(id);
+    if (!row) repositoryError('not-found', `Workflow definition ${id} was not found.`);
+    return parseStoredDefinition(row);
+  }
+  private requireMutable(id: string, revision: number, mustBeRetired = false): WorkflowDefinition {
+    const value = this.requireDefinition(id); if (value.revision !== revision) repositoryError('revision-conflict', `Workflow definition ${id} revision does not match.`);
+    if (value.retiredAt !== undefined && !mustBeRetired) repositoryError('retired', `Workflow definition ${id} is retired.`);
+    if (value.retiredAt === undefined && mustBeRetired) repositoryError('bad-input', `Workflow definition ${id} is not retired.`);
+    return value;
+  }
+  private write(value: WorkflowDefinition, insert: boolean, expected = 0): void {
+    const data = { id: value.id, title: value.title, revision: value.revision, enabled: value.enabled ? 1 : 0,
+      retiredAt: value.retiredAt ?? null, json: JSON.stringify(value), createdAt: value.createdAt, updatedAt: value.updatedAt, expected };
+    if (insert) this.db.prepare(`INSERT INTO workflow_definitions
+      (id,title,revision,enabled,retired_at,definition_json,created_at,updated_at)
+      VALUES (@id,@title,@revision,@enabled,@retiredAt,@json,@createdAt,@updatedAt)`).run(data);
+    else if (this.db.prepare(`UPDATE workflow_definitions SET title=@title,revision=@revision,enabled=@enabled,
+      retired_at=@retiredAt,definition_json=@json,updated_at=@updatedAt WHERE id=@id AND revision=@expected`).run(data).changes !== 1) {
+      repositoryError('revision-conflict', `Workflow definition ${value.id} revision does not match.`);
+    }
+  }
+
+  createDefinition(input: CreateWorkflowInput): WorkflowDefinition {
+    const normalized = parseDefinitionInput(input, true);
+    const value = initialDefinition(normalized, this.transactionStamp());
+    return this.db.transaction(() => { if (this.row(value.id)) repositoryError('id-conflict', `Workflow definition ${value.id} already exists.`);
+      this.write(value, true); return this.requireDefinition(value.id); }).immediate();
+  }
+  getDefinition(id: string): WorkflowDefinition | null { const row = this.row(parseWorkflowId(id)); return row ? parseStoredDefinition(row) : null; }
+  listDefinitions(query: DefinitionListQuery): CursorPage<WorkflowDefinitionSummary> {
+    const value = parseDefinitionQuery(query); const clauses = [value.retired ? 'retired_at IS NOT NULL' : 'retired_at IS NULL'];
+    const data: Record<string, string | number> = { limit: value.limit + 1 };
+    if (value.enabled !== undefined) { clauses.push('enabled=@enabled'); data.enabled = value.enabled ? 1 : 0; }
+    if (value.cursor) { clauses.push('(updated_at<@at OR (updated_at=@at AND id<@id))'); data.at = value.cursor.updatedAt; data.id = value.cursor.id; }
+    const values = (this.db.prepare(`SELECT * FROM workflow_definitions WHERE ${clauses.join(' AND ')}
+      ORDER BY updated_at DESC,id DESC LIMIT @limit`).all(data) as DefinitionRow[]).map(parseStoredDefinition);
+    const page = values.slice(0, value.limit); const last = page.at(-1);
+    return { items: page.map(definitionSummary), nextCursor: values.length > value.limit && last
+      ? encodeCursor(DEFINITION_CURSOR, last.updatedAt, last.id) : null };
+  }
+  saveDefinition(definition: WorkflowDefinition, expectedRevision: number): WorkflowDefinition {
+    const requested = parseInputDefinition(definition); const revision = parseExpectedRevision(`Workflow definition ${requested.id}`, expectedRevision);
+    const stamp = this.transactionStamp(); return this.db.transaction(() => { const current = this.requireMutable(requested.id, revision);
+      const candidate = editableDefinition(requested, current, stamp, current.revision);
+      const saved = graphUnchanged(candidate, current) ? candidate : { ...candidate, revision: current.revision + 1 };
+      this.write(saved, false, revision); return this.requireDefinition(saved.id); }).immediate();
+  }
+  setEnabled(id: string, enabled: boolean, expectedRevision: number): WorkflowDefinition {
+    const workflowId = parseWorkflowId(id); if (typeof enabled !== 'boolean') repositoryError('bad-input', 'Enabled state must be boolean.');
+    const revision = parseExpectedRevision(`Workflow definition ${workflowId}`, expectedRevision); const stamp = this.transactionStamp();
+    return this.db.transaction(() => { const current = this.requireMutable(workflowId, revision);
+      const saved = parseInputDefinition({ ...current, revision: current.revision + 1, enabled, updatedAt: stamp });
+      this.write(saved, false, revision); return this.requireDefinition(workflowId); }).immediate();
+  }
+  setRetired(id: string, retired: boolean, expectedRevision: number, at: string): WorkflowDefinition {
+    const workflowId = parseWorkflowId(id); const revision = parseExpectedRevision(`Workflow definition ${workflowId}`, expectedRevision);
+    if (typeof at !== 'string' || typeof retired !== 'boolean') repositoryError('bad-input', 'Workflow definition is invalid.'); const stamp = this.transactionStamp();
+    return this.db.transaction(() => { const { retiredAt: _retiredAt, ...current } = this.requireMutable(workflowId, revision, !retired);
+      const saved = parseInputDefinition({ ...current, revision: current.revision + 1, enabled: false, ...(retired ? { retiredAt: at } : {}), updatedAt: stamp });
+      this.write(saved, false, revision); return this.requireDefinition(workflowId); }).immediate();
+  }
+  duplicateDefinition(id: WorkflowId, input: { id: WorkflowId; title: string }): WorkflowDefinition {
+    const target = initialDefinition(parseDefinitionInput(input, false), VALIDATION_STAMP); const sourceId = parseWorkflowId(id);
+    const stamp = this.transactionStamp(); return this.db.transaction(() => { const { retiredAt: _, ...source } = this.requireDefinition(sourceId);
+      const copy = parseInputDefinition({ ...source, id: target.id, title: target.title, revision: 1, enabled: false, createdAt: stamp, updatedAt: stamp });
+      if (this.row(copy.id)) repositoryError('id-conflict', `Workflow definition ${copy.id} already exists.`);
+      this.write(copy, true); return this.requireDefinition(copy.id); }).immediate();
+  }
+
+  createRun(input: CreateRunInput, frozenDefinition?: WorkflowDefinition): WorkflowRunRecord {
+    const value = parseCreateRun(input); const frozen = frozenDefinition ? parseInputDefinition(frozenDefinition) : undefined;
+    if (frozen && frozen.id !== value.workflowId) repositoryError('bad-input', 'Workflow run definition is invalid.');
+    const stamp = this.transactionStamp();
+    return this.db.transaction(() => {
+      const current = this.requireDefinition(value.workflowId); const definition = frozen ?? current;
+      const replay = value.idempotencyKey ? (value.trigger.kind === 'workflow-call'
+        ? readWorkflowCallByIdempotency(this.db, value.idempotencyKey)
+        : readRunByIdempotency(this.db, value.workflowId, value.idempotencyKey)) : null;
+      if (replay) {
+        if (replay.workflowId === value.workflowId && replay.definitionRevision === definition.revision
+          && equivalentRun(replay, value.input, value.trigger, value.invocationSessionId)) return replay;
+        repositoryError('idempotency-conflict', 'Workflow idempotency key was reused with different input.');
+      }
+      const trigger = definition.nodes.find((node) => node.id === value.trigger.nodeId);
+      if (!trigger || trigger.type !== 'trigger' || trigger.config.kind !== value.trigger.kind) repositoryError('bad-input', 'Workflow run trigger is invalid.');
+      const run: WorkflowRunRecord = { id: newRunId(), workflowId: definition.id, workflowTitle: definition.title,
+        definitionRevision: definition.revision, definition, input: value.input, trigger: value.trigger,
+        status: 'pending', revision: 1, ...(value.idempotencyKey ? { idempotencyKey: value.idempotencyKey } : {}),
+        ...(value.invocationSessionId ? { invocationSessionId: value.invocationSessionId } : {}), startedAt: stamp };
+      insertRun(this.db, run); return readRun(this.db, run.id)!;
+    }).immediate();
+  }
+  getRun(workflowId: string, runId: string): WorkflowRunDetail | null {
+    return readRunDetail(this.db, parseWorkflowId(workflowId), parseRunId(runId));
+  }
+  listRuns(workflowId: string, query: RunListQuery): CursorPage<WorkflowRunSummary> {
+    const id = parseWorkflowId(workflowId); const value = parseRunQuery(query);
+    const rows = listRunSummaries(this.db, id, value); const page = rows.slice(0, value.limit); const last = page.at(-1);
+    return { items: page, nextCursor: rows.length > value.limit && last ? encodeCursor(RUN_CURSOR, last.startedAt, last.id) : null };
+  }
+  findRunByIdempotency(workflowId: string, key: string): WorkflowRunRecord | null {
+    const id = parseWorkflowId(workflowId); const parsed = parseBoundedString(key as unknown as JsonValue, 'Workflow idempotency key');
+    return readRunByIdempotency(this.db, id, parsed!);
+  }
+  findWorkflowCallByIdempotency(input: { workflowId: string; input: Record<string, JsonValue>;
+    caller: { workflowId: string; runId: string; nodeId: string }; itemIndex?: number;
+    todoId?: string; idempotencyKey: string }): WorkflowRunRecord | null {
+    const workflowId = parseWorkflowId(input.workflowId);
+    const value = parseJsonRecord(input.input, 'Workflow run input is invalid.');
+    const caller = parseJsonRecord(input.caller, 'Workflow caller identity is invalid.');
+    const key = parseBoundedString(input.idempotencyKey, 'Workflow idempotency key', 128)!;
+    const replay = readWorkflowCallByIdempotency(this.db, key);
+    if (replay && (replay.workflowId !== workflowId || !equivalentRun(replay, value,
+      { nodeId: replay.trigger.nodeId, kind: 'workflow-call', payload: {
+        caller, ...(input.itemIndex === undefined ? {} : { itemIndex: input.itemIndex }),
+      }, ...(input.todoId === undefined ? {} : { todoId: input.todoId }) }))) {
+      repositoryError('idempotency-conflict', 'Workflow idempotency key was reused with different input.');
+    }
+    return replay;
+  }
+  mutateRun<T>(runId: string, expectedRevision: number, mutation: (tx: WorkflowRunTransaction) => T): T {
+    const id = parseRunId(runId); const revision = parseExpectedRevision(`Workflow run ${id}`, expectedRevision);
+    if (typeof mutation !== 'function' || isProxy(mutation)) repositoryError('bad-input', 'Workflow run mutation is invalid.');
+    if (this.mutating) repositoryError('bad-input', 'Workflow run mutations cannot be nested.');
+    const stamp = this.transactionStamp(); this.mutating = true;
+    try {
+      return this.db.transaction(() => { const run = readRun(this.db, id); if (!run) repositoryError('not-found', `Workflow run ${id} was not found.`);
+        if (run.revision !== revision) repositoryError('revision-conflict', `Workflow run ${id} revision does not match.`);
+        const tx = new RunMutation(this.db, id, stamp);
+        try { const result = mutation(tx); if (isThenable(result)) repositoryError('bad-input', 'Workflow run mutation must be synchronous.');
+          if (tx.changed && this.db.prepare('UPDATE workflow_runs SET revision=revision+1 WHERE id=? AND revision=?').run(id, revision).changes !== 1) {
+            repositoryError('revision-conflict', `Workflow run ${id} revision does not match.`);
+          }
+          return result;
+        } finally { tx.close(); }
+      }).immediate();
+    } finally { this.mutating = false; }
+  }
+  getAttempt(runId: string, nodeId: string, attempt: number): WorkflowAttemptRecord | null {
+    const run = parseRunId(runId); const node = parseNodeId(nodeId);
+    if (!Number.isInteger(attempt) || attempt < 1) repositoryError('bad-input', 'Workflow attempt number is invalid.');
+    return readAttempt(this.db, run, node, attempt);
+  }
+  listAttempts(runId: string, nodeId: string): WorkflowAttemptRecord[] { return readAttempts(this.db, parseRunId(runId), parseNodeId(nodeId)); }
+  listChildRuns(parentRunId: string, nodeId: string): WorkflowChildRunSummary[] { return readRunsByCaller(this.db, parseRunId(parentRunId), parseNodeId(nodeId)); }
+  findAttemptBySessionId(sessionId: string): WorkflowAttemptRecord | null {
+    return readAttemptBySession(this.db, parseBoundedString(sessionId as unknown as JsonValue, 'Workflow session ID')!);
+  }
+  findContinuationAttempt(query: ContinuationAttemptQuery): WorkflowAttemptRecord | null { return readContinuationAttempt(this.db, query); }
+  findAttemptByRetryKey(runId: string, key: string): WorkflowAttemptRecord | null {
+    return readAttemptByRetryKey(this.db, parseRunId(runId),
+      parseBoundedString(key as unknown as JsonValue, 'Workflow retry idempotency key', 128)!);
+  }
+  listRecoverableRuns(): WorkflowRunRecord[] { return readRecoverableRuns(this.db); }
+  listMutexNodeRuns(): WorkflowMutexNodeRun[] { return readMutexNodeRuns(this.db); }
+  listDueWaits(now: string, limit: number): WorkflowNodeRunRecord[] {
+    const stamp = canonicalStamp(now); const parsedLimit = parseLimit(limit as unknown as JsonValue, 'Workflow due wait');
+    return readDueWaits(this.db, stamp, parsedLimit);
+  }
+  nextDueWait(): WorkflowNodeRunRecord | null { return readNextDueWait(this.db); }
+  listDueReminders(now: string, limit: number): WorkflowAttemptRecord[] {
+    const stamp = canonicalStamp(now); const parsedLimit = parseLimit(limit as unknown as JsonValue, 'Workflow due reminder');
+    return readDueReminders(this.db, stamp, parsedLimit);
+  }
+  nextDueReminder(): { runId: string; nodeId: string; attempt: number; nextReminderAt: string } | null {
+    return readNextDueReminder(this.db);
+  }
+  nextDueTimeout(): string | null { return readNextDueTimeout(this.db); }
+}

--- a/packages/jimmy/src/workflows/restart-redispatch.ts
+++ b/packages/jimmy/src/workflows/restart-redispatch.ts
@@ -1,0 +1,71 @@
+import type { WorkflowAttemptCompletion } from "../shared/types.js";
+import { RESTART_INTERRUPTED } from "./failure.js";
+import type { ResolvedEmployeeConfig, WorkflowAttemptRecord, WorkflowError, WorkflowRunDetail } from "./runtime.js";
+import type { JsonValue } from "./model.js";
+import type { WorkflowRepository } from "./repository.js";
+import type { WorkflowSessionExecutor } from "./session-executor.js";
+import type { WorkflowTodoSessionLink } from "./todo-ports.js";
+import { settleTodoRun } from "./todo-run-ledger.js";
+
+/**
+ * Replacing an attempt a gateway restart killed.
+ *
+ * The restart is not a fault of the work — the process the attempt lived in went
+ * away — so its replacement spends no retry budget and waits out no backoff. It
+ * carries the engine thread the dead session still holds, so the phase resumes
+ * where it was instead of re-deriving everything it had already worked out.
+ *
+ * A gateway that keeps dying would re-dispatch forever, so the count of restarts
+ * a node has already survived is the bound. Past it, the caller settles the run.
+ */
+
+/** How many restarts one node's work survives before the run fails instead. */
+export const RESTART_REDISPATCH_CAP = 3;
+
+/** Restarts kept killing the same node. Re-dispatching again would be a loop, so
+ *  the run stops and says how many of them it survived. */
+export function restartExhaustedFailure(nodeId: string, attempt: number, restarts: number): WorkflowError {
+  return { code: "workflow-attempt-restart-exhausted", nodeId, attempt, retryable: false,
+    message: `Workflow attempt was killed by ${restarts} gateway restarts; it will not be re-dispatched again.` };
+}
+
+/** How many of this node's attempts a gateway restart has killed. */
+export function restartsOn(run: WorkflowRunDetail, nodeId: string): number {
+  return run.attempts.filter((item) => item.nodeId === nodeId && item.error?.code === RESTART_INTERRUPTED).length;
+}
+
+export interface RestartReplacementPorts {
+  repository: WorkflowRepository;
+  executor: WorkflowSessionExecutor;
+  todoSessions?: WorkflowTodoSessionLink;
+  /** What the replacement carries, composed for a continuing or a cold turn. */
+  prompt: (continued: boolean) => string;
+}
+
+/**
+ * Settle the killed attempt and open its replacement in one transaction, leaving
+ * it `dispatching` for the caller to send. Null at the cap: the caller settles
+ * the failure instead.
+ */
+export function openRestartReplacement(deps: RestartReplacementPorts, run: WorkflowRunDetail,
+  attempt: WorkflowAttemptRecord, error: WorkflowError, event: WorkflowAttemptCompletion): number | null {
+  if (restartsOn(run, attempt.nodeId) >= RESTART_REDISPATCH_CAP) return null;
+  const endedAt = event.completedAt;
+  const engineSessionId = deps.executor.resumableEngineSession(event.sessionId, attempt.resolvedConfig.engine);
+  // The killed session supersedes whatever the dead attempt itself continued
+  // from; with no usable thread left, the replacement goes out cold.
+  const { continuedFrom: _lost, ...cold } = attempt.resolvedConfig;
+  const config: ResolvedEmployeeConfig = engineSessionId
+    ? { ...cold, continuedFrom: { sessionId: event.sessionId, engineSessionId } } : cold;
+  const promptText = deps.prompt(Boolean(config.continuedFrom));
+  const replacement = deps.repository.mutateRun(run.id, run.revision, (tx) => {
+    tx.setAttemptReminder(attempt.nodeId, attempt.attempt, { lastProcessedTurn: event.turn });
+    tx.settleAttempt(attempt.nodeId, attempt.attempt, { status: "cancelled", sessionId: event.sessionId, error, endedAt });
+    tx.setNodeStatus(attempt.nodeId, "dispatching", { activated: true, input: attempt.input, startedAt: endedAt,
+      resolvedConfig: config as unknown as Record<string, JsonValue> });
+    tx.setRunStatus("running");
+    return tx.createAttempt({ nodeId: attempt.nodeId, resolvedConfig: config, input: attempt.input, promptText });
+  });
+  settleTodoRun(deps.todoSessions, run, attempt, { status: "cancelled", endedAt, error });
+  return replacement.attempt;
+}

--- a/packages/jimmy/src/workflows/run-closure.ts
+++ b/packages/jimmy/src/workflows/run-closure.ts
@@ -1,0 +1,134 @@
+import { logger } from "../shared/logger.js";
+import { gitLandingEvidence } from "./git-landing-evidence.js";
+import type { EndNode } from "./model.js";
+import type { WorkflowApprovalRecord, WorkflowRunDetail } from "./runtime.js";
+import type { WorkflowTodoLifecycle } from "./todo-ports.js";
+
+/**
+ * What a run that reached a success End owes its bound Todo.
+ *
+ * Reaching one used to be proof enough: the runner closed the Todo whenever a
+ * success End completed behind an approved operator-only gate, without ever
+ * asking what the run had produced. A landing phase that aborted on five rebase
+ * conflicts reported "nothing merged" and satisfied that exactly as well as a
+ * real merge did, because its node contract asked for a summary and not for a
+ * commit — so the board read `done` for work that never left its branch.
+ *
+ * A success End may now declare what has to be true first. Ends that declare
+ * nothing behave exactly as before: most Todo-closing Workflows land nothing,
+ * and a demand they cannot meet would close nothing at all.
+ */
+
+/** Proof that a commit a run reported really reached the canonical branch. A port so the rule
+ *  can be judged without a repository; the default shells git. */
+export interface WorkflowLandingVerifier {
+  mergedIntoMain(input: { commit: string; checkout: string }): Promise<boolean>;
+}
+
+/** Why a landing cannot be believed, and the End that demanded it. */
+export interface WorkflowLandingShortfall {
+  nodeId: string;
+  reason: string;
+}
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+/** Long enough to recognise what a phase reported, short enough to stay a comment. */
+const MAX_QUOTED = 80;
+
+function completedSuccessEnds(run: WorkflowRunDetail): EndNode[] {
+  return run.definition.nodes.filter((node): node is EndNode => node.type === "end"
+    && node.config.result === "success"
+    && run.nodeRuns.some((runtime) => runtime.nodeId === node.id && runtime.status === "completed"));
+}
+
+export function reachedSuccessEnd(run: WorkflowRunDetail): boolean {
+  return completedSuccessEnds(run).length > 0;
+}
+
+/** What a node reported for one of its output fields, trimmed — empty for a node
+ *  that never ran, never completed, or left the field out. */
+function reported(run: WorkflowRunDetail, nodeId: string, field: string): string {
+  const value = run.nodeRuns.find((runtime) => runtime.nodeId === nodeId)?.output?.fields[field];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function quoted(value: string): string {
+  return value.length > MAX_QUOTED ? `${value.slice(0, MAX_QUOTED)}…` : value;
+}
+
+/** `undefined` when the question could not be put. Unproven delivery must block
+ *  closure just as firmly as disproven delivery. */
+async function onMain(verifier: WorkflowLandingVerifier, commit: string, checkout: string): Promise<boolean | undefined> {
+  try {
+    return await verifier.mergedIntoMain({ commit, checkout });
+  } catch (error) {
+    logger.warn(`Workflow could not check whether ${commit} is on the canonical branch in ${checkout}: `
+      + `${error instanceof Error ? error.message : String(error)}`);
+    return undefined;
+  }
+}
+
+/**
+ * Why a completed run must NOT close its Todo, or `undefined` when every success
+ * End it reached is satisfied.
+ *
+ * A missing field, a blank one and a value that is not a SHA are the same
+ * failure in different clothes: the phase landed nothing and said so in the
+ * only place it had. A declared checkout makes canonical delivery mandatory;
+ * an unavailable repository or remote is failed proof, never permission to close.
+ */
+export async function landingShortfall(run: WorkflowRunDetail,
+  verifier: WorkflowLandingVerifier = gitLandingEvidence): Promise<WorkflowLandingShortfall | undefined> {
+  for (const end of completedSuccessEnds(run)) {
+    const requires = end.config.requires;
+    if (!requires) continue;
+    const commit = reported(run, requires.nodeId, requires.field);
+    if (commit === "") {
+      return { nodeId: end.id, reason: `Step ${requires.nodeId} reported no ${requires.field}, so nothing was landed.` };
+    }
+    if (!COMMIT_SHA.test(commit)) {
+      return { nodeId: end.id,
+        reason: `Step ${requires.nodeId} reported ${requires.field} "${quoted(commit)}", which is not a commit SHA.` };
+    }
+    const checkout = requires.commitIn ? reported(run, requires.commitIn.nodeId, requires.commitIn.field) : "";
+    if (checkout !== "") {
+      const delivered = await onMain(verifier, commit, checkout);
+      if (delivered === false) {
+        return { nodeId: end.id,
+          reason: `Commit ${commit} reported by step ${requires.nodeId} is not on the canonical branch.` };
+      }
+      if (delivered === undefined) {
+        return { nodeId: end.id,
+          reason: `Commit ${commit} reported by step ${requires.nodeId} could not be verified on the canonical branch.` };
+      }
+    }
+  }
+  return undefined;
+}
+
+/** The operator-only gate whose approval authorized this run to close its Todo. */
+function approvedGate(run: WorkflowRunDetail): WorkflowApprovalRecord | undefined {
+  return run.approvals.find((approval) => {
+    const authored = run.definition.nodes.find((node) => node.id === approval.nodeId);
+    const runtime = run.nodeRuns.find((node) => node.nodeId === approval.nodeId);
+    return authored?.type === "approval" && authored.config.operatorOnly === true
+      && runtime?.status === "completed" && approval.status === "approved"
+      && approval.decidedBy !== undefined && approval.decidedAt !== undefined;
+  });
+}
+
+/** Close the bound Todo of a run that completed behind an approved operator-only
+ *  gate. Best-effort like every other Todo-side write from a run: the Todo may
+ *  have been closed or deleted since the run started. */
+export function completeBoundTodo(lifecycle: WorkflowTodoLifecycle | undefined, run: WorkflowRunDetail): void {
+  const todoId = run.trigger.todoId;
+  const gate = approvedGate(run);
+  if (!todoId || !lifecycle || !gate?.decidedBy || !gate.decidedAt) return;
+  try {
+    lifecycle.complete({ todoId, workflowId: run.workflowId, runId: run.id, nodeId: gate.nodeId,
+      approvedBy: gate.decidedBy, approvedAt: gate.decidedAt });
+  } catch (error) {
+    logger.warn(`Workflow run ${run.id} could not complete Todo ${todoId}: `
+      + `${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/packages/jimmy/src/workflows/run-graph.ts
+++ b/packages/jimmy/src/workflows/run-graph.ts
@@ -1,0 +1,78 @@
+/** Reading a run's node graph: what a node's runtime record is, what feeds it,
+ *  which of its edges have fired, which of its nodes can still be reached, and
+ *  which sessions upstream of it are still readable. */
+
+import type { WorkflowNodeRunRecord, WorkflowRunDetail } from "./runtime.js";
+
+export function nodeRun(run: WorkflowRunDetail, nodeId: string): WorkflowNodeRunRecord {
+  const found = run.nodeRuns.find((node) => node.nodeId === nodeId);
+  if (!found) throw new Error(`Workflow node ${nodeId} was not found.`);
+  return found;
+}
+
+export function incoming(run: WorkflowRunDetail, nodeId: string) {
+  return run.definition.edges.filter((edge) => edge.to.nodeId === nodeId);
+}
+
+/** Every completed ancestor of `nodeId`, with the session that produced it when
+ *  there is one — the transcripts a phase is allowed to read for context. */
+export function upstreamSessions(run: WorkflowRunDetail, nodeId: string): Array<{ nodeId: string; sessionId?: string }> {
+  const ancestors = new Set<string>();
+  const pending = incoming(run, nodeId).map((edge) => edge.from.nodeId);
+  while (pending.length > 0) {
+    const upstreamId = pending.pop()!;
+    if (ancestors.has(upstreamId)) continue;
+    ancestors.add(upstreamId);
+    pending.push(...incoming(run, upstreamId).map((edge) => edge.from.nodeId));
+  }
+  return run.definition.nodes.flatMap((authored) => {
+    const runtime = nodeRun(run, authored.id);
+    if (!ancestors.has(authored.id) || runtime.status !== "completed") return [];
+    const attempt = run.attempts.filter((candidate) => candidate.nodeId === authored.id
+      && candidate.status === "completed" && candidate.sessionId).at(-1);
+    const sessionId = runtime.output?.sessionId ?? attempt?.sessionId;
+    return [{ nodeId: authored.id, ...(sessionId ? { sessionId } : {}) }];
+  });
+}
+
+export function terminalNode(node: WorkflowNodeRunRecord): boolean {
+  return ["completed", "failed", "skipped", "cancelled"].includes(node.status);
+}
+
+/** Whether an edge has fired: its source is done, and the port it leaves by is the
+ *  one that source chose. Only a routing node chooses; everything else leaves by
+ *  `success`, and a failed employee leaves by `error` if anything is wired there. */
+export function edgeActivated(run: WorkflowRunDetail, edge: WorkflowRunDetail["definition"]["edges"][number]): boolean {
+  const source = run.definition.nodes.find((node) => node.id === edge.from.nodeId)!;
+  const runtime = nodeRun(run, source.id);
+  if (!runtime.activated) return false;
+  if (runtime.status === "failed" && source.type === "employee") return edge.from.port === "error";
+  if (runtime.status !== "completed") return false;
+  const routed = source.type === "condition" || source.type === "approval"
+    || (source.type === "workflow-call" && source.config.iterate !== undefined);
+  const port = routed ? runtime.output?.fields.port : "success";
+  return port === edge.from.port;
+}
+
+function activationPossible(run: WorkflowRunDetail, nodeId: string, seen = new Set<string>()): boolean {
+  const runtime = nodeRun(run, nodeId);
+  if (runtime.activated) return true;
+  if (runtime.status === "skipped" || runtime.status === "cancelled" || seen.has(nodeId)) return false;
+  const path = new Set(seen).add(nodeId);
+  return incoming(run, nodeId).some((edge) => {
+    const source = nodeRun(run, edge.from.nodeId);
+    if (!source.activated) return activationPossible(run, edge.from.nodeId, path);
+    return terminalNode(source) ? edgeActivated(run, edge) : true;
+  });
+}
+
+export function canNeverActivate(run: WorkflowRunDetail, nodeId: string): boolean {
+  return incoming(run, nodeId).length > 0 && !activationPossible(run, nodeId);
+}
+
+export function mergeReady(run: WorkflowRunDetail, nodeId: string): boolean {
+  return incoming(run, nodeId).every((edge) => {
+    const source = nodeRun(run, edge.from.nodeId);
+    return source.activated ? terminalNode(source) : !activationPossible(run, edge.from.nodeId);
+  });
+}

--- a/packages/jimmy/src/workflows/runner.ts
+++ b/packages/jimmy/src/workflows/runner.ts
@@ -1,0 +1,1015 @@
+import { logger } from "../shared/logger.js";
+import type { Employee, ModelRegistry, WorkflowAttemptCompletion } from "../shared/types.js";
+import { TODO_ID_PATTERN } from "../work-items/id.js";
+import { approvalDescription } from "./approval-description.js";
+import { interpolateWorkflowPrompt, resolveBinding } from "./bindings.js";
+import { buildNodeContract } from "./contract.js";
+import { continuationPrompt } from "./employee-continuation.js";
+import { bindingContext, hasSubstitute, resolveDispatch, resolveString, type DispatchResolutionDeps } from "./node-dispatch.js";
+import { canNeverActivate, edgeActivated, incoming, mergeReady, nodeRun, terminalNode, upstreamSessions } from "./run-graph.js";
+import { commentReplyOutput, waitDueOutput } from "./wait-comment-output.js";
+import type {
+  ConditionNode,
+  EmployeeNode,
+  EndNode,
+  JsonValue,
+  ApprovalNode,
+  WaitNode,
+  WorkflowCallNode,
+  WorkflowNode,
+  WorkflowNodeOutput,
+} from "./model.js";
+import { dispatchFailure, interruptedAttemptFailure, RESTART_INTERRUPTED, workflowError } from "./failure.js";
+import { openRestartReplacement, restartExhaustedFailure, restartsOn } from "./restart-redispatch.js";
+import { fanoutOutput, parseWorkflowOutput, validateSubmittedFields, WorkflowOutputError } from "./output.js";
+import { fanoutConcurrencyRecord } from "./capacity.js";
+import { mutexHolder, recordMutexWaits, wakeMutexWaiters } from "./node-mutex.js";
+import { predicatesHold } from "./predicates.js";
+import { completeBoundTodo, landingShortfall, reachedSuccessEnd, type WorkflowLandingVerifier } from "./run-closure.js";
+import { callChildren, childTerminal, fanoutInput, fanoutPlan, iterationSettings, iterationStep, validateFanoutChildren,
+  type FanoutPlan, type IterationStep } from "./workflow-call.js";
+import { addMinutes, hasWorkflowOutputBlock, remindDueAttempts, REMINDER_RUNGS_MINUTES } from "./reminder-ladder.js";
+import { planStopNudge, STOP_NUDGE_TEXT } from "../sessions/stop-nudge.js";
+import { WorkflowRepositoryError, type WorkflowRepository } from "./repository.js";
+import type {
+  ResolvedEmployeeConfig,
+  WorkflowFanoutChildSummary,
+  WorkflowError,
+  WorkflowNodeRunRecord,
+  WorkflowRunDetail,
+} from "./runtime.js";
+import type { WorkflowSessionExecutor } from "./session-executor.js";
+import { resolveRearmTarget } from "./rearm-target.js";
+import { todoApprovalRef } from "./todo-approval-ref.js";
+import { openTodoRun, settleTodoRun } from "./todo-run-ledger.js";
+import type { WorkflowRearmTarget, WorkflowRunReflection, WorkflowTodoApprovalMirror, WorkflowTodoDispatchOverride,
+  WorkflowTodoLifecycle, WorkflowTodoSessionLink } from "./todo-ports.js";
+import { topologicalOrder, validateExecutableWorkflow } from "./validation.js";
+
+export interface WorkflowRunnerOptions extends Pick<DispatchResolutionDeps, "engineFallback"> {
+  repository: WorkflowRepository;
+  executor: WorkflowSessionExecutor;
+  employees: () => ReadonlyMap<string, Employee>;
+  models: () => ModelRegistry;
+  now?: () => string;
+  onChange?: (change: { workflowId: string; runId: string }) => void;
+  callWorkflow: (input: {
+    workflowId: string;
+    caller: { workflowId: string; runId: string; nodeId: string };
+    input: Record<string, JsonValue>;
+    idempotencyKey: string;
+    itemIndex: number;
+    todoId?: string;
+  }) => Promise<WorkflowRunDetail>;
+  /** Mirrors an Approval node's gate onto the run's bound Todo so the operator
+   *  decides it from Todos, not from Workflows. Absent = no Todo surface (the
+   *  gate still parks the run and is decidable through the workflow API). */
+  todoApprovals?: WorkflowTodoApprovalMirror;
+  /** Links each phase session to the run's bound Todo so the run's spend rolls
+   *  up on that Todo. Absent = no attribution (the run still executes). */
+  todoSessions?: WorkflowTodoSessionLink;
+  /** Reflects the run's own lifecycle onto its bound Todo, so no workflow author
+   *  has to write `update_work_item` into a phase prompt for the board to be
+   *  honest. Absent = no reflection (the run still executes). */
+  todoLifecycle?: WorkflowTodoLifecycle;
+  /** Lets the run's bound Todo redirect the next attempt to another engine or
+   *  model. Absent = the node's own configuration decides. */
+  todoDispatch?: WorkflowTodoDispatchOverride;
+  /** Proves that a commit a success End demanded really reached `main`, in the
+   *  checkout the run itself named. Absent = git in that checkout, which is the
+   *  answer everywhere but a test. */
+  landingEvidence?: WorkflowLandingVerifier;
+  /** Engine sessions across the whole gateway that already hold the machine,
+   *  read fresh whenever a fan-out asks for room. Absent = no system ceiling:
+   *  the authored concurrency stands, bounded only by its schema maximum. */
+  activeEngineSessions?: () => number;
+}
+
+/** The Todo-facing ports live in todo-ports.ts; re-exported so the runner stays
+ *  the one import every implementer and caller already had. */
+export type { WorkflowRearmTarget, WorkflowRevisionRequest, WorkflowRunReflection, WorkflowTodoApprovalMirror,
+  WorkflowTodoDispatchOverride, WorkflowTodoLifecycle, WorkflowTodoSessionLink } from "./todo-ports.js";
+
+type NodeAction =
+  | { kind: "activate" | "skip" | "condition" | "merge" | "approval" | "wait" | "end"; node: WorkflowNode }
+  | { kind: "fanout" | "iterate"; node: WorkflowCallNode }
+  | { kind: "dispatch"; node: EmployeeNode; config: ResolvedEmployeeConfig };
+
+function composeEmployeePrompt(run: WorkflowRunDetail, node: EmployeeNode, continued: boolean): string {
+  const prompt = interpolateWorkflowPrompt(continuationPrompt(node, continued), bindingContext(run));
+  return `${prompt}\n\n---\n${buildNodeContract(node, upstreamSessions(run, node.id))}`;
+}
+function conditionPort(run: WorkflowRunDetail, node: ConditionNode): string {
+  const context = bindingContext(run);
+  return node.config.cases.find((item) => predicatesHold(item.all, context))?.port
+    ?? node.config.defaultPort;
+}
+function inputFor(run: WorkflowRunDetail, nodeId: string): JsonValue {
+  const outputs = incoming(run, nodeId).filter((edge) => edgeActivated(run, edge))
+    .map((edge) => nodeRun(run, edge.from.nodeId).output).filter((output): output is WorkflowNodeOutput => output !== undefined);
+  return outputs.length === 1 ? outputs[0] as unknown as JsonValue : run.input;
+}
+function mergeOutput(run: WorkflowRunDetail, nodeId: string): WorkflowNodeOutput {
+  const values = incoming(run, nodeId).filter((edge) => edgeActivated(run, edge)).map((edge) => {
+    const output = nodeRun(run, edge.from.nodeId).output;
+    return [edge.from.nodeId, output ?? { text: "", fields: {} }] as const;
+  });
+  return { text: "", fields: { byNode: Object.fromEntries(values) as unknown as JsonValue } };
+}
+function approvalRef(run: WorkflowRunDetail, node: ApprovalNode): string | undefined {
+  return node.config.approver ? resolveString(node.config.approver, bindingContext(run), "Workflow approver") : undefined;
+}
+/** What a Wait node writes when it parks. `resumeAt` is the instant it stops
+ *  waiting unprompted: the scheduled resume for `duration` and `until`, and the
+ *  timeout ceiling for `todo-comment`, which an operator reply pre-empts. */
+function waitPark(run: WorkflowRunDetail, node: WaitNode, now: string):
+{ resumeAt: string; resolvedConfig?: Record<string, JsonValue> } {
+  if (node.config.mode === "duration") {
+    return { resumeAt: new Date(Date.parse(now) + node.config.minutes * 60_000).toISOString() };
+  }
+  if (node.config.mode === "todo-comment") {
+    const { todoId } = run.trigger;
+    if (!todoId) {
+      throw new Error(`Workflow Wait ${node.id} waits for the operator's comment on this run's Todo, `
+        + "but the run is not bound to one. Start it from a Todo — a todo-status Trigger, or a manual "
+        + "or Workflow Call start that carries a todoId.");
+    }
+    const { timeoutMinutes } = node.config;
+    return { resumeAt: new Date(Date.parse(now) + timeoutMinutes * 60_000).toISOString(),
+      resolvedConfig: { mode: "todo-comment", todoId, timeoutMinutes } };
+  }
+  const value = resolveBinding(node.config.timestamp, bindingContext(run));
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value)) || new Date(value).toISOString() !== value) {
+    throw new Error("Workflow Wait timestamp must resolve to a canonical instant.");
+  }
+  return { resumeAt: value };
+}
+function endOutput(run: WorkflowRunDetail, node: EndNode): WorkflowNodeOutput {
+  let fields: Record<string, JsonValue> = {};
+  if (node.config.output) {
+    const value = resolveBinding(node.config.output, bindingContext(run));
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`Workflow End ${node.id} output must resolve to a JSON object.`);
+    }
+    fields = value as Record<string, JsonValue>;
+  }
+  return { text: node.config.message ?? "", fields };
+}
+export class WorkflowRunner {
+  private readonly advances = new Map<string, Promise<WorkflowRunDetail>>();
+
+  constructor(private readonly options: WorkflowRunnerOptions) {}
+  private now(): string { return (this.options.now ?? (() => new Date().toISOString()))(); }
+  private detail(workflowId: string, runId: string): WorkflowRunDetail {
+    const run = this.options.repository.getRun(workflowId, runId);
+    if (!run) throw new Error(`Workflow run ${runId} was not found.`);
+    return run;
+  }
+  private changed(run: Pick<WorkflowRunDetail, "workflowId" | "id">): void {
+    this.options.onChange?.({ workflowId: run.workflowId, runId: run.id });
+  }
+  private failRun(run: WorkflowRunDetail, error: unknown, nodeId = run.trigger.nodeId): WorkflowRunDetail {
+    const endedAt = this.now();
+    const failure = workflowError(error, nodeId);
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setRunStatus("failed", { endedAt, error: failure });
+      const runtime = nodeRun(run, nodeId);
+      if (!terminalNode(runtime)) tx.setNodeStatus(nodeId, "failed", { activated: true, error: failure, startedAt: endedAt, endedAt });
+    });
+    this.reflectFailure(run, nodeId, failure);
+    this.changed(run);
+    return this.detail(run.workflowId, run.id);
+  }
+
+  async start(runId: string): Promise<WorkflowRunDetail> {
+    const record = this.options.repository.listRecoverableRuns().find((candidate) => candidate.id === runId);
+    if (!record) throw new Error(`Workflow run ${runId} was not found.`);
+    const run = this.detail(record.workflowId, record.id);
+    if (run.status !== "pending") return run;
+    const validation = validateExecutableWorkflow(run.definition);
+    if (!run.definition.enabled || !validation.ok) return this.failRun(run, new Error("Workflow is not enabled and executable."));
+    const trigger = run.definition.nodes.find((node) => node.id === run.trigger.nodeId)!;
+    const endedAt = this.now();
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setRunStatus("running");
+      tx.setNodeStatus(trigger.id, "completed", { activated: true, startedAt: run.startedAt, endedAt });
+    });
+    this.changed(run);
+    return this.advance(run.workflowId, run.id);
+  }
+
+  private nextAction(run: WorkflowRunDetail): NodeAction | null {
+    for (const id of topologicalOrder(run.definition)) {
+      const node = run.definition.nodes.find((candidate) => candidate.id === id)!;
+      const runtime = nodeRun(run, id);
+      if (node.type === "trigger"
+        || (node.type === "workflow-call" ? !["pending", "running"].includes(runtime.status) : runtime.status !== "pending")) continue;
+      if (!runtime.activated && incoming(run, id).some((edge) => edgeActivated(run, edge))) return { kind: "activate", node };
+      if (!runtime.activated && canNeverActivate(run, id)) return { kind: "skip", node };
+      if (!runtime.activated) continue;
+      if (node.type === "employee") {
+        if (mutexHolder(this.options.repository, run, node)) continue;
+        try { return { kind: "dispatch", node, config: resolveDispatch(run, node, this.options) }; }
+        catch (error) { this.failRun(run, error, node.id); return null; }
+      }
+      if (node.type === "workflow-call") {
+        try {
+          const children = callChildren(run, node.id);
+          const active = children.filter((child) => !childTerminal(child)).length;
+          if (node.config.iterate) {
+            // One round at a time, so there is nothing to decide until the round
+            // in flight has settled.
+            if (runtime.status === "pending" || active === 0) return { kind: "iterate", node };
+            continue;
+          }
+          const plan = fanoutPlan(run, node, this.options.activeEngineSessions, active);
+          validateFanoutChildren(node, plan, children);
+          if (runtime.status === "pending" || (children.length === plan.items.length && active === 0)
+            || (children.length < plan.items.length && active < plan.concurrency.effective)) {
+            return { kind: "fanout", node };
+          }
+        } catch (error) {
+          this.failRun(run, error, node.id);
+          return null;
+        }
+        continue;
+      }
+      if (node.type === "condition") return { kind: "condition", node };
+      if (node.type === "merge" && mergeReady(run, node.id)) return { kind: "merge", node };
+      if (node.type === "approval") return { kind: "approval", node };
+      if (node.type === "wait") return { kind: "wait", node };
+      if (node.type === "end") return { kind: "end", node };
+    }
+    return null;
+  }
+
+  private applyInline(run: WorkflowRunDetail, action: Exclude<NodeAction, { kind: "dispatch" | "fanout" }>): void {
+    const at = this.now();
+    let approver: string | undefined;
+    let park: { resumeAt: string; resolvedConfig?: Record<string, JsonValue> } | undefined;
+    let output: WorkflowNodeOutput | undefined;
+    if (action.kind === "approval") approver = approvalRef(run, action.node as ApprovalNode);
+    if (action.kind === "wait") {
+      try { park = waitPark(run, action.node as WaitNode, at); }
+      catch (error) { this.failRun(run, error, action.node.id); return; }
+    }
+    if (action.kind === "end" && action.node.type === "end") {
+      try { output = endOutput(run, action.node); }
+      catch (error) { this.failRun(run, error, action.node.id); return; }
+    }
+    const failureEnd: WorkflowError | undefined = action.kind === "end" && action.node.type === "end"
+      && action.node.config.result === "failure"
+      ? { code: "workflow-failure-end", message: `Workflow reached failure End ${action.node.id}.`,
+          retryable: false, nodeId: action.node.id }
+      : undefined;
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      if (action.kind === "activate") tx.setNodeStatus(action.node.id, "pending", { activated: true, input: inputFor(run, action.node.id) });
+      else if (action.kind === "skip") tx.setNodeStatus(action.node.id, "skipped", { endedAt: at });
+      else if (action.kind === "condition") {
+        const port = conditionPort(run, action.node as ConditionNode);
+        tx.setNodeStatus(action.node.id, "completed", { output: { text: "", fields: { port } }, startedAt: at, endedAt: at });
+      } else if (action.kind === "merge") {
+        tx.setNodeStatus(action.node.id, "completed", { output: mergeOutput(run, action.node.id), startedAt: at, endedAt: at });
+      } else if (action.kind === "approval") {
+        tx.putApproval({ nodeId: action.node.id, status: "pending", requestedAt: at, ...(approver ? { approverRef: approver } : {}) });
+        tx.setNodeStatus(action.node.id, "waiting", { startedAt: at });
+        tx.setRunStatus("waiting");
+        this.mirrorApproval(run, action.node as ApprovalNode, approver);
+      } else if (action.kind === "wait") {
+        tx.setNodeStatus(action.node.id, "waiting", { resumeAt: park!.resumeAt, startedAt: at,
+          ...(park!.resolvedConfig ? { resolvedConfig: park!.resolvedConfig } : {}) });
+        tx.setRunStatus("waiting");
+      } else {
+        tx.setNodeStatus(action.node.id, "completed", { output, startedAt: at, endedAt: at });
+        if (failureEnd) tx.setRunStatus("failed", { endedAt: at, error: failureEnd });
+      }
+    });
+    if (action.kind === "approval") this.reflect(run, "in_review", action.node.id);
+    if (failureEnd) this.reflectFailure(run, action.node.id, failureEnd);
+    this.changed(run);
+  }
+
+  /** Keep the node's account of its own fan-out width true: the ceiling is read again on every
+   *  reconcile, so a record frozen at the first wave would claim a width the run stopped using. */
+  private recordFanoutWidth(run: WorkflowRunDetail, node: WorkflowCallNode, runtime: WorkflowNodeRunRecord, plan: FanoutPlan): void {
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setNodeStatus(node.id, runtime.status, { resolvedConfig: { ...runtime.resolvedConfig, ...fanoutConcurrencyRecord(plan.concurrency) } });
+    });
+  }
+
+  /** One round of a bounded loop. The node stays `running` across rounds — the
+   *  service refuses a child whose caller node is not live — and settles only
+   *  when `continueWhile` stops asking or the bound runs out. Exhaustion routes
+   *  through the `exhausted` port rather than failing the run, so what happens
+   *  after N is whatever the author wired there. */
+  private async reconcileIteration(run: WorkflowRunDetail, node: WorkflowCallNode): Promise<void> {
+    const children = callChildren(run, node.id);
+    if (children.some((child) => !childTerminal(child))) return;
+    const at = this.now();
+    let step: IterationStep;
+    try {
+      step = iterationStep(run, node, children);
+    } catch (error) { this.failRun(run, error, node.id); return; }
+    if (step.kind === "settle") {
+      this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.setNodeStatus(node.id, "completed", { output: step.output, endedAt: at });
+      });
+      this.changed(run);
+      return;
+    }
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setNodeStatus(node.id, "running", {
+        resolvedConfig: { workflowId: step.workflowId, round: step.round, maxRounds: iterationSettings(node).maxRounds },
+        ...(nodeRun(run, node.id).startedAt ? {} : { startedAt: at }),
+      });
+    });
+    try {
+      await this.options.callWorkflow({
+        workflowId: step.workflowId,
+        caller: { workflowId: run.workflowId, runId: run.id, nodeId: node.id },
+        input: step.input,
+        idempotencyKey: `${run.id}:${node.id}:${step.round}`,
+        itemIndex: step.round - 1,
+      });
+    } catch (error) {
+      const current = this.detail(run.workflowId, run.id);
+      if (!current.cancelRequestedAt && !["completed", "failed", "cancelled"].includes(current.status)) {
+        this.failRun(current, error, node.id);
+      }
+      return;
+    }
+    this.changed(run);
+  }
+
+  private async reconcileFanout(run: WorkflowRunDetail, node: WorkflowCallNode): Promise<void> {
+    const children = callChildren(run, node.id)
+      .filter((child): child is WorkflowFanoutChildSummary => child.itemIndex !== undefined);
+    const active = children.filter((child) => !childTerminal(child)).length;
+    const plan = fanoutPlan(run, node, this.options.activeEngineSessions, active);
+    const runtime = nodeRun(run, node.id);
+    if (runtime.status === "pending") {
+      const at = this.now();
+      this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.setNodeStatus(node.id, "running", {
+          resolvedConfig: { workflowId: plan.workflowId, total: plan.items.length, ...fanoutConcurrencyRecord(plan.concurrency) },
+          startedAt: at,
+        });
+      });
+      this.changed(run);
+      return;
+    }
+
+    validateFanoutChildren(node, plan, children);
+    if (children.length === plan.items.length && children.every(childTerminal)) {
+      const at = this.now();
+      this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.setNodeStatus(node.id, "completed", { output: fanoutOutput(children), endedAt: at });
+      });
+      this.changed(run);
+      return;
+    }
+
+    this.recordFanoutWidth(run, node, runtime, plan);
+    const started = new Set(children.map((child) => child.itemIndex));
+    const indexes = plan.items.map((_, index) => index).filter((index) => !started.has(index));
+    const capacity = Math.max(0, plan.concurrency.effective - active);
+    try {
+      for (const index of indexes.slice(0, capacity)) {
+        const input = fanoutInput(run, node, plan, index);
+        let todoId: string | undefined;
+        if (node.config.input && Object.hasOwn(node.config.input, "todoId")) {
+          const mappedTodoId = input.todoId;
+          if (typeof mappedTodoId !== "string" || !TODO_ID_PATTERN.test(mappedTodoId)) {
+            throw new Error(`Workflow Call ${node.id} todoId must resolve to a Todo id matching AAA-123.`);
+          }
+          todoId = mappedTodoId;
+        }
+        await this.options.callWorkflow({
+          workflowId: plan.workflowId,
+          caller: { workflowId: run.workflowId, runId: run.id, nodeId: node.id },
+          input,
+          idempotencyKey: `${run.id}:${node.id}:${index}`,
+          itemIndex: index,
+          ...(todoId === undefined ? {} : { todoId }),
+        });
+      }
+    } catch (error) {
+      const current = this.detail(run.workflowId, run.id);
+      if (!current.cancelRequestedAt && !["completed", "failed", "cancelled"].includes(current.status)) {
+        this.failRun(current, error, node.id);
+      }
+      return;
+    }
+    if (capacity > 0 && indexes.length > 0) this.changed(run);
+  }
+
+  /** Mirror a parked gate onto the run's bound Todo (Gap 2: the operator picks
+   *  and approves from Todos), then wake its routed employee when it has one.
+   *  Best-effort — neither a mirror nor a notification failure may fail a run
+   *  whose gate is already parked and decidable through the workflow API.
+   *  Reached only from the transition INTO parked, so an employee notification
+   *  fires once per gate rather than on every recovery sweep. */
+  private mirrorApproval(run: WorkflowRunDetail, node: ApprovalNode, approver: string | undefined): void {
+    const todoId = run.trigger.todoId;
+    if (!todoId || !this.options.todoApprovals) return;
+    const ref = todoApprovalRef(run, node.id);
+    const request = approvalDescription(run, node);
+    try {
+      this.options.todoApprovals.request({ todoId, request, ref,
+        ...(node.config.options ? { options: node.config.options } : {}),
+        ...(approver ? { approver } : {}) });
+    } catch { /* the workflow-side gate stands on its own */ }
+    try {
+      this.options.todoApprovals.notifyParked({ todoId, workflowId: run.workflowId, runId: run.id,
+        nodeId: node.id, request, ref });
+    } catch (error) {
+      logger.warn(`Workflow run ${run.id} could not notify the approver of parked gate ${node.id}: `
+        + `${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /** Reflect the run's own lifecycle onto its bound Todo. The platform owes the
+   *  board this: until now the ONLY reason a bound Todo moved was an author
+   *  hand-writing `update_work_item` into a phase prompt, so one forgotten
+   *  instruction left a merged Todo reading `assigned`. Best-effort — the Todo
+   *  may have been closed or deleted since the run started. */
+  private reflect(run: WorkflowRunDetail, status: WorkflowRunReflection, nodeId: string): void {
+    const todoId = run.trigger.todoId;
+    if (!todoId || !this.options.todoLifecycle) return;
+    try {
+      this.options.todoLifecycle.reflect({ todoId, status, workflowId: run.workflowId, runId: run.id, nodeId });
+    } catch (error) {
+      logger.warn(`Workflow run ${run.id} could not reflect ${status} onto Todo ${todoId}: `
+        + `${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /** A run that settles failed leaves an honest trace: `blocked`, plus which
+   *  node died and why. Both halves so an author needs neither a status
+   *  instruction in a prompt nor a record-failure node in the graph. */
+  private reflectFailure(run: WorkflowRunDetail, nodeId: string, error: WorkflowError): void {
+    this.reflect(run, "blocked", nodeId);
+    const todoId = run.trigger.todoId;
+    if (!todoId || !this.options.todoLifecycle) return;
+    try {
+      this.options.todoLifecycle.recordFailure({ todoId, workflowId: run.workflowId, runId: run.id, nodeId, error });
+    } catch (recordError) {
+      logger.warn(`Workflow run ${run.id} could not record its failure onto Todo ${todoId}: `
+        + `${recordError instanceof Error ? recordError.message : String(recordError)}`);
+    }
+  }
+
+  /** Hand a rejection's feedback to the bound Todo so the work goes round again.
+   *  Best-effort like every other Todo-side write from a run: the run has already
+   *  stopped, and a Todo closed or deleted mid-run must not throw from here. */
+  private requestRevision(run: WorkflowRunDetail, nodeId: string, feedback: string, decidedBy: string): void {
+    const todoId = run.trigger.todoId;
+    if (!todoId || !this.options.todoLifecycle) return;
+    try {
+      this.options.todoLifecycle.requestRevision({ todoId, workflowId: run.workflowId, runId: run.id,
+        nodeId, feedback, decidedBy, rearm: this.rearmTarget(run.workflowId) });
+    } catch (error) {
+      logger.warn(`Workflow run ${run.id} could not send Todo ${todoId} round again: `
+        + `${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private rearmTarget(workflowId: string): WorkflowRearmTarget {
+    return resolveRearmTarget(this.options.repository.getDefinition(workflowId), workflowId);
+  }
+
+  /** Attribute a phase session to the run's bound Todo, so the Todo's derived
+   *  spend covers what the pipeline cost — it sums `total_cost` over its linked
+   *  sessions, and until now a run's phases were linked to nothing. Best-effort:
+   *  the attempt is already dispatched and the Todo may have been deleted since
+   *  the run started, so a failure is logged rather than failing the run. */
+  private attributeSession(run: WorkflowRunDetail, sessionId: string): void {
+    const todoId = run.trigger.todoId;
+    if (!todoId || !this.options.todoSessions) return;
+    try {
+      this.options.todoSessions.link({ todoId, sessionId });
+    } catch (error) {
+      logger.warn(`Workflow run ${run.id} could not attribute session ${sessionId} to Todo ${todoId}: `
+        + `${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async dispatch(run: WorkflowRunDetail, node: EmployeeNode, config: ResolvedEmployeeConfig): Promise<void> {
+    const at = this.now();
+    const promptText = composeEmployeePrompt(run, node, Boolean(config.continuedFrom));
+    const firstPhase = run.attempts.length === 0;
+    const attempt = this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setNodeStatus(node.id, "dispatching", { resolvedConfig: config as unknown as Record<string, JsonValue>,
+        input: inputFor(run, node.id), startedAt: at });
+      return tx.createAttempt({ nodeId: node.id, resolvedConfig: config, input: inputFor(run, node.id), promptText });
+    });
+    // The run's first attempt going out is the moment work starts. Later phases do
+    // not re-assert it: a phase that deliberately moved the Todo somewhere more
+    // informative keeps that status for the rest of the run.
+    if (firstPhase) this.reflect(run, "executing", node.id);
+    this.changed(run);
+    await this.sendAttempt(run, node.id, attempt.attempt);
+  }
+
+  /** Hand a created attempt to the executor, settling it as a dispatch failure if the executor refuses it. */
+  private async sendAttempt(run: WorkflowRunDetail, nodeId: string, attemptNumber: number): Promise<void> {
+    try {
+      await this.recoverDispatching(run.workflowId, run.id, nodeId, attemptNumber);
+    } catch (error) {
+      const current = this.detail(run.workflowId, run.id);
+      const stored = current.attempts.find((item) => item.nodeId === nodeId && item.attempt === attemptNumber)!;
+      this.settleFailure(current, stored, dispatchFailure(error, nodeId, attemptNumber), "failed", this.now());
+    }
+  }
+
+  private async finish(run: WorkflowRunDetail): Promise<boolean> {
+    const active = run.nodeRuns.some((node) => node.activated && !terminalNode(node));
+    if (active || !reachedSuccessEnd(run) || run.status !== "running") return false;
+    const endedAt = this.now();
+    // Arriving at a success End is not the same as having landed. An End that
+    // declared what its landing had to produce settles the run FAILED when that
+    // cannot be shown, so the bound Todo reads blocked with the reason rather
+    // than done over work that never left its branch.
+    const shortfall = await landingShortfall(run, this.options.landingEvidence);
+    if (shortfall) {
+      const error: WorkflowError = { code: "workflow-landing-unverified", message: shortfall.reason,
+        retryable: false, nodeId: shortfall.nodeId };
+      this.options.repository.mutateRun(run.id, run.revision, (tx) => tx.setRunStatus("failed", { endedAt, error }));
+      this.reflectFailure(run, shortfall.nodeId, error);
+      this.changed(run);
+      return true;
+    }
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => tx.setRunStatus("completed", { endedAt }));
+    completeBoundTodo(this.options.todoLifecycle, run);
+    this.changed(run);
+    return true;
+  }
+
+  private advance(workflowId: string, runId: string): Promise<WorkflowRunDetail> {
+    const previous = this.advances.get(runId) ?? Promise.resolve(this.detail(workflowId, runId));
+    const current = previous.catch(() => this.detail(workflowId, runId))
+      .then(() => this.advanceNow(workflowId, runId));
+    this.advances.set(runId, current);
+    const clear = () => { if (this.advances.get(runId) === current) this.advances.delete(runId); };
+    void current.then(clear, clear);
+    return current;
+  }
+
+  private async advanceNow(workflowId: string, runId: string): Promise<WorkflowRunDetail> {
+    const definition = this.detail(workflowId, runId).definition;
+    const max = definition.nodes.length * 4 + 4
+      + definition.nodes.reduce((budget, node) => budget
+        + (node.type === "workflow-call" ? 100 * (node.config.iterate?.maxRounds ?? 1) : 0), 0);
+    for (let index = 0; index < max; index += 1) {
+      const run = this.detail(workflowId, runId);
+      if (["completed", "failed", "cancelled"].includes(run.status)) return run;
+      if (run.cancelRequestedAt) return run;
+      const action = this.nextAction(run);
+      if (!action) {
+        recordMutexWaits(this.options.repository, run);
+        if (await this.finish(run)) continue;
+        return this.detail(workflowId, runId);
+      }
+      if (action.kind === "dispatch") await this.dispatch(run, action.node, action.config);
+      else if (action.kind === "fanout") await this.reconcileFanout(run, action.node);
+      else if (action.kind === "iterate") await this.reconcileIteration(run, action.node);
+      else this.applyInline(run, action);
+    }
+    return this.failRun(this.detail(workflowId, runId), new Error("Workflow control flow did not settle."));
+  }
+
+  async advanceCaller(workflowId: string, runId: string, nodeId: string): Promise<boolean> {
+    const run = this.detail(workflowId, runId);
+    const authored = run.definition.nodes.find((node) => node.id === nodeId);
+    const runtime = run.nodeRuns.find((node) => node.nodeId === nodeId);
+    if (authored?.type !== "workflow-call" || !runtime?.activated || terminalNode(runtime)
+      || run.cancelRequestedAt || ["completed", "failed", "cancelled"].includes(run.status)) return false;
+    await this.advance(workflowId, runId);
+    return true;
+  }
+
+  async resumeWait(workflowId: string, runId: string, nodeId: string, now: string): Promise<boolean> {
+    const run = this.detail(workflowId, runId);
+    const runtime = nodeRun(run, nodeId);
+    const authored = run.definition.nodes.find((node) => node.id === nodeId);
+    const resumableEmployee = authored?.type === "employee" && runtime.status === "waiting";
+    if (run.status !== "waiting" || (authored?.type !== "wait" && !resumableEmployee)
+      || runtime.status !== "waiting" || !runtime.resumeAt || runtime.resumeAt > now) return false;
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      if (resumableEmployee) tx.setNodeStatus(nodeId, "pending", { activated: true });
+      else tx.setNodeStatus(nodeId, "completed", { output: waitDueOutput(authored), endedAt: now });
+      tx.setRunStatus("running");
+    });
+    this.changed(run);
+    await this.advance(workflowId, runId);
+    return true;
+  }
+
+  /** Resume a `todo-comment` Wait early, because the operator answered. The
+   *  comment is not claimed: every run parked on that Todo resumes from it, and
+   *  a re-sweep is a no-op because the node is no longer `waiting`. */
+  async resumeCommentWait(workflowId: string, runId: string, nodeId: string,
+    comment: { id: string; body: string; attachments: ReadonlyArray<{ id: string; mime: string }> }, now: string,
+  ): Promise<boolean> {
+    const run = this.detail(workflowId, runId);
+    const runtime = nodeRun(run, nodeId);
+    const authored = run.definition.nodes.find((node) => node.id === nodeId);
+    const todoId = run.trigger.todoId;
+    if (!todoId || run.status !== "waiting" || authored?.type !== "wait" || authored.config.mode !== "todo-comment"
+      || runtime.status !== "waiting") return false;
+    const output = commentReplyOutput(todoId, comment);
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setNodeStatus(nodeId, "completed", { endedAt: now, output });
+      tx.setRunStatus("running");
+    });
+    this.changed(run);
+    await this.advance(workflowId, runId);
+    return true;
+  }
+
+  async recoverDispatching(workflowId: string, runId: string, nodeId: string, attemptNumber: number): Promise<boolean> {
+    const run = this.detail(workflowId, runId);
+    const attempt = run.attempts.find((item) => item.nodeId === nodeId && item.attempt === attemptNumber);
+    const node = run.definition.nodes.find((item): item is EmployeeNode => item.id === nodeId && item.type === "employee");
+    if (!attempt || attempt.status !== "dispatching" || !node) return false;
+    // Prefer the prompt persisted at attempt creation so the session receives
+    // exactly what the run detail shows; recompose only for attempts that
+    // predate the column.
+    const config = attempt.resolvedConfig;
+    const prompt = attempt.promptText ?? composeEmployeePrompt(run, node, Boolean(config.continuedFrom));
+    const { sessionId } = await this.options.executor.startAttempt({ owner: { workflowId, runId, nodeId, attempt: attemptNumber },
+      employeeId: config.employeeId, engine: config.engine, ...(config.model ? { model: config.model } : {}),
+      ...(config.effort ? { effort: config.effort } : {}), prompt,
+      ...(config.continuedFrom ? { continueFrom: { engine: config.engine, engineSessionId: config.continuedFrom.engineSessionId, sourceSessionId: config.continuedFrom.sessionId } } : {}) });
+    const current = this.detail(workflowId, runId);
+    this.options.repository.mutateRun(runId, current.revision, (tx) => {
+      tx.settleAttempt(nodeId, attemptNumber, { status: "running", sessionId });
+      tx.setNodeStatus(nodeId, "running");
+    });
+    this.attributeSession(current, sessionId);
+    openTodoRun(this.options.todoSessions, current, sessionId, this.now());
+    this.changed(current);
+    return true;
+  }
+
+  async timeoutAttempt(workflowId: string, runId: string, nodeId: string, attemptNumber: number, at: string): Promise<boolean> {
+    const run = this.detail(workflowId, runId);
+    const attempt = run.attempts.find((item) => item.nodeId === nodeId && item.attempt === attemptNumber);
+    if (!attempt || attempt.status !== "running") return false;
+    this.settleFailure(run, attempt, { code: "workflow-timeout", message: "Workflow attempt timed out.", retryable: true, nodeId, attempt: attemptNumber }, "timed-out", at);
+    return true;
+  }
+
+  async retryNode(workflowId: string, runId: string, nodeId: string, idempotencyKey: string): Promise<WorkflowRunDetail> {
+    const run = this.detail(workflowId, runId);
+    const replay = this.options.repository.findAttemptByRetryKey(run.id, idempotencyKey);
+    if (replay) return this.detail(workflowId, runId);
+    const latest = run.attempts.filter((attempt) => attempt.nodeId === nodeId).at(-1);
+    const authored = run.definition.nodes.find((item): item is EmployeeNode => item.id === nodeId && item.type === "employee");
+    if (!latest || !authored) throw new Error(`Workflow Employee ${nodeId} has no retryable attempt.`);
+    const resolvedConfig = resolveDispatch(run, authored, this.options); // ICI-733: resolved fresh, never copied off the attempt that just failed.
+    const promptText = composeEmployeePrompt(run, authored, Boolean(resolvedConfig.continuedFrom));
+    try {
+      this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.setNodeStatus(nodeId, "dispatching", { activated: true });
+        tx.setRunStatus("running");
+        tx.createAttempt({ nodeId, resolvedConfig, input: latest.input, promptText, retryIdempotencyKey: idempotencyKey });
+      });
+    } catch (error) {
+      const claimed = this.options.repository.findAttemptByRetryKey(run.id, idempotencyKey);
+      if (claimed?.nodeId === nodeId && error instanceof WorkflowRepositoryError
+        && error.code === "revision-conflict") return this.detail(workflowId, runId);
+      throw error;
+    }
+    this.changed(run);
+    const attempt = this.options.repository.findAttemptByRetryKey(run.id, idempotencyKey)!;
+    await this.recoverDispatching(workflowId, runId, nodeId, attempt.attempt);
+    return this.detail(workflowId, runId);
+  }
+
+  async decideApproval(input: {
+    workflowId: string; runId: string; nodeId: string; decision: "approve" | "reject";
+    decidedBy: string; reason?: string; choice?: string; expectedRevision: number;
+  }): Promise<WorkflowRunDetail> {
+    const run = this.detail(input.workflowId, input.runId);
+    const at = this.now();
+    const status = input.decision === "approve" ? "approved" : "rejected";
+    // A rejection that carries a note is not "no", it is "not yet — do it again
+    // with this". The graph's `rejected` route encodes what "no" means (in
+    // practice, an End that abandons the work), so it is deliberately NOT taken:
+    // this run stops here and the bound Todo goes round again carrying the note.
+    // Silence still means stop, and takes the authored route exactly as before.
+    const note = input.reason?.trim();
+    const feedback = input.decision === "reject" ? note ?? "" : "";
+    const revising: WorkflowError | undefined = feedback && run.trigger.todoId && this.options.todoLifecycle
+      ? { code: "workflow-revision-requested", nodeId: input.nodeId, retryable: false,
+          message: `Workflow approval ${input.nodeId} was rejected with feedback; the Todo goes round again.` }
+      : undefined;
+    const routed = !revising
+      && run.definition.edges.some((edge) => edge.from.nodeId === input.nodeId && edge.from.port === status);
+    const missingRoute: WorkflowError = { code: "workflow-approval-route-missing", message: `Workflow approval ${input.nodeId} has no ${status} route.`, retryable: false, nodeId: input.nodeId };
+    const gateOutput = { text: input.choice ?? "", fields: { port: status, ...(note ? { reason: note } : {}) }, ...(input.choice !== undefined ? { choice: input.choice } : {}) };
+    this.options.repository.mutateRun(run.id, input.expectedRevision, (tx) => {
+      const pending = run.approvals.find((approval) => approval.nodeId === input.nodeId)!;
+      tx.putApproval({ nodeId: pending.nodeId, requestedAt: pending.requestedAt,
+        ...(pending.approverRef ? { approverRef: pending.approverRef } : {}), status,
+        decidedAt: at, decidedBy: input.decidedBy, decision: input.decision,
+        ...(input.reason !== undefined ? { reason: input.reason } : {}) });
+      if (revising) {
+        // The gate was decided, not broken — `completed` on its `rejected` port.
+        // The run is `cancelled`, not `failed`: a human stopped it on purpose, and
+        // a failed run would reflect `blocked` onto the very Todo being re-armed.
+        tx.setNodeStatus(input.nodeId, "completed", { output: gateOutput, endedAt: at });
+        tx.setRunStatus("cancelled", { cancelRequestedAt: at, endedAt: at, error: revising });
+      } else if (routed) {
+        tx.setNodeStatus(input.nodeId, "completed", { output: gateOutput, endedAt: at });
+        tx.setRunStatus("running");
+      } else {
+        tx.setNodeStatus(input.nodeId, "failed", { error: missingRoute, endedAt: at });
+        tx.setRunStatus("failed", { error: missingRoute, endedAt: at });
+      }
+    });
+    const todoId = run.trigger.todoId;
+    if (todoId && this.options.todoLifecycle) {
+      try {
+        this.options.todoLifecycle.recordApprovalDecision({
+          todoId, workflowId: run.workflowId, runId: run.id, nodeId: input.nodeId,
+          decision: input.decision, decidedBy: input.decidedBy,
+          ...(input.choice !== undefined ? { choice: input.choice } : {}),
+          ...(note ? { note } : {}),
+        });
+      } catch (error) {
+        logger.warn(`Workflow run ${run.id} could not record gate ${input.nodeId} decision onto Todo ${todoId}: `
+          + `${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    this.changed(run);
+    if (revising) {
+      this.requestRevision(run, input.nodeId, feedback, input.decidedBy);
+      return this.detail(input.workflowId, input.runId);
+    }
+    // An unrouted decision ends the run, so the bound Todo owes the same honest
+    // trace as any other failure — without this it kept reading `in_review`
+    // while the run behind it was already dead.
+    if (!routed) this.reflectFailure(run, input.nodeId, missingRoute);
+    return routed ? this.advance(input.workflowId, input.runId) : this.detail(input.workflowId, input.runId);
+  }
+
+  private settleFailure(run: WorkflowRunDetail, attempt: typeof run.attempts[number], error: WorkflowError,
+    status: "failed" | "timed-out" | "cancelled", endedAt: string, processedTurn?: number, handoff?: unknown): boolean {
+    // `error.retryable` is what decides this, not the attempt counter alone. A node's retry budget exists for
+    // attempts that never landed; spending it on an employee that ran and reported failure pays twice for a verdict
+    // that was already reached, and can override a phase that deliberately refused. A substitution spends none of it:
+    // the budget governs asking the SAME engine again, and an engine with no allowance left never answered at all.
+    // A gateway restart is not one of this node's attempts at the work, so the replacements it forced are discounted first.
+    const retry = (error.retryable && attempt.attempt - restartsOn(run, attempt.nodeId) < attempt.resolvedConfig.retry.attempts)
+      || hasSubstitute(run, attempt, error, this.options);
+    const routed = !retry && run.definition.edges.some((edge) => edge.from.nodeId === attempt.nodeId && edge.from.port === "error");
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      if (processedTurn !== undefined) {
+        tx.setAttemptReminder(attempt.nodeId, attempt.attempt, { lastProcessedTurn: processedTurn });
+      }
+      tx.settleAttempt(attempt.nodeId, attempt.attempt, { status,
+        ...(attempt.sessionId ? { sessionId: attempt.sessionId } : {}), error, endedAt });
+      if (retry) {
+        const factor = attempt.resolvedConfig.retry.backoff === "exponential" ? 2 ** (attempt.attempt - 1) : 1;
+        const resumeAt = new Date(Date.parse(endedAt)
+          + Math.min(600, attempt.resolvedConfig.retry.delaySeconds * factor) * 1000).toISOString();
+        tx.setNodeStatus(attempt.nodeId, "waiting", { error, resumeAt, endedAt });
+        tx.setRunStatus("waiting");
+      } else {
+        tx.setNodeStatus(attempt.nodeId, "failed", { error, endedAt });
+        if (routed) tx.setRunStatus("running");
+        else tx.setRunStatus("failed", { error, endedAt });
+      }
+    });
+    // A routed error edge keeps the run alive, so the Todo is not blocked yet —
+    // whatever that branch reaches decides.
+    if (!retry && !routed) this.reflectFailure(run, attempt.nodeId, error);
+    // The ATTEMPT is over either way: a retry opens a fresh row on the next
+    // dispatch and this one's evidence is what that retry gets to read.
+    settleTodoRun(this.options.todoSessions, run, attempt, { status, endedAt, error, handoff });
+    // A retry keeps the node live, and with it its mutex key: the node is still working the same
+    // critical section, so handing the key on mid-backoff puts two of them in there when it ends.
+    if (!retry) wakeMutexWaiters(this.options.repository, run, attempt.nodeId, (id, item) => this.advance(id, item));
+    this.changed(run);
+    return routed;
+  }
+
+  private activeRunForAttempt(attempt: WorkflowRunDetail["attempts"][number]): WorkflowRunDetail {
+    const record = this.options.repository.listRecoverableRuns().find((candidate) => candidate.id === attempt.runId);
+    if (!record) {
+      throw new WorkflowRepositoryError("corrupt-record", `Workflow attempt ${attempt.nodeId}:${attempt.attempt} has no active run.`);
+    }
+    return this.detail(record.workflowId, record.id);
+  }
+
+  private alreadySubmitted(sessionId: string): never {
+    throw new WorkflowRepositoryError("already-submitted", `Workflow attempt session ${sessionId} already submitted.`);
+  }
+
+  async remindDueAttempts(now: string): Promise<void> {
+    await remindDueAttempts(now, {
+      repository: this.options.repository,
+      executor: this.options.executor,
+      activeRun: (attempt) => this.activeRunForAttempt(attempt),
+      changed: (run) => this.changed(run),
+    });
+  }
+
+  /**
+   * The immediate half of the same problem the ladder solves on a timer: a turn
+   * that ended on narration decided nothing, and the first rung is five minutes
+   * away. Nudging inline costs nothing and usually ends the step right here.
+   *
+   * The nudge is itself a turn, so its own end re-enters `complete()`; the
+   * persisted count is what bounds the loop. A dispatch that cannot be claimed
+   * (the session took a message in the meantime) is not a failure worth
+   * propagating: the caller falls back to arming the ordinary rung.
+   */
+  private async stopNudge(run: WorkflowRunDetail, attempt: WorkflowRunDetail["attempts"][number],
+    event: WorkflowAttemptCompletion): Promise<boolean> {
+    if (!planStopNudge({ finalText: event.finalText ?? "", stopNudgesSent: attempt.stopNudgesSent })) return false;
+    try {
+      await this.options.executor.remind({ sessionId: event.sessionId, text: STOP_NUDGE_TEXT });
+    } catch (error) {
+      logger.warn(`Workflow attempt ${attempt.nodeId}:${attempt.attempt} could not be nudged to submit: `
+        + `${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setAttemptReminder(attempt.nodeId, attempt.attempt, {
+        stopNudgesSent: attempt.stopNudgesSent + 1,
+        lastProcessedTurn: event.turn,
+      });
+    });
+    this.changed(run);
+    return true;
+  }
+
+  async submit(input: {
+    sessionId: string;
+    outcome?: "success" | "failure";
+    fields?: unknown;
+    summary?: string;
+  }): Promise<WorkflowRunDetail> {
+    const attempt = this.options.repository.findAttemptBySessionId(input.sessionId);
+    if (!attempt) {
+      throw new WorkflowRepositoryError("not-found", `Workflow attempt session ${input.sessionId} was not found.`);
+    }
+    if (attempt.status !== "running") this.alreadySubmitted(input.sessionId);
+    const run = this.activeRunForAttempt(attempt);
+    const node = run.definition.nodes.find((candidate): candidate is EmployeeNode =>
+      candidate.id === attempt.nodeId && candidate.type === "employee");
+    if (!node) throw new WorkflowRepositoryError("corrupt-record", `Workflow attempt ${attempt.nodeId} has no Employee node.`);
+    if (input.outcome === "failure") {
+      const error: WorkflowError = {
+        code: "workflow-submitted-failure",
+        // The employee ran and reported failure. That is a verdict, not a dropped
+        // attempt: re-dispatching it spends again on a decision already made, and
+        // has overridden a phase that stopped on purpose.
+        message: input.summary ?? "Step reported failure.",
+        retryable: false,
+        nodeId: attempt.nodeId,
+        attempt: attempt.attempt,
+      };
+      const routed = this.settleFailure(run, attempt, error, "failed", this.now(), undefined, input.fields);
+      return routed ? this.advance(run.workflowId, run.id) : this.detail(run.workflowId, run.id);
+    }
+    const fields = validateSubmittedFields(input.fields, node.config.output);
+    const output: WorkflowNodeOutput = {
+      text: input.summary ?? "",
+      fields,
+      employeeId: attempt.resolvedConfig.employeeId,
+      engine: attempt.resolvedConfig.engine,
+      ...(attempt.resolvedConfig.model ? { model: attempt.resolvedConfig.model } : {}),
+      sessionId: input.sessionId,
+    };
+    try {
+      this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+        tx.settleAttempt(attempt.nodeId, attempt.attempt, {
+          status: "completed",
+          sessionId: input.sessionId,
+          output,
+          endedAt: this.now(),
+        });
+        tx.setNodeStatus(attempt.nodeId, "completed", { output, endedAt: this.now() });
+      });
+    } catch (error) {
+      if (error instanceof WorkflowRepositoryError && error.code === "revision-conflict"
+        && this.options.repository.findAttemptBySessionId(input.sessionId)?.status !== "running") {
+        this.alreadySubmitted(input.sessionId);
+      }
+      throw error;
+    }
+    settleTodoRun(this.options.todoSessions, run, attempt, { status: "completed", endedAt: this.now(), output });
+    this.changed(run);
+    return this.advance(run.workflowId, run.id);
+  }
+
+  async extend(input: { sessionId: string; reason?: string }): Promise<void> {
+    const attempt = this.options.repository.findAttemptBySessionId(input.sessionId);
+    if (!attempt) {
+      throw new WorkflowRepositoryError("not-found", `Workflow attempt session ${input.sessionId} was not found.`);
+    }
+    if (attempt.status !== "running") this.alreadySubmitted(input.sessionId);
+    const run = this.activeRunForAttempt(attempt);
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setAttemptReminder(attempt.nodeId, attempt.attempt, {
+        remindersSent: 0,
+        nextReminderAt: null,
+        extensions: attempt.extensions + 1,
+        lastExtensionReason: input.reason ?? null,
+        pendingOutputError: null,
+      });
+    });
+    this.changed(run);
+  }
+
+  async complete(event: WorkflowAttemptCompletion): Promise<boolean> {
+    const attempt = this.options.repository.findAttemptBySessionId(event.sessionId);
+    if (!attempt || attempt.status !== "running" || event.terminalVersion < 1
+      || !Number.isInteger(event.turn) || event.turn < 1 || event.turn <= attempt.lastProcessedTurn) return false;
+    const run = this.detail(event.owner.workflowId, event.owner.runId);
+    if (attempt.runId !== run.id || attempt.nodeId !== event.owner.nodeId || attempt.attempt !== event.owner.attempt) return false;
+    const node = run.definition.nodes.find((candidate): candidate is EmployeeNode => candidate.id === attempt.nodeId && candidate.type === "employee");
+    if (!node) return false;
+    const cancellation = event.outcome === "interrupted" && run.cancelRequestedAt
+      ? { code: "workflow-cancelled", message: event.error ?? "Workflow run cancelled.", retryable: false, nodeId: attempt.nodeId, attempt: attempt.attempt } satisfies WorkflowError : undefined;
+    const userMessageTurnEnd = event.outcome === "interrupted"
+      && event.interruptionCause === "user-message"
+      && !run.cancelRequestedAt;
+    const cleanTurnEnd = event.outcome === "succeeded" || userMessageTurnEnd;
+    let output: WorkflowNodeOutput | undefined;
+    let failure: WorkflowError | undefined;
+    let pendingOutputError: string | undefined;
+    if (event.outcome === "succeeded") {
+      const finalText = event.finalText ?? "";
+      if (hasWorkflowOutputBlock(finalText)) {
+        try {
+          output = { ...parseWorkflowOutput(finalText, node.config.output), employeeId: attempt.resolvedConfig.employeeId,
+            engine: attempt.resolvedConfig.engine, ...(attempt.resolvedConfig.model ? { model: attempt.resolvedConfig.model } : {}), sessionId: event.sessionId };
+        } catch (error) {
+          if (error instanceof WorkflowOutputError) pendingOutputError = error.message;
+          else failure = workflowError(error, attempt.nodeId, attempt.attempt);
+        }
+      }
+    } else if (!userMessageTurnEnd) {
+      failure = event.outcome === "interrupted"
+        ? interruptedAttemptFailure(event.error ?? "Workflow attempt was interrupted.", attempt.nodeId, attempt.attempt, event.interruptionCause)
+        : workflowError(event.error ?? `Workflow attempt was ${event.outcome}.`, attempt.nodeId, attempt.attempt);
+    }
+    const endedAt = event.completedAt;
+    if (cleanTurnEnd && !output && !failure) {
+      // An unparseable block already earns its own targeted reminder, so telling
+      // that turn it ended on narration would simply be untrue.
+      if (!pendingOutputError && await this.stopNudge(run, attempt, event)) return true;
+      if (attempt.remindersSent < REMINDER_RUNGS_MINUTES.length) {
+        this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+          tx.setAttemptReminder(attempt.nodeId, attempt.attempt, {
+            nextReminderAt: addMinutes(endedAt, REMINDER_RUNGS_MINUTES[attempt.remindersSent]!),
+            ...(pendingOutputError ? { pendingOutputError } : {}),
+            lastProcessedTurn: event.turn,
+          });
+        });
+        this.changed(run);
+        return true;
+      }
+      const state = this.options.executor.attemptState(event.sessionId);
+      if ((state?.runningChildren ?? 0) > 0) return true;
+      const noOutput: WorkflowError = { code: "workflow-no-output", message: "Workflow attempt ended without submitting output.", retryable: true, nodeId: attempt.nodeId, attempt: attempt.attempt };
+      const routed = this.settleFailure(run, attempt, noOutput, "failed", endedAt, event.turn);
+      if (routed) await this.advance(run.workflowId, run.id);
+      return true;
+    }
+    if (!output && !cancellation) {
+      const replacement = failure!.code === RESTART_INTERRUPTED
+        ? openRestartReplacement({ ...this.options, prompt: (continued) => composeEmployeePrompt(run, node, continued) },
+          run, attempt, failure!, event) : null;
+      if (replacement !== null) { this.changed(run); await this.sendAttempt(run, attempt.nodeId, replacement); return true; }
+      const routed = this.settleFailure(run, attempt, failure!.code === RESTART_INTERRUPTED
+        ? restartExhaustedFailure(attempt.nodeId, attempt.attempt, restartsOn(run, attempt.nodeId) + 1) : failure!,
+        event.outcome === "interrupted" ? "cancelled" : "failed", endedAt, event.turn);
+      if (routed) await this.advance(run.workflowId, run.id);
+      return true;
+    }
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      tx.setAttemptReminder(attempt.nodeId, attempt.attempt, { lastProcessedTurn: event.turn });
+      if (cancellation) {
+        tx.settleAttempt(attempt.nodeId, attempt.attempt, { status: "cancelled", sessionId: event.sessionId, error: cancellation, endedAt });
+        tx.setNodeStatus(attempt.nodeId, "cancelled", { error: cancellation, endedAt });
+        // A cancel the gateway died inside of has no drain left to finish it, so the last node going terminal settles the run itself.
+        if (!run.nodeRuns.some((item) => item.nodeId !== attempt.nodeId && item.activated && !terminalNode(item))) tx.setRunStatus("cancelled", { endedAt });
+      } else if (output) {
+        tx.settleAttempt(attempt.nodeId, attempt.attempt, { status: "completed", sessionId: event.sessionId, output, endedAt });
+        tx.setNodeStatus(attempt.nodeId, "completed", { output, endedAt });
+      }
+    });
+    if (cancellation) settleTodoRun(this.options.todoSessions, run, attempt, { status: "cancelled", endedAt, error: cancellation });
+    else if (output) settleTodoRun(this.options.todoSessions, run, attempt, { status: "completed", endedAt, output });
+    wakeMutexWaiters(this.options.repository, run, attempt.nodeId, (id, item) => this.advance(id, item));
+    this.changed(run);
+    if (output && !cancellation) await this.advance(run.workflowId, run.id);
+    return true;
+  }
+}

--- a/packages/jimmy/src/workflows/runtime.ts
+++ b/packages/jimmy/src/workflows/runtime.ts
@@ -1,0 +1,143 @@
+import type { JsonValue, WorkflowDefinition, WorkflowNode, WorkflowNodeOutput } from './model.js';
+
+export const WORKFLOW_RUN_STATUSES = ['pending', 'running', 'waiting', 'completed', 'failed', 'cancelled'] as const;
+export const WORKFLOW_NODE_RUN_STATUSES = [
+  'pending', 'ready', 'dispatching', 'running', 'waiting', 'completed', 'failed', 'skipped', 'cancelled',
+] as const;
+export const WORKFLOW_ATTEMPT_STATUSES = [
+  'dispatching', 'running', 'completed', 'failed', 'timed-out', 'cancelled',
+] as const;
+
+export type WorkflowRunStatus = typeof WORKFLOW_RUN_STATUSES[number];
+export type WorkflowNodeRunStatus = typeof WORKFLOW_NODE_RUN_STATUSES[number];
+export type WorkflowAttemptStatus = typeof WORKFLOW_ATTEMPT_STATUSES[number];
+
+export interface ResolvedEmployeeConfig {
+  employeeId: string;
+  engine: string;
+  model?: string;
+  effort?: 'low' | 'medium' | 'high' | 'xhigh';
+  retry: { attempts: number; delaySeconds: number; backoff: 'fixed' | 'exponential' };
+  timeoutMinutes?: number;
+  /** The completed attempt session whose engine thread this attempt continues.
+   *  Absent means the attempt was dispatched cold. */
+  continuedFrom?: { sessionId: string; engineSessionId: string };
+  /** The engine this node's own precedence resolved to, when it could not serve
+   *  the turn and a fallback chain covered for it. Absent means `engine` is what
+   *  the node asked for. */
+  substitutedFrom?: { engine: string; reason: string };
+}
+
+export interface WorkflowError {
+  code: string;
+  message: string;
+  retryable: boolean;
+  nodeId?: string;
+  attempt?: number;
+  details?: Record<string, JsonValue>;
+}
+
+export interface WorkflowRunRecord {
+  id: string;
+  workflowId: string;
+  workflowTitle: string;
+  definitionRevision: number;
+  definition: WorkflowDefinition;
+  input: Record<string, JsonValue>;
+  trigger: {
+    nodeId: string;
+    kind: 'manual' | 'schedule' | 'event' | 'todo-status' | 'workflow-call';
+    fireId?: string;
+    payload: Record<string, JsonValue>;
+    /** The Todo this run is bound to: set by a `todo-status` trigger to the
+     *  Todo that fired it, so parked gates and comments land on THAT Todo
+     *  instead of minting a new one. Exposed to nodes as `{{ run.todoId }}`. */
+    todoId?: string;
+  };
+  status: WorkflowRunStatus;
+  revision: number;
+  idempotencyKey?: string;
+  invocationSessionId?: string;
+  cancelRequestedAt?: string;
+  startedAt: string;
+  endedAt?: string;
+  error?: WorkflowError;
+}
+
+export interface WorkflowNodeRunRecord {
+  runId: string;
+  nodeId: string;
+  nodeType: WorkflowNode['type'];
+  status: WorkflowNodeRunStatus;
+  activated: boolean;
+  resolvedConfig?: Record<string, JsonValue>;
+  input?: JsonValue;
+  output?: WorkflowNodeOutput;
+  error?: WorkflowError;
+  resumeAt?: string;
+  startedAt?: string;
+  endedAt?: string;
+}
+
+export interface WorkflowAttemptRecord {
+  runId: string;
+  nodeId: string;
+  attempt: number;
+  sessionId?: string;
+  status: WorkflowAttemptStatus;
+  resolvedConfig: ResolvedEmployeeConfig;
+  input: JsonValue;
+  /** The final composed prompt handed to the session (interpolated + contract block). */
+  promptText?: string;
+  output?: WorkflowNodeOutput;
+  error?: WorkflowError;
+  startedAt: string;
+  endedAt?: string;
+  remindersSent: number;
+  /** Immediate nudges spent on turns that ended on narration. Counted apart from
+   *  `remindersSent` so the time ladder is still whole once they run out. */
+  stopNudgesSent: number;
+  nextReminderAt?: string;
+  extensions: number;
+  lastExtensionReason?: string;
+  pendingOutputError?: string;
+  lastProcessedTurn: number;
+}
+
+export interface WorkflowApprovalRecord {
+  runId: string;
+  nodeId: string;
+  status: 'pending' | 'approved' | 'rejected';
+  requestedAt: string;
+  approverRef?: string;
+  decidedAt?: string;
+  decidedBy?: string;
+  decision?: 'approve' | 'reject';
+  reason?: string;
+}
+
+export interface WorkflowChildRunSummary {
+  runId: string;
+  workflowId: string;
+  nodeId: string;
+  /** Absent on a run an attempt session started: that is a single spawn, not one item of a batch. */
+  itemIndex?: number;
+  status: WorkflowRunStatus;
+  startedAt: string;
+  endedAt?: string;
+  endOutput?: Record<string, JsonValue>;
+  /** The engine session this child ran in, when it had one — what makes a single
+   *  iteration round separately readable from its caller's run detail. */
+  sessionId?: string;
+  error?: WorkflowError;
+}
+
+/** A Workflow Call child, which is always one item of its node's batch. */
+export type WorkflowFanoutChildSummary = WorkflowChildRunSummary & { itemIndex: number };
+
+export interface WorkflowRunDetail extends WorkflowRunRecord {
+  nodeRuns: WorkflowNodeRunRecord[];
+  attempts: WorkflowAttemptRecord[];
+  approvals: WorkflowApprovalRecord[];
+  childRuns: WorkflowChildRunSummary[];
+}

--- a/packages/jimmy/src/workflows/service-input.ts
+++ b/packages/jimmy/src/workflows/service-input.ts
@@ -1,0 +1,30 @@
+import { jsonValueSchema, nodeIdSchema, workflowIdSchema, type JsonValue } from "./model.js";
+import { WorkflowRepositoryError } from "./repository.js";
+import type { WorkflowCallInput } from "./service.js";
+
+/**
+ * Shape guards for the Workflow service's public methods: whether a caller's
+ * argument is a Workflow input at all. Pure and decision-free — what the
+ * service then DOES with a valid input stays in the service.
+ */
+
+export function fail(code: "bad-input" | "not-found", message: string): never {
+  throw new WorkflowRepositoryError(code, message);
+}
+
+export function boundedRecord(value: unknown, subject: string): Record<string, JsonValue> {
+  const parsed = jsonValueSchema.safeParse(value);
+  if (!parsed.success || parsed.data === null || typeof parsed.data !== "object" || Array.isArray(parsed.data)) {
+    fail("bad-input", `${subject} must be a JSON object.`);
+  }
+  if (Buffer.byteLength(JSON.stringify(parsed.data), "utf8") > 64 * 1024) fail("bad-input", `${subject} is too large.`);
+  return parsed.data as Record<string, JsonValue>;
+}
+
+export function callerIdentity(value: unknown): value is WorkflowCallInput["caller"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return workflowIdSchema.safeParse(record.workflowId).success
+    && typeof record.runId === "string" && /^run_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(record.runId)
+    && nodeIdSchema.safeParse(record.nodeId).success;
+}

--- a/packages/jimmy/src/workflows/service.ts
+++ b/packages/jimmy/src/workflows/service.ts
@@ -1,0 +1,482 @@
+import type { Employee, ModelRegistry } from "../shared/types.js";
+import { logger } from "../shared/logger.js";
+import { TODO_ID_PATTERN } from "../work-items/id.js";
+import type { WorkflowTodoEventFeed } from "../work-items/workflow-event-feed.js";
+import { workflowIdSchema, type JsonValue, type WorkflowDefinition, type WorkflowId } from "./model.js";
+import { boundedRecord, callerIdentity, fail } from "./service-input.js";
+import { assertCallableCaller, callerForSession } from "./session-caller.js";
+import { settleTodoRun } from "./todo-run-ledger.js";
+import {
+  WorkflowRepositoryError,
+  type CreateWorkflowInput,
+  type CursorPage,
+  type DefinitionListQuery,
+  type RunListQuery,
+  type WorkflowDefinitionSummary,
+  type WorkflowRepository,
+  type WorkflowRunSummary,
+} from "./repository.js";
+import type { WorkflowError, WorkflowRunDetail } from "./runtime.js";
+import { WorkflowRunner, type WorkflowRunnerOptions, type WorkflowTodoApprovalMirror, type WorkflowTodoDispatchOverride, type WorkflowTodoLifecycle, type WorkflowTodoSessionLink } from "./runner.js";
+import type { WorkflowSessionExecutor } from "./session-executor.js";
+import { WorkflowTriggerService, type FireWorkflowEventInput } from "./trigger-service.js";
+import {
+  endRequirementIssues, scheduleTriggerIssues,
+  todoCommentWaitTriggerIssues,
+  todoTriggerFilterIssues,
+  validateExecutableWorkflow,
+  workflowCallSaveIssues,
+  type WorkflowValidationIssue,
+} from "./validation.js";
+
+export { WorkflowRepositoryError };
+export type { FireWorkflowEventInput };
+
+export interface StartWorkflowRunInput {
+  workflowId: string;
+  input: Record<string, JsonValue>;
+  idempotencyKey?: string;
+  /** Bind this manual run to an existing Todo, exactly as a `todo-status`
+   *  trigger would — its gates mirror onto that Todo. Omit for an unbound run. */
+  todoId?: string;
+  /** The session asking for the run. When it turns out to be a live Workflow
+   *  attempt the run is guarded and parented like a Workflow Call; every other
+   *  session — an operator, a cron run — starts an unparented run as before. */
+  callerSessionId?: string;
+}
+export interface RerunWorkflowInput {
+  workflowId: string;
+  runId: string;
+  definition: "original" | "current";
+  idempotencyKey: string;
+}
+export interface DecideWorkflowApprovalInput {
+  workflowId: string;
+  runId: string;
+  nodeId: string;
+  decision: "approve" | "reject";
+  decidedBy: string;
+  reason?: string;
+  /** Required when approving a node that offers options; must be one of them. */
+  choice?: string;
+  expectedRevision: number;
+}
+export interface RetryWorkflowNodeInput {
+  workflowId: string;
+  runId: string;
+  nodeId: string;
+  idempotencyKey: string;
+}
+export interface WorkflowCallInput {
+  workflowId: string;
+  caller: { workflowId: string; runId: string; nodeId: string };
+  input: Record<string, JsonValue>;
+  idempotencyKey: string;
+  itemIndex?: number;
+  todoId?: string;
+}
+export class WorkflowServiceError extends Error {
+  readonly code: "forbidden" | "conflict" | "invalid-definition";
+  readonly issues?: readonly WorkflowValidationIssue[];
+
+  constructor(code: "forbidden" | "conflict", message: string);
+  constructor(code: "invalid-definition", message: string, issues: readonly WorkflowValidationIssue[]);
+  constructor(code: "forbidden" | "conflict" | "invalid-definition", message: string,
+    issues?: readonly WorkflowValidationIssue[]) {
+    super(message);
+    this.name = "WorkflowServiceError";
+    this.code = code;
+    this.issues = issues;
+  }
+}
+export type WorkflowTranscript = Array<{ id: string; role: string; content: string; timestamp: number }>;
+/** The Todos side of a comment-wait: the earliest live operator comment on a
+ *  Todo written strictly inside the window between the park and its deadline. */
+export interface WorkflowTodoCommentFeed {
+  firstOperatorCommentAfter(todoId: string, after: string, until: string): { id: string; body: string; createdAt: string; attachments: ReadonlyArray<{ id: string; mime: string }> } | undefined;
+}
+export interface WorkflowServiceOptions extends Pick<WorkflowRunnerOptions, "activeEngineSessions" | "engineFallback" | "landingEvidence"> {
+  repository: WorkflowRepository;
+  executor: WorkflowSessionExecutor;
+  employees: () => ReadonlyMap<string, Employee>;
+  models: () => ModelRegistry;
+  readTranscript?: (sessionId: string) => WorkflowTranscript;
+  now?: () => string;
+  onChange?: (change: { workflowId: string; runId: string }) => void;
+  onDefinitionChange?: (change: { workflowId: string; revision: number }) => void;
+  todoEventFeed?: WorkflowTodoEventFeed;
+  /** The Todo-facing ports, each documented on the runner: the operator replies
+   *  a parked `todo-comment` Wait node resumes on, the Approval gates mirrored
+   *  onto the bound Todo, the phase sessions linked to it for spend, the run
+   *  lifecycle reflected onto it, and the next attempt's engine/model. */
+  todoComments?: WorkflowTodoCommentFeed;
+  todoApprovals?: WorkflowTodoApprovalMirror;
+  todoSessions?: WorkflowTodoSessionLink;
+  todoLifecycle?: WorkflowTodoLifecycle;
+  todoDispatch?: WorkflowTodoDispatchOverride;
+  /** Live session-cost aggregate for Workflow attempt sessions. */
+  sessionSpend?: (sessionIds: string[]) => number;
+}
+function assertExecutableWorkflow(definition: WorkflowDefinition): void {
+  const result = validateExecutableWorkflow(definition);
+  if (!result.ok) {
+    throw new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", result.issues);
+  }
+}
+export class WorkflowService {
+  private readonly runner: WorkflowRunner;
+  private readonly triggers: WorkflowTriggerService;
+  private unsubscribe: (() => void) | null;
+  private wakeTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(private readonly options: WorkflowServiceOptions) {
+    this.runner = new WorkflowRunner({ ...options, callWorkflow: (input) => this.callWorkflow(input),
+      onChange: ({ workflowId, runId }) => {
+      const run = options.repository.getRun(workflowId, runId);
+      if (run) {
+        options.onChange?.({ workflowId, runId });
+        this.wakeCaller(run);
+      }
+      this.armWakeTimer();
+    } });
+    this.triggers = new WorkflowTriggerService(options.repository, this.runner,
+      () => this.now(), options.todoEventFeed);
+    this.unsubscribe = options.executor.subscribe(async (event) => { await this.runner.complete(event); });
+    this.armWakeTimer();
+  }
+  private now(): string { return (this.options.now ?? (() => new Date().toISOString()))(); }
+  private definitionChanged(definition: WorkflowDefinition): void {
+    this.triggers.rebuild();
+    this.options.onDefinitionChange?.({ workflowId: definition.id, revision: definition.revision });
+  }
+  private runChanged(run: WorkflowRunDetail): void {
+    this.options.onChange?.({ workflowId: run.workflowId, runId: run.id });
+    this.wakeCaller(run);
+    this.armWakeTimer();
+  }
+  private wakeCaller(run: WorkflowRunDetail): void {
+    if (!["completed", "failed", "cancelled"].includes(run.status) || run.trigger.kind !== "workflow-call") return;
+    const caller = run.trigger.payload.caller;
+    if (!callerIdentity(caller)) return;
+    void this.runner.advanceCaller(caller.workflowId, caller.runId, caller.nodeId).catch((error) => {
+      logger.warn(`Workflow caller ${caller.runId}:${caller.nodeId} could not resume: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+  private requiredRun(workflowId: string, runId: string): WorkflowRunDetail {
+    const run = this.options.repository.getRun(workflowId, runId);
+    return run ?? fail("not-found", `Workflow run ${runId} was not found.`);
+  }
+  private armWakeTimer(): void {
+    if (this.wakeTimer) clearTimeout(this.wakeTimer);
+    this.wakeTimer = null;
+    if (this.disposed) return;
+    const wait = this.options.repository.nextDueWait();
+    const reminder = this.options.repository.nextDueReminder();
+    const timeout = this.options.repository.nextDueTimeout();
+    const nextAt = [wait?.resumeAt, reminder?.nextReminderAt, timeout].filter((value): value is string => Boolean(value)).sort()[0];
+    if (!nextAt) return;
+    const delay = Math.min(2_147_483_647, Math.max(0, Date.parse(nextAt) - Date.parse(this.now())));
+    this.wakeTimer = setTimeout(() => {
+      this.wakeTimer = null;
+      void this.recover(this.now()).catch(() => { this.armWakeTimer(); });
+    }, delay);
+    this.wakeTimer.unref?.();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.wakeTimer) clearTimeout(this.wakeTimer);
+    this.wakeTimer = null;
+    this.unsubscribe?.(); this.unsubscribe = null; this.triggers.dispose();
+  }
+  listDefinitions(query: DefinitionListQuery): CursorPage<WorkflowDefinitionSummary> { return this.options.repository.listDefinitions(query); }
+  getDefinition(id: string): WorkflowDefinition | null { return this.options.repository.getDefinition(id); }
+  getRun(workflowId: string, runId: string): WorkflowRunDetail | null { return this.options.repository.getRun(workflowId, runId); }
+  getRunSpend(workflowId: string, runId: string): number {
+    const run = this.requiredRun(workflowId, runId);
+    const sessionIds = [...new Set(run.attempts.flatMap((attempt) => attempt.sessionId ? [attempt.sessionId] : []))];
+    return sessionIds.length > 0 ? (this.options.sessionSpend?.(sessionIds) ?? 0) : 0;
+  }
+  listRuns(workflowId: string, query: RunListQuery): CursorPage<WorkflowRunSummary> { return this.options.repository.listRuns(workflowId, query); }
+  submitAttemptOutput(input: {
+    sessionId: string;
+    outcome?: "success" | "failure";
+    fields?: unknown;
+    summary?: string;
+  }): Promise<WorkflowRunDetail> {
+    return this.runner.submit(input);
+  }
+  extendAttemptDeadline(input: { sessionId: string; reason?: string }): Promise<void> {
+    return this.runner.extend(input);
+  }
+
+  createDefinition(input: CreateWorkflowInput): WorkflowDefinition {
+    const value = this.options.repository.createDefinition(input); this.definitionChanged(value); return value;
+  }
+  saveDefinition(definition: WorkflowDefinition, expectedRevision: number): WorkflowDefinition {
+    // Saving a revision of an already-enabled Workflow bypasses the enable gate,
+    // so an unarmable trigger is refused here before it can become durable.
+    const issues = [
+      ...scheduleTriggerIssues(definition),
+      ...todoCommentWaitTriggerIssues(definition),
+      ...todoTriggerFilterIssues(definition),
+      ...workflowCallSaveIssues(definition), ...endRequirementIssues(definition),
+    ];
+    if (issues.length > 0) throw new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", issues);
+    const value = this.options.repository.saveDefinition(definition, expectedRevision); this.definitionChanged(value); return value;
+  }
+  duplicateDefinition(sourceId: WorkflowId, input: { id: WorkflowId; title: string }): WorkflowDefinition {
+    const value = this.options.repository.duplicateDefinition(sourceId, input); this.definitionChanged(value); return value;
+  }
+  setRetired(input: { id: string; retired: boolean; expectedRevision: number }): WorkflowDefinition {
+    const value = this.options.repository.setRetired(input.id, input.retired, input.expectedRevision, this.now());
+    this.definitionChanged(value); return value;
+  }
+  setEnabled(input: { id: string; enabled: boolean; expectedRevision: number }): WorkflowDefinition {
+    if (input.enabled === true) {
+      const current = this.options.repository.getDefinition(input.id)
+        ?? fail("not-found", `Workflow definition ${input.id} was not found.`);
+      if (current.revision !== input.expectedRevision) {
+        throw new WorkflowRepositoryError("revision-conflict", `Workflow definition ${current.id} revision does not match.`);
+      }
+      if (current.retiredAt !== undefined) {
+        throw new WorkflowRepositoryError("retired", `Workflow definition ${current.id} is retired.`);
+      }
+      assertExecutableWorkflow(current);
+    }
+    const value = this.options.repository.setEnabled(input.id, input.enabled, input.expectedRevision);
+    this.definitionChanged(value); return value;
+  }
+  async startManual(input: StartWorkflowRunInput): Promise<WorkflowRunDetail> {
+    const definition = this.options.repository.getDefinition(input.workflowId);
+    if (!definition?.enabled) fail("bad-input", "Workflow does not have an enabled manual trigger.");
+    assertExecutableWorkflow(definition);
+    const trigger = definition.nodes.find((node) => node.type === "trigger" && node.config.kind === "manual");
+    if (!trigger) fail("bad-input", "Workflow does not have an enabled manual trigger.");
+    const caller = callerForSession(this.options.repository, input.callerSessionId);
+    if (caller) assertCallableCaller(this.options.repository, definition.id, caller);
+    const created = this.options.repository.createRun({ workflowId: definition.id,
+      input: boundedRecord(input.input, "Workflow input"),
+      trigger: { nodeId: trigger.id, kind: "manual", payload: caller ? { caller } : {}, ...(input.todoId ? { todoId: input.todoId } : {}) },
+      ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}) });
+    const detail = this.requiredRun(definition.id, created.id);
+    return detail.status === "pending" ? this.runner.start(created.id) : detail;
+  }
+  fireEvent(input: FireWorkflowEventInput): Promise<WorkflowRunDetail[]> { return this.triggers.fire(input); }
+  async callWorkflow(input: WorkflowCallInput): Promise<WorkflowRunDetail> {
+    const workflowId = workflowIdSchema.safeParse(input.workflowId);
+    if (!workflowId.success) fail("bad-input", "Workflow target identity is invalid.");
+    if (!callerIdentity(input.caller)) fail("bad-input", "Workflow caller identity is invalid.");
+    if (typeof input.idempotencyKey !== "string" || input.idempotencyKey.length < 1 || input.idempotencyKey.length > 128) {
+      fail("bad-input", "Workflow idempotency key is invalid.");
+    }
+    if (input.itemIndex !== undefined && (!Number.isInteger(input.itemIndex) || input.itemIndex < 0 || input.itemIndex >= 100)) {
+      fail("bad-input", "Workflow call item index is invalid.");
+    }
+    if (input.todoId !== undefined && (typeof input.todoId !== "string" || !TODO_ID_PATTERN.test(input.todoId))) {
+      fail("bad-input", "Workflow Todo id must match AAA-123.");
+    }
+    const value = boundedRecord(input.input, "Workflow input");
+    const replay = this.options.repository.findWorkflowCallByIdempotency({ workflowId: workflowId.data,
+      input: value, caller: input.caller, ...(input.itemIndex === undefined ? {} : { itemIndex: input.itemIndex }),
+      ...(input.todoId === undefined ? {} : { todoId: input.todoId }),
+      idempotencyKey: input.idempotencyKey });
+    if (replay) return this.requiredRun(replay.workflowId, replay.id);
+    const definition = this.options.repository.getDefinition(workflowId.data);
+    const targets = definition?.nodes.filter((node) => node.type === "trigger" && node.config.kind === "workflow-call") ?? [];
+    if (!definition?.enabled || !validateExecutableWorkflow(definition).ok || targets.length !== 1) {
+      fail("bad-input", "Workflow target must have one enabled executable workflow-call trigger.");
+    }
+    assertCallableCaller(this.options.repository, definition.id, input.caller);
+    const created = this.options.repository.createRun({ workflowId: definition.id,
+      input: value, trigger: { nodeId: targets[0]!.id, kind: "workflow-call",
+        payload: { caller: input.caller, ...(input.itemIndex === undefined ? {} : { itemIndex: input.itemIndex }) },
+        ...(input.todoId === undefined ? {} : { todoId: input.todoId }) },
+      idempotencyKey: input.idempotencyKey });
+    const detail = this.requiredRun(definition.id, created.id);
+    return detail.status === "pending" ? this.runner.start(created.id) : detail;
+  }
+  getAttemptTranscript(input: { workflowId: string; runId: string; nodeId: string; attempt: number }): WorkflowTranscript {
+    this.requiredRun(input.workflowId, input.runId);
+    const attempt = this.options.repository.getAttempt(input.runId, input.nodeId, input.attempt);
+    if (!attempt) fail("not-found", `Workflow attempt ${input.nodeId}:${input.attempt} was not found.`);
+    if (!attempt.sessionId) return [];
+    const transcript = this.options.readTranscript?.(attempt.sessionId) ?? [];
+    return transcript.map((message) => Object.freeze({ id: message.id, role: message.role, content: message.content, timestamp: message.timestamp }));
+  }
+
+  async cancelRun(input: { workflowId: string; runId: string; reason: string }): Promise<WorkflowRunDetail> {
+    let run = this.requiredRun(input.workflowId, input.runId);
+    if (["completed", "failed", "cancelled"].includes(run.status)) fail("bad-input", `Workflow run ${run.id} is already terminal.`);
+    if (typeof input.reason !== "string" || input.reason.length > 1000) fail("bad-input", "Workflow cancellation reason is invalid.");
+    const requestedAt = this.now();
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => tx.setRunStatus(run.status, { cancelRequestedAt: requestedAt }));
+    run = this.requiredRun(input.workflowId, input.runId); this.runChanged(run);
+    const children = run.definition.nodes
+      .filter((node) => node.type === "workflow-call" || node.type === "employee")
+      .flatMap((node) => this.options.repository.listChildRuns(run.id, node.id))
+      .filter((child) => !["completed", "failed", "cancelled"].includes(child.status));
+    await Promise.allSettled(children.map((child) => this.cancelRun({
+      workflowId: child.workflowId,
+      runId: child.runId,
+      reason: input.reason || "Parent Workflow run cancelled.",
+    })));
+    await Promise.allSettled(run.attempts.filter((item) => item.status === "running" && item.sessionId)
+      .map((item) => this.options.executor.stopAttempt({ sessionId: item.sessionId!, reason: input.reason || "Workflow run cancelled." })));
+    run = this.requiredRun(input.workflowId, input.runId);
+    const error: WorkflowError = { code: "workflow-cancelled", message: input.reason || "Workflow run cancelled.", retryable: false };
+    const cancelled = run.attempts.filter((item) => (item.status === "running" || item.status === "dispatching") && item.sessionId);
+    this.options.repository.mutateRun(run.id, run.revision, (tx) => {
+      for (const attempt of run.attempts.filter((item) => item.status === "running" || item.status === "dispatching")) {
+        tx.settleAttempt(attempt.nodeId, attempt.attempt, { status: "cancelled", ...(attempt.sessionId ? { sessionId: attempt.sessionId } : {}), error, endedAt: requestedAt });
+      }
+      for (const node of run.nodeRuns.filter((item) => !["completed", "failed", "skipped", "cancelled"].includes(item.status))) {
+        tx.setNodeStatus(node.nodeId, "cancelled", { error, endedAt: requestedAt });
+      }
+      tx.setRunStatus("cancelled", { cancelRequestedAt: requestedAt, endedAt: requestedAt, error });
+    });
+    // This path settles its own attempts, so their run-ledger rows close here.
+    for (const attempt of cancelled) settleTodoRun(this.options.todoSessions, run, attempt, { status: "cancelled", endedAt: requestedAt });
+    run = this.requiredRun(input.workflowId, input.runId); this.runChanged(run); return run;
+  }
+
+  async rerun(input: RerunWorkflowInput): Promise<WorkflowRunDetail> {
+    if (input.definition !== "original" && input.definition !== "current") fail("bad-input", "Workflow rerun definition is invalid.");
+    if (typeof input.idempotencyKey !== "string" || input.idempotencyKey.length < 1 || input.idempotencyKey.length > 256) fail("bad-input", "Workflow idempotency key is invalid.");
+    const source = this.requiredRun(input.workflowId, input.runId);
+    const current = this.options.repository.getDefinition(input.workflowId);
+    if (!current?.enabled || current.retiredAt) fail("bad-input", "Workflow is not enabled for rerun.");
+    const definition = input.definition === "original" ? source.definition : current;
+    const created = this.options.repository.createRun({ workflowId: input.workflowId, input: source.input,
+      trigger: source.trigger, idempotencyKey: input.idempotencyKey }, definition);
+    const detail = this.requiredRun(input.workflowId, created.id);
+    return detail.status === "pending" ? this.runner.start(created.id) : detail;
+  }
+
+  async decideApproval(input: DecideWorkflowApprovalInput): Promise<WorkflowRunDetail> {
+    const run = this.requiredRun(input.workflowId, input.runId);
+    if (run.revision !== input.expectedRevision) {
+      throw new WorkflowRepositoryError("revision-conflict", `Workflow run ${run.id} revision does not match.`);
+    }
+    if (!input.decidedBy.trim()) fail("bad-input", "Workflow approval actor is invalid.");
+    if (input.decision !== "approve" && input.decision !== "reject") fail("bad-input", "Workflow approval decision is invalid.");
+    if (input.reason !== undefined && (typeof input.reason !== "string" || input.reason.length > 1000)) {
+      fail("bad-input", "Workflow approval reason is invalid.");
+    }
+    const authored = run.definition.nodes.find((node) => node.id === input.nodeId);
+    const approval = run.approvals.find((item) => item.nodeId === input.nodeId);
+    if (authored?.type !== "approval" || !approval) fail("not-found", `Workflow approval ${input.nodeId} was not found.`);
+    if (approval.status !== "pending") throw new WorkflowServiceError("conflict", `Workflow approval ${input.nodeId} is already decided.`);
+    if (authored.config.operatorOnly && input.decidedBy !== "operator") {
+      throw new WorkflowServiceError("forbidden", `Workflow approval ${input.nodeId} is operator-only; ${input.decidedBy} cannot decide it.`);
+    }
+    if (approval.approverRef && input.decidedBy !== approval.approverRef && input.decidedBy !== "operator") {
+      throw new WorkflowServiceError("forbidden", `Workflow actor ${input.decidedBy} is not authorized for approval ${input.nodeId}.`);
+    }
+    const offered = authored.config.options;
+    if (input.choice !== undefined) {
+      if (input.decision !== "approve") fail("bad-input", "A workflow approval choice requires an approve decision.");
+      if (!offered?.includes(input.choice)) fail("bad-input", `Workflow approval ${input.nodeId} does not offer that choice.`);
+    } else if (offered && input.decision === "approve") {
+      fail("bad-input", `Workflow approval ${input.nodeId} requires choosing one of: ${offered.join(", ")}.`);
+    }
+    return this.runner.decideApproval(input);
+  }
+
+  async retryNode(input: RetryWorkflowNodeInput): Promise<WorkflowRunDetail> {
+    const run = this.requiredRun(input.workflowId, input.runId);
+    if (typeof input.idempotencyKey !== "string" || input.idempotencyKey.length < 1 || input.idempotencyKey.length > 128) {
+      fail("bad-input", "Workflow retry idempotency key is invalid.");
+    }
+    const replay = this.options.repository.findAttemptByRetryKey(run.id, input.idempotencyKey);
+    if (replay) {
+      if (replay.nodeId !== input.nodeId) {
+        throw new WorkflowServiceError("conflict", "Workflow retry idempotency key belongs to a different Employee.");
+      }
+      return run;
+    }
+    if (run.status === "completed" || run.status === "cancelled") {
+      throw new WorkflowServiceError("conflict", `Workflow run ${run.id} is ${run.status}.`);
+    }
+    const authored = run.definition.nodes.find((node) => node.id === input.nodeId);
+    const runtime = run.nodeRuns.find((node) => node.nodeId === input.nodeId);
+    const latest = run.attempts.filter((attempt) => attempt.nodeId === input.nodeId).at(-1);
+    if (authored?.type !== "employee" || !runtime || !latest) fail("not-found", `Workflow Employee ${input.nodeId} was not found.`);
+    if (latest.status !== "failed" && latest.status !== "timed-out") {
+      throw new WorkflowServiceError("conflict", `Workflow Employee ${input.nodeId} is active or already completed.`);
+    }
+    if (latest.attempt >= latest.resolvedConfig.retry.attempts) fail("bad-input", `Workflow Employee ${input.nodeId} exhausted its retry bounds.`);
+    try { return await this.runner.retryNode(input.workflowId, input.runId, input.nodeId, input.idempotencyKey); }
+    catch (error) {
+      const claimed = this.options.repository.findAttemptByRetryKey(run.id, input.idempotencyKey);
+      if (claimed && claimed.nodeId !== input.nodeId) {
+        throw new WorkflowServiceError("conflict", "Workflow retry idempotency key belongs to a different Employee.");
+      }
+      throw error;
+    }
+  }
+
+  /** Resume every run parked on a `todo-comment` Wait whose bound Todo was
+   *  commented on by the operator between the park and the node's timeout
+   *  deadline. Runs before the due-wait sweep so a reply that landed inside that
+   *  window beats its own timeout, and is bounded by the deadline so a sweep
+   *  arriving after one cannot answer a park that had already expired. */
+  private async resumeCommentWaits(now: string): Promise<number> {
+    const feed = this.options.todoComments;
+    if (!feed) return 0;
+    let resumed = 0;
+    for (const record of this.options.repository.listRecoverableRuns()) {
+      const run = this.requiredRun(record.workflowId, record.id);
+      const todoId = run.trigger.todoId;
+      if (run.status !== "waiting" || !todoId) continue;
+      for (const runtime of run.nodeRuns) {
+        if (runtime.status !== "waiting" || !runtime.startedAt || !runtime.resumeAt) continue;
+        const authored = run.definition.nodes.find((node) => node.id === runtime.nodeId);
+        if (authored?.type !== "wait" || authored.config.mode !== "todo-comment") continue;
+        const comment = feed.firstOperatorCommentAfter(todoId, runtime.startedAt, runtime.resumeAt);
+        if (comment && await this.runner.resumeCommentWait(run.workflowId, run.id, runtime.nodeId, comment, now)) resumed += 1;
+      }
+    }
+    return resumed;
+  }
+
+  async recover(now: string): Promise<{ resumedRuns: number; resumedWaits: number; resumedComments: number }> {
+    let resumedRuns = 0;
+    for (const record of this.options.repository.listRecoverableRuns()) {
+      const run = this.requiredRun(record.workflowId, record.id);
+      for (const attempt of run.attempts.filter((item) => item.status === "dispatching")) {
+        if (await this.runner.recoverDispatching(run.workflowId, run.id, attempt.nodeId, attempt.attempt)) resumedRuns += 1;
+      }
+      for (const attempt of run.attempts.filter((item) => item.status === "running" && item.sessionId)) {
+        const completion = this.options.executor.readTerminalCompletion(attempt.sessionId!);
+        if (completion && await this.runner.complete(completion)) { resumedRuns += 1; continue; }
+        if (attempt.resolvedConfig.timeoutMinutes !== undefined
+          && Date.parse(attempt.startedAt) + attempt.resolvedConfig.timeoutMinutes * 60_000 <= Date.parse(now)) {
+          await this.options.executor.stopAttempt({ sessionId: attempt.sessionId!, reason: "Workflow attempt timed out." }).catch(() => undefined);
+          if (await this.runner.timeoutAttempt(run.workflowId, run.id, attempt.nodeId, attempt.attempt, now)) resumedRuns += 1;
+        }
+      }
+      const current = this.requiredRun(run.workflowId, run.id);
+      if (current.definition.nodes.some((node) => node.type === "workflow-call"
+        && current.nodeRuns.some((runtime) => runtime.nodeId === node.id && runtime.activated
+          && !["completed", "failed", "skipped", "cancelled"].includes(runtime.status)))) {
+        const revision = current.revision;
+        for (const node of current.definition.nodes.filter((item) => item.type === "workflow-call")) {
+          await this.runner.advanceCaller(current.workflowId, current.id, node.id);
+        }
+        if (this.requiredRun(current.workflowId, current.id).revision !== revision) resumedRuns += 1;
+      }
+    }
+    const resumedComments = await this.resumeCommentWaits(now);
+    let resumedWaits = 0;
+    for (const wait of this.options.repository.listDueWaits(now, 100)) {
+      const run = this.options.repository.listRecoverableRuns().find((candidate) => candidate.id === wait.runId);
+      if (run && await this.runner.resumeWait(run.workflowId, run.id, wait.nodeId, now)) resumedWaits += 1;
+    }
+    await this.runner.remindDueAttempts(now);
+    await this.triggers.recoverTodoEvents();
+    this.armWakeTimer();
+    return { resumedRuns, resumedWaits, resumedComments };
+  }
+}

--- a/packages/jimmy/src/workflows/session-caller.ts
+++ b/packages/jimmy/src/workflows/session-caller.ts
@@ -1,0 +1,83 @@
+import type { WorkflowRepository } from "./repository.js";
+import type { WorkflowRunDetail } from "./runtime.js";
+import { callerIdentity, fail } from "./service-input.js";
+import type { WorkflowCallInput } from "./service.js";
+
+/**
+ * Which Workflow invocation a new run is being started on behalf of, and whether
+ * that invocation may reach the target at all. A Workflow Call names its caller
+ * outright; a run started from an attempt session has to be traced back to one.
+ */
+
+type CallerRepository = Pick<WorkflowRepository, "getRun" | "findAttemptBySessionId" | "listRecoverableRuns">;
+type WorkflowCaller = WorkflowCallInput["caller"];
+
+/** The trigger kinds whose payload the service writes itself, and so the only
+ *  ones where a `caller` key is ancestry. A schedule, event, or todo-status
+ *  payload is the fire's own data, in which `caller` is just a business field. */
+const PARENTED_TRIGGER_KINDS: ReadonlyArray<WorkflowRunDetail["trigger"]["kind"]> = ["manual", "workflow-call"];
+
+/** The invocation a session speaks for, or null when the session is not one —
+ *  an operator, a cron run, or an attempt that has already settled. */
+export function callerForSession(repository: CallerRepository, sessionId: string | undefined): WorkflowCaller | null {
+  if (sessionId === undefined) return null;
+  const attempt = repository.findAttemptBySessionId(sessionId);
+  if (!attempt || !["dispatching", "running"].includes(attempt.status)) return null;
+  const run = repository.listRecoverableRuns().find((candidate) => candidate.id === attempt.runId);
+  return run ? { workflowId: run.workflowId, runId: run.id, nodeId: attempt.nodeId } : null;
+}
+
+/** Whether the node a caller names is mid-invocation right now: an Employee node
+ *  with a live attempt, or a Workflow Call still waiting on its children. */
+function isActiveInvocation(run: WorkflowRunDetail, caller: WorkflowCaller): boolean {
+  const runtime = run.nodeRuns.find((node) => node.nodeId === caller.nodeId);
+  if (!runtime?.activated) return false;
+  const authored = run.definition.nodes.find((node) => node.id === caller.nodeId);
+  if (authored?.type === "workflow-call") return runtime.status === "running";
+  if (authored?.type !== "employee") return false;
+  const attempt = run.attempts.filter((item) => item.nodeId === caller.nodeId).at(-1);
+  return attempt !== undefined && ["dispatching", "running"].includes(attempt.status);
+}
+
+/** The invocation that started this run, or undefined where the ancestry ends. A
+ *  Workflow Call always names its caller; a manual run names one only when an
+ *  attempt session started it. */
+function parentCaller(run: WorkflowRunDetail): WorkflowCaller | undefined {
+  if (!PARENTED_TRIGGER_KINDS.includes(run.trigger.kind)) return undefined;
+  const parent = run.trigger.payload.caller;
+  if (parent === undefined && run.trigger.kind !== "workflow-call") return undefined;
+  if (!callerIdentity(parent)) fail("bad-input", "Workflow caller ancestry is invalid.");
+  return parent;
+}
+
+/** The run one hop up the ancestry, refusing a parent whose named node could not
+ *  have made the call. */
+function parentRun(repository: CallerRepository, parent: WorkflowCaller): WorkflowRunDetail {
+  const run = repository.getRun(parent.workflowId, parent.runId)
+    ?? fail("bad-input", "Workflow caller ancestry was not found.");
+  if (!run.definition.nodes.some((node) => node.id === parent.nodeId
+    && (node.type === "employee" || node.type === "workflow-call"))) {
+    fail("bad-input", "Workflow caller ancestry is invalid.");
+  }
+  return run;
+}
+
+/** Refuse a caller that is not a live invocation, or whose ancestry re-enters the
+ *  target, loops, unwinds into a run already being cancelled, or nests deeper than
+ *  a Workflow tree has any reason to go. */
+export function assertCallableCaller(repository: CallerRepository, targetWorkflowId: string, caller: WorkflowCaller): void {
+  let current = repository.getRun(caller.workflowId, caller.runId)
+    ?? fail("bad-input", "Workflow caller run was not found.");
+  if (!isActiveInvocation(current, caller)) fail("bad-input", "Workflow caller node is not an active invocation.");
+  const seen = new Set<string>();
+  for (let depth = 0; depth < 128; depth += 1) {
+    if (current.cancelRequestedAt) fail("bad-input", "Workflow caller run is being cancelled.");
+    if (current.workflowId === targetWorkflowId) fail("bad-input", "Workflow call recursion is not allowed.");
+    if (seen.has(current.id)) fail("bad-input", "Workflow caller ancestry contains a cycle.");
+    seen.add(current.id);
+    const parent = parentCaller(current);
+    if (!parent) return;
+    current = parentRun(repository, parent);
+  }
+  fail("bad-input", "Workflow caller ancestry is too deep.");
+}

--- a/packages/jimmy/src/workflows/session-executor.ts
+++ b/packages/jimmy/src/workflows/session-executor.ts
@@ -1,0 +1,72 @@
+import type {
+  WorkflowAttemptCommand,
+  WorkflowAttemptCompletion,
+  WorkflowAttemptCompletionListener,
+  WorkflowSessionExecutor as WorkflowSessionExecutorContract,
+  Session,
+} from "../shared/types.js";
+import type { SessionManager } from "../sessions/manager.js";
+import { resumableEngineSession } from "../sessions/attempt-continuation.js";
+import { workflowAttemptInterruptionCause } from "../sessions/workflow-interruptions.js";
+
+export type WorkflowSessionReceiptReader =
+  (sessionId: string) => { session: Session; finalText?: string } | null;
+
+/** The sole adapter between the Workflow runtime and conversational execution. */
+export class WorkflowSessionExecutor implements WorkflowSessionExecutorContract {
+  constructor(
+    private readonly sessions: SessionManager,
+    private readonly readReceipt: WorkflowSessionReceiptReader = () => null,
+  ) {}
+
+  startAttempt(command: WorkflowAttemptCommand): Promise<{ sessionId: string }> {
+    return this.sessions.runWorkflowAttempt(command);
+  }
+
+  stopAttempt(input: { sessionId: string; reason: string }): Promise<void> {
+    return this.sessions.stopWorkflowAttempt(input);
+  }
+
+  remind(input: { sessionId: string; text: string }): Promise<void> {
+    return this.sessions.remindWorkflowAttempt(input.sessionId, input.text);
+  }
+
+  attemptState(sessionId: string): { idle: boolean; runningChildren: number } | null {
+    return this.sessions.workflowAttemptState(sessionId);
+  }
+
+  /** The engine thread a completed attempt session still holds and a new attempt
+   *  could pick up, or null when there is nothing usable to continue from. */
+  resumableEngineSession(sessionId: string, engine: string): string | null {
+    return resumableEngineSession(sessionId, engine);
+  }
+
+  subscribe(listener: WorkflowAttemptCompletionListener): () => void {
+    return this.sessions.subscribeWorkflowAttemptCompletion(listener);
+  }
+
+  readTerminalCompletion(sessionId: string): WorkflowAttemptCompletion | null {
+    const receipt = this.readReceipt(sessionId);
+    const session = receipt?.session;
+    const provenance = session?.workflowProvenance;
+    if (!session?.attemptOutcome || provenance?.kind !== "phase" || !provenance.phase
+      || session.attemptTerminalVersion !== 1 || !session.attemptTurn) return null;
+    return {
+      sessionId,
+      owner: { workflowId: provenance.workflowId, runId: provenance.runId, nodeId: provenance.phase.nodeId, attempt: provenance.phase.attempt },
+      turn: session.attemptTurn,
+      terminalVersion: 1,
+      outcome: session.attemptOutcome,
+      ...(session.attemptOutcome === "interrupted" ? {
+        interruptionCause: workflowAttemptInterruptionCause(
+          session.lastError,
+          session,
+          session.attemptTurn,
+        ),
+      } : {}),
+      completedAt: session.lastActivity,
+      ...(receipt?.finalText ? { finalText: receipt.finalText } : {}),
+      ...(session.lastError ? { error: session.lastError } : {}),
+    };
+  }
+}

--- a/packages/jimmy/src/workflows/todo-approval-ref.ts
+++ b/packages/jimmy/src/workflows/todo-approval-ref.ts
@@ -1,0 +1,17 @@
+/**
+ * The correlation key a workflow writes onto a Todo approval when it mirrors a
+ * parked gate there. Its own module because both sides of the loop need it: the
+ * runner formats it, and the Todo layer reads it to tell a mirrored gate (whose
+ * consequences the RUN owns) apart from a native Todo review gate.
+ */
+
+/** Stable correlation key tying a Todo approval back to the node that parked. */
+export function todoApprovalRef(run: { workflowId: string; id: string }, nodeId: string): string {
+  return `workflow:${run.workflowId}:${run.id}:${nodeId}`;
+}
+
+export function parseTodoApprovalRef(ref: string | null): { workflowId: string; runId: string; nodeId: string } | null {
+  const parts = ref?.split(":") ?? [];
+  if (parts.length !== 4 || parts[0] !== "workflow") return null;
+  return { workflowId: parts[1]!, runId: parts[2]!, nodeId: parts[3]! };
+}

--- a/packages/jimmy/src/workflows/todo-event-outcome.ts
+++ b/packages/jimmy/src/workflows/todo-event-outcome.ts
@@ -1,0 +1,103 @@
+import { logger } from "../shared/logger.js";
+import type { WorkflowTodoEventClaimOutcome, WorkflowTodoEventFeed, WorkflowTodoStatusEvent }
+  from "../work-items/workflow-event-feed.js";
+import type { TriggerNode, WorkflowDefinition } from "./model.js";
+
+/**
+ * What becomes of a Todo event once the trigger filters have spoken: which
+ * definitions are told why they did not run, and whether the event is sealed or
+ * put back for the next drain.
+ *
+ * It sits beside the trigger service rather than inside it because the service's
+ * own job is indexing triggers, claiming work, and starting runs, and none of
+ * that needs to know how a decline is worded or when an event may be put back.
+ */
+
+export interface IndexedTrigger { definition: WorkflowDefinition; trigger: TriggerNode }
+/** Which filter refused a Todo event, and why. The `filter` half exists because
+ *  `label` is the one refusal that can be a race rather than a decision. */
+export interface TodoMismatch { filter: "label" | "other"; reason: string }
+export interface TodoCandidate extends IndexedTrigger { mismatch: TodoMismatch | undefined }
+/** Definition id to the newer event that superseded this one for that definition. */
+export type SupersededBy = ReadonlyMap<string, string>;
+export const NOTHING_SUPERSEDED: SupersededBy = new Map();
+
+/** Whether the Todo is still sitting where this event put it. Once it has moved
+ *  on the event is stale, whatever a later write does to the Todo. */
+export function stillWhereTheEventLeftIt(event: WorkflowTodoStatusEvent): boolean {
+  return event.item.live?.status === event.toStatus;
+}
+/** Record WHY a candidate did not run. A Todo event that a filter refused, or
+ *  that a newer event superseded, otherwise completes silently, which is
+ *  indistinguishable from a broken trigger. A `label` refusal is provisional:
+ *  `settle` may defer the event on it, and whatever settles the event later
+ *  overwrites what is recorded here. */
+export function declinedOutcomes(event: WorkflowTodoStatusEvent, candidates: ReadonlyArray<TodoCandidate>,
+  superseded: SupersededBy, deferred: boolean): WorkflowTodoEventClaimOutcome[] {
+  const outcomes: WorkflowTodoEventClaimOutcome[] = [];
+  for (const item of candidates) {
+    const workflowId = item.definition.id;
+    const winner = superseded.get(workflowId);
+    let declined: WorkflowTodoEventClaimOutcome | undefined;
+    if (item.mismatch !== undefined) {
+      declined = { workflowId, outcome: "suppressed", detail: `Todo event ${event.id} suppressed: ${item.mismatch.reason}.` };
+    } else if (winner !== undefined) {
+      // An event held back for its label and then beaten once it qualified is a
+      // different story from one that never qualified, and the ledger has to say
+      // which of the two happened.
+      declined = deferred
+        ? { workflowId, outcome: "deferred-then-superseded",
+          detail: `Todo event ${event.id} waited for its label, then was superseded by ${winner},`
+            + ` a newer ${event.toStatus} event on ${event.workItemId}.` }
+        : { workflowId, outcome: "superseded",
+          detail: `Todo event ${event.id} superseded by ${winner}, a newer ${event.toStatus} event on ${event.workItemId}.` };
+    }
+    if (declined === undefined) continue;
+    logger.info(`Workflow ${workflowId}: ${declined.detail}`);
+    outcomes.push(declined);
+  }
+  return outcomes;
+}
+
+/**
+ * Close the event, or put it back for the next drain.
+ *
+ * Labels are read when the event DRAINS, and the drain is kicked by the status
+ * write, so a Todo labelled a moment after it moved is judged unlabelled — a
+ * race, not a decision, and sealing the event there is what leaves the Todo
+ * sitting at its arming status with nothing armed and nothing that will ever
+ * look again. `todoMismatch` judges `label` last, so a label refusal means every
+ * other filter on that definition was satisfied and the label alone is missing.
+ *
+ * Deferral therefore sits UPSTREAM of supersession: while a definition is
+ * waiting on its label it is not in the running for this event, so it can
+ * neither be declined as superseded nor beat a newer event. When the label
+ * lands it re-enters the supersession gate on the next drain, as a fresh
+ * arrival would.
+ *
+ * Only the definitions the label refused go back in. The event is shared by
+ * every definition bound to the status, and the ones that just started must not
+ * be considered again when the label lands, or they run twice.
+ */
+export function settle(feed: WorkflowTodoEventFeed, event: WorkflowTodoStatusEvent,
+  candidates: ReadonlyArray<TodoCandidate>, outcomes: WorkflowTodoEventClaimOutcome[]): void {
+  const waiting = candidates.filter((item) => item.mismatch?.filter === "label");
+  if (waiting.length === 0 || !stillWhereTheEventLeftIt(event)) {
+    feed.completeEvent(event.id, outcomes);
+    return;
+  }
+  feed.deferEvent(event.id, waiting.map((item) => item.definition.id), outcomes);
+}
+
+/** Refuse every candidate that survived the filters for the same reason, and
+ *  close the event on it. What that reason can be is the caller's business. */
+export function suppressAll(feed: WorkflowTodoEventFeed, event: WorkflowTodoStatusEvent,
+  runnable: ReadonlyArray<IndexedTrigger>, outcomes: WorkflowTodoEventClaimOutcome[], reason: string): number {
+  for (const item of runnable) {
+    const detail = `Todo event ${event.id} suppressed: ${reason}.`;
+    logger.info(`Workflow ${item.definition.id}: ${detail}`);
+    outcomes.push({ workflowId: item.definition.id, outcome: "suppressed", detail });
+  }
+  feed.completeEvent(event.id, outcomes);
+  return 0;
+}

--- a/packages/jimmy/src/workflows/todo-ports.ts
+++ b/packages/jimmy/src/workflows/todo-ports.ts
@@ -1,0 +1,97 @@
+import type { TodoRunHandoff, TodoRunOutcome } from "../work-items/runs.js";
+import type { WorkflowError } from "./runtime.js";
+
+/**
+ * What a Todo-bound Workflow run owes the Todo it runs for, expressed as ports
+ * the runner calls and the gateway implements. They live here rather than in
+ * `runner.ts` because they are a CONTRACT with the Todos side, not runner
+ * mechanics — and because `work-items/` must stay importable from the gateway
+ * without pulling the runner in. `runner.ts` re-exports all of them, so no
+ * caller had to move.
+ *
+ * Every port is optional at the runner's options level: absent means no Todo
+ * surface, and the run still executes.
+ */
+
+
+/** Where a bound Todo sits when a run is reporting its own lifecycle. */
+export type WorkflowRunReflection = "executing" | "in_review" | "blocked";
+
+export interface WorkflowTodoApprovalMirror {
+  request(input: { todoId: string; request: string; ref: string; options?: string[]; approver?: string }): void;
+  /** Wake the routed employee when a run parks on their decision. Called once,
+   *  on the transition into parked. Root and operator-only gates stay on Todos. */
+  notifyParked(input: {
+    todoId: string; workflowId: string; runId: string; nodeId: string; request: string; ref: string;
+  }): void;
+}
+
+export interface WorkflowTodoSessionLink {
+  link(input: { todoId: string; sessionId: string }): void;
+  /** Start the bound Todo's run row for this attempt. Idempotent per session,
+   *  so a re-entered dispatch adds no second row. */
+  openRun(input: { todoId: string; sessionId: string; startedAt: string }): void;
+  /** Settle the run this attempt opened. A session with no open run — an
+   *  attempt that never dispatched, or one already settled by the path that
+   *  reached the terminal state first — is a no-op, not a failure. */
+  closeRun(input: {
+    sessionId: string; outcome: TodoRunOutcome; endedAt: string;
+    summary?: string; handoff?: TodoRunHandoff; error?: string;
+  }): void;
+}
+
+export interface WorkflowTodoLifecycle {
+  reflect(input: { todoId: string; status: WorkflowRunReflection; workflowId: string; runId: string; nodeId: string }): void;
+  recordApprovalDecision(input: {
+    todoId: string; workflowId: string; runId: string; nodeId: string;
+    decision: "approve" | "reject"; decidedBy: string; choice?: string; note?: string;
+  }): void;
+  complete(input: {
+    todoId: string; workflowId: string; runId: string; nodeId: string;
+    approvedBy: string; approvedAt: string;
+  }): void;
+  /** Write onto the bound Todo why a run settled failed: which node died, the
+   *  error, and the run id. Factual, no LLM call. */
+  recordFailure(input: { todoId: string; workflowId: string; runId: string; nodeId: string; error: WorkflowError }): void;
+  /** Send the work round again from a rejection that carried feedback (see
+   *  `WorkflowRevisionRequest`). The run has already stopped when this is called. */
+  requestRevision(input: WorkflowRevisionRequest): void;
+}
+
+/** Where a re-armed Todo has to land for the workflow's own trigger to fire it
+ *  again, or the reason no re-arm can fire at all. `actor` and `label` are the
+ *  trigger's own filters, carried so the re-arm can check it would fire —
+ *  `label` also has to be re-applied, because a node prompt that disarmed the
+ *  Todo mid-run has taken it off. */
+export type WorkflowRearmTarget =
+  | { status: string; actor?: string; label?: string }
+  | { unavailable: string };
+
+/**
+ * A run-bound Approval gate was rejected WITH a note. A note turns "no" into
+ * "not yet — do it again with this", so the Todo goes round rather than the run
+ * ending: the note becomes the current requirement, and the Todo returns to the
+ * status its workflow's trigger fires on.
+ */
+export interface WorkflowRevisionRequest {
+  todoId: string;
+  workflowId: string;
+  runId: string;
+  nodeId: string;
+  /** The rejecter's note, trimmed and non-empty — this IS the new instruction. */
+  feedback: string;
+  /** Who rejected it. Becomes the actor of the re-arm, because they decided it. */
+  decidedBy: string;
+  rearm: WorkflowRearmTarget;
+}
+
+/**
+ * The engine/model a run's bound Todo says its NEXT attempt should use
+ * (ICI-733). Read once per attempt at dispatch, so setting one never disturbs
+ * an attempt already running. Absent port = no overrides (the run still
+ * executes on the node's own configuration).
+ */
+export interface WorkflowTodoDispatchOverride {
+  /** Undefined when the Todo has no dispatch preferences of its own. */
+  read(todoId: string): { engine: string | null; model: string | null } | undefined;
+}

--- a/packages/jimmy/src/workflows/todo-run-ledger.ts
+++ b/packages/jimmy/src/workflows/todo-run-ledger.ts
@@ -1,0 +1,89 @@
+import { logger } from "../shared/logger.js";
+import { isRateLimitMessage } from "../shared/rateLimit.js";
+import { normalizeTodoRunHandoff, type TodoRunOutcome } from "../work-items/runs.js";
+import type { WorkflowNodeOutput } from "./model.js";
+import type { WorkflowError, WorkflowRunDetail } from "./runtime.js";
+import type { WorkflowTodoSessionLink } from "./todo-ports.js";
+
+/**
+ * What a Todo-bound run writes into that Todo's run ledger: one row per phase
+ * ATTEMPT, opened when the attempt gets a session and settled when it reaches a
+ * terminal state.
+ *
+ * Which files an attempt changed and which checks it ran are facts about the
+ * ATTEMPT, so a retry has to leave the previous attempt's evidence readable
+ * rather than overwrite it — which is the whole reason these are rows and not
+ * fields on the Todo.
+ *
+ * Every write is best-effort, exactly like session attribution: the ledger is
+ * evidence, and evidence must never take the run down with it.
+ */
+
+/** The four states an attempt can settle in. */
+export type WorkflowAttemptTerminalStatus = "completed" | "failed" | "timed-out" | "cancelled";
+
+/** How a terminal attempt reads in the ledger. `failed` is the only split: an
+ *  employee that ran and reported a verdict left BLOCKED work, while a
+ *  transport fault that produced no output is a CRASH — and an agent deciding
+ *  whether to try the same thing again needs to tell those apart.
+ *
+ *  A quota window outranks all of it (ICI-731). The attempt did not fail, time
+ *  out or get cancelled at the work: the provider turned it away, and reading
+ *  the error is the only way that fact reaches the ledger — no error CODE says
+ *  it, because every transport spells it differently in the message. */
+export function todoRunOutcome(status: WorkflowAttemptTerminalStatus, errorCode?: string,
+  errorMessage?: string): TodoRunOutcome {
+  if (status === "completed") return "completed";
+  if (isRateLimitMessage(errorMessage)) return "rate_limited";
+  if (status === "timed-out") return "timed_out";
+  if (status === "cancelled") return "abandoned";
+  return errorCode === "workflow-submitted-failure" ? "blocked" : "crashed";
+}
+
+export function openTodoRun(link: WorkflowTodoSessionLink | undefined, run: WorkflowRunDetail,
+  sessionId: string, startedAt: string): void {
+  record(link, run, (ledger, todoId) => ledger.openRun({ todoId, sessionId, startedAt }));
+}
+
+/**
+ * Settle the row of an attempt that just reached a terminal state. EVERY
+ * terminal path routes through here — one that skipped it would leave an
+ * attempt reading as still running forever, which is why the outcome comes from
+ * `todoRunOutcome` and not from a judgement made at each call site.
+ */
+export function settleTodoRun(link: WorkflowTodoSessionLink | undefined, run: WorkflowRunDetail,
+  attempt: { sessionId?: string }, settle: {
+    status: WorkflowAttemptTerminalStatus; endedAt: string; error?: WorkflowError; output?: WorkflowNodeOutput;
+    /** What a phase that submitted FAILURE reported. A success carries its
+     *  handoff on `output.fields`; a failure has no output to carry it, and
+     *  that report is the one the next attempt most needs to read. Deliberately
+     *  NOT checked against the node's success schema on the way in: a phase that
+     *  failed must not have its honest report rejected for missing an output it
+     *  never got to produce. Known keys are kept, the rest dropped. */
+    handoff?: unknown;
+  }): void {
+  const sessionId = attempt.sessionId;
+  if (!sessionId) return;
+  const summary = settle.output?.text ?? settle.error?.message;
+  const handoff = normalizeTodoRunHandoff(settle.output?.fields ?? settle.handoff);
+  record(link, run, (ledger) => ledger.closeRun({
+    sessionId,
+    outcome: todoRunOutcome(settle.status, settle.error?.code, settle.error?.message),
+    endedAt: settle.endedAt,
+    ...(summary ? { summary } : {}),
+    ...(Object.keys(handoff).length > 0 ? { handoff } : {}),
+    ...(settle.error ? { error: settle.error.message } : {}),
+  }));
+}
+
+function record(link: WorkflowTodoSessionLink | undefined, run: WorkflowRunDetail,
+  write: (ledger: WorkflowTodoSessionLink, todoId: string) => void): void {
+  const todoId = run.trigger.todoId;
+  if (!todoId || !link) return;
+  try {
+    write(link, todoId);
+  } catch (error) {
+    logger.warn(`Workflow run ${run.id} could not record a run on Todo ${todoId}: `
+      + `${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/packages/jimmy/src/workflows/trigger-config-schema.ts
+++ b/packages/jimmy/src/workflows/trigger-config-schema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+/**
+ * What each trigger kind accepts. It sits beside `model.ts` rather than inside
+ * it so the filter surface can grow without pushing that file past its size
+ * budget; the node schema that wraps it stays there.
+ */
+export const triggerConfigSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('manual') }),
+  z.strictObject({ kind: z.literal('schedule'), cron: z.string(), timezone: z.string() }),
+  z.strictObject({
+    kind: z.literal('event'),
+    eventName: z.string().min(1).max(80).regex(/^[A-Za-z][A-Za-z0-9._-]*$/),
+    tokenRef: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal('todo-status'),
+    status: z.string(),
+    /** Who performed the status transition — `operator` for the human surface,
+     *  `session:<uuid>` for an agent, `reconciler`/`policy:trust` for derived
+     *  moves. This is the only filter that is an authority boundary: a label
+     *  any employee can attach is not one. */
+    actor: z.string().min(1).max(120).optional(),
+    /** Opt out of `workflows.armingDelegates`, so an `actor: operator` filter on
+     *  this binding means the operator and nobody the operator has delegated
+     *  arming to. `false` is the only storable value: leaving it unset is what
+     *  accepting delegates looks like. */
+    delegates: z.literal(false).optional(),
+    label: z.string().min(1).max(80).optional(),
+    department: z.string().min(1).max(80).optional(),
+    /** Matched against the Todo's assignee, which the `assigned` STATUS does not
+     *  imply: assigning is its own action (`assignWorkItem`), and a plain status
+     *  move to `assigned` leaves the assignee null. Filtering on `assignee` for
+     *  such a Todo never fires — pick the status the assignment itself produces. */
+    assignee: z.string().min(1).max(80).optional(),
+    /** These three read the Todo's CURRENT row when the trigger fires rather than
+     *  the provenance snapshot frozen into the status event, so a Todo re-tagged,
+     *  reassigned, or re-parented after it moved is judged as it stands now.
+     *  `true` is the only storable value: a persisted `false` reads as a filter
+     *  that is set and matches everything, which is never what an author meant. */
+    unlabeled: z.literal(true).optional(),
+    unassigned: z.literal(true).optional(),
+    rootOnly: z.literal(true).optional(),
+  }),
+  z.strictObject({ kind: z.literal('workflow-call') }),
+]);

--- a/packages/jimmy/src/workflows/trigger-service.ts
+++ b/packages/jimmy/src/workflows/trigger-service.ts
@@ -1,0 +1,287 @@
+import { Buffer } from "node:buffer";
+import cron, { type ScheduledTask } from "node-cron";
+import { validateCronSchedule } from "../cron/validation.js";
+import { logger } from "../shared/logger.js";
+import { claimWorkItem, releaseWorkItemClaim } from "../work-items/claims.js";
+import { normalizeLabelName } from "../work-items/labels.js";
+import { appendRespawnGuardHold, checkRespawnGuard } from "../work-items/respawn-guards.js";
+import { createWorkflowTodoEventFeed, type WorkflowTodoEventFeed,
+  type WorkflowTodoStatusEvent } from "../work-items/workflow-event-feed.js";
+import { startedAfterEvent } from "../work-items/workflow-event-winners.js";
+import { jsonValueSchema, type JsonValue, type TriggerNode, type WorkflowDefinition } from "./model.js";
+import { WorkflowRepositoryError, type WorkflowRepository } from "./repository.js";
+import type { WorkflowRunDetail } from "./runtime.js";
+import type { WorkflowRunner } from "./runner.js";
+import { owningWorkflowId } from "../work-items/workflow-ownership.js";
+import { declinedOutcomes, NOTHING_SUPERSEDED, settle, stillWhereTheEventLeftIt, suppressAll,
+  type IndexedTrigger, type SupersededBy, type TodoCandidate, type TodoMismatch } from "./todo-event-outcome.js";
+
+export interface FireWorkflowEventInput {
+  eventName: string;
+  fireId: string;
+  payload: Record<string, JsonValue>;
+}
+
+interface ScheduleIndex extends IndexedTrigger { task: ScheduledTask }
+function bad(message: string): never { throw new WorkflowRepositoryError("bad-input", message); }
+function payload(value: unknown): Record<string, JsonValue> {
+  const parsed = jsonValueSchema.safeParse(value);
+  if (!parsed.success || parsed.data === null || typeof parsed.data !== "object" || Array.isArray(parsed.data)) {
+    bad("Workflow event payload must be a JSON object.");
+  }
+  if (Buffer.byteLength(JSON.stringify(parsed.data), "utf8") > 64 * 1024) bad("Workflow event payload must be at most 64 KiB.");
+  return parsed.data as Record<string, JsonValue>;
+}
+function trigger(definition: WorkflowDefinition, kind: TriggerNode["config"]["kind"]): TriggerNode | undefined {
+  return definition.nodes.find((node): node is TriggerNode => node.type === "trigger" && node.config.kind === kind);
+}
+function labelMatches(filter: string, labels: WorkflowTodoStatusEvent["item"]["labels"]): boolean {
+  let name: string; try { name = normalizeLabelName(filter); } catch { return false; }
+  return labels.some((label) => label.id === filter || label.name === name);
+}
+function refused(reason: string): TodoMismatch { return { filter: "other", reason }; }
+/** Why this Todo event does NOT match the trigger, or undefined when it does.
+ *  Filters are ANDed; the first mismatch is what gets reported, so a suppressed
+ *  run always says which filter refused it. */
+function todoMismatch(node: TriggerNode, event: WorkflowTodoStatusEvent): TodoMismatch | undefined {
+  if (node.config.kind !== "todo-status") return refused("trigger is not a todo-status trigger");
+  const { actor, label, department, assignee, delegates, unlabeled, unassigned, rootOnly } = node.config;
+  // An arming delegate moved the Todo as itself, so the event names its session
+  // rather than the operator; the stamp the status route wrote at that moment is
+  // what says the operator's authority stands behind it. Only an `operator`
+  // filter is widened, and only where the binding has not opted out.
+  const armed = actor === "operator" && delegates !== false && event.armedAsDelegate !== null;
+  const resumed = actor === "operator" && (event.quotaWindowDecided || event.armedAsRecovery === true);
+  if (actor !== undefined && actor !== event.actor && !armed && !resumed) {
+    return refused(`actor ${event.actor ?? "unknown"} is not ${actor}`);
+  }
+  if (department !== undefined && department !== event.item.department) return refused(`department filter ${department} does not match`);
+  if (assignee !== undefined && assignee !== event.item.assignee) return refused(`assignee filter ${assignee} does not match`);
+  const live = event.item.live;
+  if (unlabeled !== undefined || unassigned !== undefined || rootOnly !== undefined) {
+    // These three assert what the Todo IS right now, so a row that has since been
+    // deleted answers none of them — an unknown Todo must refuse rather than fall
+    // through as a match and arm a workflow on nothing.
+    if (live === null) return refused("the Todo no longer exists, so its live filters cannot match");
+    if (unlabeled && event.item.labels.length > 0) return refused("unlabeled filter does not match: the Todo carries labels");
+    if (unassigned && live.assignee !== null) return refused(`unassigned filter does not match: the Todo is assigned to ${live.assignee}`);
+    if (rootOnly && live.parentId !== null) return refused(`rootOnly filter does not match: the Todo is a child of ${live.parentId}`);
+  }
+  // Judged LAST on purpose: a `label` mismatch has to mean that every other filter
+  // was satisfied, or a Todo refused for something a label cannot change would be
+  // read as a race and left waiting for a label that would not have helped.
+  if (label !== undefined && !labelMatches(label, event.item.labels)) {
+    return { filter: "label", reason: `label filter ${label} does not match` };
+  }
+  return undefined;
+}
+export class WorkflowTriggerService {
+  private readonly schedules = new Map<string, ScheduleIndex>();
+  private readonly todos = new Map<string, IndexedTrigger[]>();
+  private readonly feed: WorkflowTodoEventFeed;
+
+  constructor(private readonly repository: WorkflowRepository, private readonly runner: WorkflowRunner,
+    private readonly now: () => string = () => new Date().toISOString(), feed?: WorkflowTodoEventFeed) {
+    this.feed = feed ?? createWorkflowTodoEventFeed();
+    this.rebuild();
+  }
+  dispose(): void { for (const item of this.schedules.values()) item.task.stop(); this.schedules.clear(); this.todos.clear(); }
+
+  rebuild(): void {
+    this.dispose();
+    for (const definition of this.enabledDefinitions()) {
+      const schedule = trigger(definition, "schedule");
+      if (schedule && schedule.config.kind === "schedule") this.addSchedule(definition, schedule);
+      const todo = trigger(definition, "todo-status");
+      if (todo && todo.config.kind === "todo-status") {
+        const items = this.todos.get(todo.config.status) ?? []; items.push({ definition, trigger: todo });
+        this.todos.set(todo.config.status, items);
+      }
+    }
+  }
+
+  async fire(input: FireWorkflowEventInput): Promise<WorkflowRunDetail[]> {
+    if (!/^[A-Za-z][A-Za-z0-9._-]{0,79}$/.test(input.eventName)
+      || typeof input.fireId !== "string" || input.fireId.length < 1 || input.fireId.length > 128) bad("Workflow event identity is invalid.");
+    const eventPayload = payload(input.payload); const runs: WorkflowRunDetail[] = [];
+    for (const definition of this.enabledDefinitions()) {
+      const event = definition.nodes.find((node): node is TriggerNode => node.type === "trigger"
+        && node.config.kind === "event" && node.config.eventName === input.eventName);
+      if (event) runs.push(await this.start(definition, event, input.fireId, eventPayload, `event:${input.fireId}`));
+    }
+    return runs;
+  }
+
+  async recoverTodoEvents(): Promise<number> {
+    if (this.todos.size === 0) return 0;
+    const pending = this.feed.listPendingEvents(500);
+    const superseded = this.supersededDefinitions(pending);
+    let count = 0;
+    for (const event of pending) count += await this.fireTodo(event, superseded.get(event.id) ?? NOTHING_SUPERSEDED);
+    return count;
+  }
+
+  /** A Todo whose label stood down leaves a backlog of unclaimed events behind,
+   *  and restoring the label makes all of them qualify at once — six runs on one
+   *  Todo in half a minute. For each (Todo, definition) only the newest
+   *  qualifying event runs. `listPendingEvents` hands them back oldest first, so
+   *  walking backwards makes the first sighting of a key the winner. */
+  private supersededDefinitions(pending: ReadonlyArray<WorkflowTodoStatusEvent>): Map<string, Map<string, string>> {
+    const winners = new Map<string, string>();
+    const superseded = new Map<string, Map<string, string>>();
+    for (let index = pending.length - 1; index >= 0; index -= 1) {
+      const event = pending[index]!;
+      for (const item of this.todos.get(event.toStatus) ?? []) {
+        if (todoMismatch(item.trigger, event) !== undefined) continue;
+        const key = `${event.workItemId}\u0000${item.definition.id}`;
+        const winner = winners.get(key);
+        if (winner === undefined) { winners.set(key, event.id); continue; }
+        const forEvent = superseded.get(event.id) ?? new Map<string, string>();
+        forEvent.set(item.definition.id, winner);
+        superseded.set(event.id, forEvent);
+      }
+    }
+    return superseded;
+  }
+
+  private enabledDefinitions(): WorkflowDefinition[] {
+    const definitions: WorkflowDefinition[] = []; let cursor: string | undefined;
+    do {
+      const page = this.repository.listDefinitions({ enabled: true, limit: 100, ...(cursor ? { cursor } : {}) });
+      definitions.push(...page.items.map((item) => this.repository.getDefinition(item.id)!).filter(Boolean));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor);
+    return definitions;
+  }
+
+  private addSchedule(definition: WorkflowDefinition, schedule: TriggerNode): void {
+    if (schedule.config.kind !== "schedule") return;
+    // A row stored before the authoring gate existed can still be unarmable;
+    // skip-and-log it exactly as the Cron scheduler does, rather than throwing
+    // out of rebuild() and taking the whole gateway down at boot.
+    const errors = validateCronSchedule({ schedule: schedule.config.cron, timezone: schedule.config.timezone });
+    if (errors.length > 0) {
+      logger.warn(`Skipping invalid Workflow schedule "${definition.id}": ${errors.map((error) => error.message).join("; ")}`);
+      return;
+    }
+    const revision = definition.revision;
+    const task = cron.schedule(schedule.config.cron, () => { void this.fireSchedule(definition.id, revision); },
+      { timezone: schedule.config.timezone });
+    this.schedules.set(definition.id, { definition, trigger: schedule, task });
+  }
+
+  private async fireSchedule(workflowId: string, revision: number): Promise<void> {
+    const indexed = this.schedules.get(workflowId);
+    if (!indexed || indexed.definition.revision !== revision) return;
+    const fireId = this.now();
+    await this.start(indexed.definition, indexed.trigger, fireId, { scheduledAt: fireId }, `schedule:${fireId}`);
+  }
+
+  private async fireTodo(event: WorkflowTodoStatusEvent, pendingWinners: SupersededBy): Promise<number> {
+    const candidates: TodoCandidate[] = (this.todos.get(event.toStatus) ?? [])
+      .map((item) => ({ ...item, mismatch: todoMismatch(item.trigger, event) }));
+    const superseded = this.supersededForEvent(event, candidates, pendingWinners);
+    // Drop the superseded definitions BEFORE the claim: the claim stores the ids
+    // a lease takeover replays from, so one we have decided not to run must
+    // never be written into it.
+    const indexed = candidates.filter((item) => item.mismatch === undefined && !superseded.has(item.definition.id));
+    const claim = this.feed.claimEvent(event.id, indexed.map((item) => item.definition.id));
+    if (claim.state !== "acquired") return 0;
+    const allowed = new Set(claim.definitionIds);
+    // A deferred re-drain is only re-deciding the definitions the deferral put
+    // back; every other candidate was settled by the pass that deferred, and
+    // recording it again here would overwrite what actually happened to it.
+    const deciding = claim.deferred ? candidates.filter((item) => allowed.has(item.definition.id)) : candidates;
+    const outcomes = declinedOutcomes(event, deciding, superseded, claim.deferred === true);
+    const labels = event.item.labels.map((label) => label.name);
+    let runnable = indexed.filter((candidate) => allowed.has(candidate.definition.id));
+    const bound = owningWorkflowId(event.workItemId);
+    if (bound !== undefined && runnable.some((candidate) => candidate.definition.id === bound)) {
+      for (const extra of runnable.filter((candidate) => candidate.definition.id !== bound)) {
+        const detail = `Todo event ${event.id} suppressed: ${event.workItemId} already belongs to workflow \`${bound}\`.`;
+        logger.info(`Workflow ${extra.definition.id}: ${detail}`);
+        outcomes.push({ workflowId: extra.definition.id, outcome: "suppressed", detail });
+      }
+      runnable = runnable.filter((candidate) => candidate.definition.id === bound);
+    }
+    const owner = `workflow:${event.id}`;
+    const refusal = this.refusalBeforeStart(event, claim.deferred === true, runnable, owner);
+    if (refusal !== undefined) return suppressAll(this.feed, event, runnable, outcomes, refusal);
+    try {
+      for (const item of runnable) {
+        const run = await this.start(item.definition, item.trigger, event.id, {
+          todoId: event.workItemId, fromStatus: event.fromStatus, toStatus: event.toStatus,
+          actor: event.actor, source: event.item.source, department: event.item.department,
+          assignee: event.item.assignee, labels, labelList: labels.join(", "),
+        }, `todo:${event.id}`, event.workItemId);
+        outcomes.push({ workflowId: item.definition.id, outcome: "started", runId: run.id, detail: `Todo event ${event.id} started.` });
+      }
+      settle(this.feed, event, deciding, outcomes);
+      return outcomes.filter((outcome) => outcome.outcome === "started").length;
+    } catch (error) { releaseWorkItemClaim(event.workItemId, owner); this.feed.releaseEvent(event.id); throw error; }
+  }
+
+  /** Which definitions a newer event has already taken this Todo's lane for.
+   *  The pending page answers this for siblings still waiting their turn; it
+   *  cannot answer it for one that has already run, because a settled event is
+   *  no longer pending — and past the page's own limit it cannot answer it at
+   *  all. A deferral released after either kind of sibling would otherwise see
+   *  an empty gate and start a second run on a lane already running. */
+  private supersededForEvent(event: WorkflowTodoStatusEvent, candidates: ReadonlyArray<TodoCandidate>,
+    pendingWinners: SupersededBy): SupersededBy {
+    // Nothing qualified, so nothing can be beaten, and the ordinary drain pays
+    // nothing for a query with no question in it.
+    if (!candidates.some((item) => item.mismatch === undefined)) return pendingWinners;
+    const settled = startedAfterEvent(event.id);
+    if (settled.size === 0) return pendingWinners;
+    // Both maps name events strictly newer than this one, so either detail line
+    // is true. The pending page wins the tie: it is the same rule the drain has
+    // already applied to this event's waiting siblings.
+    const winners = new Map(settled);
+    for (const [definitionId, winner] of pendingWinners) winners.set(definitionId, winner);
+    return winners;
+  }
+
+  /** Why nothing may start on this event yet, or undefined when a run may. The
+   *  filters have already had their say; these are the three things that stop a
+   *  fire this late, and they all refuse the whole event rather than one
+   *  definition of it. */
+  private refusalBeforeStart(event: WorkflowTodoStatusEvent, deferred: boolean,
+    runnable: ReadonlyArray<IndexedTrigger>, owner: string): string | undefined {
+    // A deferral is only good while the Todo sits where the event put it. Once it
+    // has moved on the event is stale, and a label landing later must not fire a
+    // run on work that has already gone somewhere else.
+    if (deferred && !stillWhereTheEventLeftIt(event)) return `${event.workItemId} has moved on from ${event.toStatus}`;
+    // Nothing is going to run, so there is no work to hold and no guard to ask:
+    // taking the Todo's claim here would only lock it against somebody who will.
+    if (runnable.length === 0) return undefined;
+    // The respawn guards run BEFORE the claim (ICI-731): this is the automated
+    // re-dispatch lane — status-driven pickup, and workflow re-arm one hop later
+    // through the status transition it writes — and a Todo a guard refuses must
+    // stay free for a human to dispatch by hand. One event, one audited hold,
+    // however many definitions were about to run on it. A re-arm the availability
+    // sweep wrote arrives with the quota window already settled from the
+    // failure's own reset, so `rate_limit_cooldown` does not get to answer that
+    // question again generically; the other three guards still do.
+    const guard = checkRespawnGuard(event.workItemId, undefined, { quotaWindowDecided: event.quotaWindowDecided });
+    if (guard.state === "held") {
+      appendRespawnGuardHold(event.workItemId, guard, owner);
+      return `the ${guard.guard} guard holds it: ${guard.reason}`;
+    }
+    // Claim the TODO, not just the event: the event claim stops this event being
+    // replayed, and this stops a DIFFERENT event — or another gateway — starting
+    // a second run on work somebody is already doing. A rejected claim means the
+    // Todo row is gone, and a Todo that no longer exists cannot be double-worked.
+    const todo = claimWorkItem({ workItemId: event.workItemId, owner });
+    return todo.state === "held" ? `${event.workItemId} is already being worked by ${todo.claim.owner}` : undefined;
+  }
+
+  private async start(definition: WorkflowDefinition, source: TriggerNode, fireId: string,
+    triggerPayload: Record<string, JsonValue>, idempotencyKey: string, todoId?: string): Promise<WorkflowRunDetail> {
+    const created = this.repository.createRun({ workflowId: definition.id, input: {},
+      trigger: { nodeId: source.id, kind: source.config.kind, fireId, payload: triggerPayload, ...(todoId ? { todoId } : {}) },
+      idempotencyKey });
+    const detail = this.repository.getRun(definition.id, created.id)!;
+    return detail.status === "pending" ? this.runner.start(created.id) : detail;
+  }
+}

--- a/packages/jimmy/src/workflows/validation-end-requires.ts
+++ b/packages/jimmy/src/workflows/validation-end-requires.ts
@@ -1,0 +1,34 @@
+import type { WorkflowDefinition } from './model.js';
+import type { WorkflowValidationIssue } from './issues.js';
+
+/**
+ * A success End that demands landing evidence has to name an output field some
+ * node in the same definition actually declares. Refused at save, because a
+ * demand pointing at nothing can never be met — and the run that would discover
+ * that is one that has already done the work.
+ */
+
+function reference(definition: WorkflowDefinition, endId: string, path: string,
+  ref: { nodeId: string; field: string }): WorkflowValidationIssue[] {
+  const target = definition.nodes.find((node) => node.id === ref.nodeId);
+  const named = `field \`${ref.field}\` from node \`${ref.nodeId}\``;
+  if (!target) {
+    return [{ code: 'unknown-required-node', message: `An End requires ${named}, which this Workflow does not define.`,
+      nodeId: endId, path: `${path}.nodeId` }];
+  }
+  if (target.type !== 'employee' || !Object.hasOwn(target.config.output?.fields ?? {}, ref.field)) {
+    return [{ code: 'unknown-required-field', message: `An End requires ${named}, which that node does not declare as an output field.`,
+      nodeId: endId, path: `${path}.field` }];
+  }
+  return [];
+}
+
+export function endRequirementIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  return definition.nodes.flatMap((node, index) => {
+    if (node.type !== 'end' || !node.config.requires) return [];
+    const { commitIn, ...evidence } = node.config.requires;
+    const path = `nodes.${index}.config.requires`;
+    return [...reference(definition, node.id, path, evidence),
+      ...(commitIn ? reference(definition, node.id, `${path}.commitIn`, commitIn) : [])];
+  });
+}

--- a/packages/jimmy/src/workflows/validation-workflow-call.ts
+++ b/packages/jimmy/src/workflows/validation-workflow-call.ts
@@ -1,0 +1,55 @@
+import type { WorkflowDefinition } from './model.js';
+import type { WorkflowValidationIssue } from './issues.js';
+
+/**
+ * The rules a Workflow Call node has to pass, split by when they can be judged.
+ *
+ * `workflowCallSaveIssues` are node-local and refused at save, alongside the
+ * other rules a definition must never be stored carrying. A loop nobody bounded
+ * belongs here: "every loop bounded by construction" is not a property that can
+ * wait until someone enables the Workflow. `maxRounds` parses as optional only
+ * because a missing bound has to survive far enough to be named — a definition
+ * that fails the schema can report nothing more useful than "invalid".
+ *
+ * `workflowCallIterationIssues` are about wiring, so they can only be judged
+ * once the graph is whole, and are refused at the executable gate. Holding a
+ * half-drawn loop to them would make the node unsaveable while it is being
+ * drawn, the same reason `unreachable-node` waits.
+ */
+
+export const ITERATION_EXHAUSTED_PORT = 'exhausted';
+
+export function workflowCallSaveIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  return definition.nodes.flatMap((node, index) => {
+    if (node.type !== 'workflow-call') return [];
+    const issues: WorkflowValidationIssue[] = [];
+    if (node.config.workflowId.source === 'fixed' && node.config.workflowId.value === definition.id) {
+      issues.push({ code: 'workflow-call-self-reference',
+        message: 'A Workflow Call cannot target its own defining Workflow.',
+        nodeId: node.id, path: `nodes.${index}.config.workflowId` });
+    }
+    if (node.config.iterate?.maxRounds === undefined && node.config.iterate) {
+      issues.push({ code: 'unbounded-iteration',
+        message: 'A Workflow Call that iterates must set maxRounds, so the loop is bounded by the definition rather than by whatever the rounds decide.',
+        nodeId: node.id, path: `nodes.${index}.config.iterate.maxRounds` });
+    }
+    if (node.config.iterate && node.config.items) {
+      issues.push({ code: 'iteration-with-fanout',
+        message: 'A Workflow Call cannot both iterate and fan out over items. Fan-out is a width fixed up front; iteration is a depth decided round by round.',
+        nodeId: node.id, path: `nodes.${index}.config.items` });
+    }
+    return issues;
+  });
+}
+
+export function workflowCallIterationIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  return definition.nodes.flatMap((node, index) => node.type === 'workflow-call' && node.config.iterate
+    && !definition.edges.some((edge) => edge.from.nodeId === node.id && edge.from.port === ITERATION_EXHAUSTED_PORT)
+    ? [{
+        code: 'iteration-missing-exhausted-route',
+        message: `A Workflow Call that iterates must wire its ${ITERATION_EXHAUSTED_PORT} port, so a loop that spends every round still has somewhere to go.`,
+        nodeId: node.id,
+        path: `nodes.${index}.config.iterate`,
+      }]
+    : []);
+}

--- a/packages/jimmy/src/workflows/validation.ts
+++ b/packages/jimmy/src/workflows/validation.ts
@@ -1,0 +1,480 @@
+import {
+  jsonValueSchema,
+  workflowDefinitionSchema,
+  workflowNodeSchema,
+  type Binding,
+  type WorkflowDefinition,
+  type WorkflowEdge,
+  type WorkflowNode,
+} from './model.js';
+import { validateBindingPath } from './bindings.js';
+import { validateCronSchedule } from '../cron/validation.js';
+import type { WorkflowValidationIssue } from './issues.js';
+import { ITERATION_EXHAUSTED_PORT, workflowCallIterationIssues, workflowCallSaveIssues } from './validation-workflow-call.js';
+import { endRequirementIssues } from './validation-end-requires.js';
+
+export type { WorkflowValidationIssue } from './issues.js';
+export { workflowCallSaveIssues } from './validation-workflow-call.js';
+export { endRequirementIssues };
+
+type AddIssue = (issue: WorkflowValidationIssue) => void;
+type RecordValue = Record<string, unknown>;
+type EdgeParts = { id: string; fromId: string; fromPort: string; toId: string; toPort: string };
+type ValidEdge = EdgeParts & { edgeIndex: number; source: WorkflowNode; target: WorkflowNode };
+type Graph = {
+  outgoing: Map<string, ValidEdge[]>;
+  incoming: Map<string, ValidEdge[]>;
+  forward: Map<string, string[]>;
+  reverse: Map<string, string[]>;
+};
+type BindingCheckContext = { declared: Set<string>; graph: Graph; known: Set<string>; add: AddIssue };
+
+const PORT = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const FORBIDDEN_PORTS = new Set(['__proto__', 'prototype', 'constructor']);
+const CYCLE_MESSAGE = 'Workflow graph contains a directed cycle.';
+const INVALID_DEFINITION_MESSAGE = 'Workflow definition is invalid.';
+const REFERENCE_MESSAGE = 'Workflow graph contains an unknown node reference.';
+function record(value: unknown): RecordValue | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as RecordValue
+    : undefined;
+}
+
+function normalizedValue(value: unknown): unknown | undefined {
+  const normalized = jsonValueSchema.safeParse(value);
+  return normalized.success ? normalized.data : undefined;
+}
+
+function safeDefinition(value: WorkflowDefinition): WorkflowDefinition | undefined {
+  const normalized = normalizedValue(value);
+  if (normalized === undefined) return undefined;
+  const parsed = workflowDefinitionSchema.safeParse(normalized);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function safeNode(value: WorkflowNode): WorkflowNode | undefined {
+  const normalized = normalizedValue(value);
+  if (normalized === undefined) return undefined;
+  const parsed = workflowNodeSchema.safeParse(normalized);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function nodesOf(definition: WorkflowDefinition): WorkflowNode[] {
+  const nodes = record(definition)?.nodes;
+  return Array.isArray(nodes) ? nodes as WorkflowNode[] : [];
+}
+
+function edgesOf(definition: WorkflowDefinition): WorkflowEdge[] {
+  const edges = record(definition)?.edges;
+  return Array.isArray(edges) ? edges as WorkflowEdge[] : [];
+}
+
+function nodeId(node: WorkflowNode): string | undefined {
+  const id = record(node)?.id;
+  return typeof id === 'string' ? id : undefined;
+}
+
+function validConditionPort(value: unknown): value is string {
+  return typeof value === 'string' && PORT.test(value) && !FORBIDDEN_PORTS.has(value);
+}
+
+function conditionValues(node: WorkflowNode): { cases?: unknown[]; defaultPort?: unknown } {
+  const config = record(record(node)?.config);
+  return { cases: Array.isArray(config?.cases) ? config.cases : undefined, defaultPort: config?.defaultPort };
+}
+
+function conditionPorts(node: WorkflowNode): string[] {
+  const { cases, defaultPort } = conditionValues(node);
+  const ports: string[] = [];
+  const seen = new Set<string>();
+  for (const item of cases ?? []) {
+    const port = record(item)?.port;
+    if (validConditionPort(port) && !seen.has(port)) {
+      ports.push(port);
+      seen.add(port);
+    }
+  }
+  if (validConditionPort(defaultPort) && !seen.has(defaultPort)) ports.push(defaultPort);
+  return ports;
+}
+
+function portsOf(node: WorkflowNode): string[] {
+  const type = record(node)?.type;
+  switch (type) {
+    case 'trigger': return ['success'];
+    case 'employee': return ['success', 'error'];
+    case 'workflow-call': return record(record(node)?.config)?.iterate
+      ? ['success', ITERATION_EXHAUSTED_PORT] : ['success'];
+    case 'condition': return conditionPorts(node);
+    case 'merge': return ['success'];
+    case 'approval': return ['approved', 'rejected'];
+    case 'wait': return ['success'];
+    case 'end': return [];
+    default: return [];
+  }
+}
+
+export function outputPorts(node: WorkflowNode): string[] {
+  const safe = safeNode(node);
+  return safe ? portsOf(safe) : [];
+}
+
+function edgeParts(edge: WorkflowEdge): EdgeParts | undefined {
+  const value = record(edge);
+  const from = record(value?.from);
+  const to = record(value?.to);
+  if (typeof value?.id !== 'string' || typeof from?.nodeId !== 'string' || typeof from.port !== 'string'
+    || typeof to?.nodeId !== 'string' || typeof to.port !== 'string') return undefined;
+  return { id: value.id, fromId: from.nodeId, fromPort: from.port, toId: to.nodeId, toPort: to.port };
+}
+
+function addConditionIssues(nodes: WorkflowNode[], add: AddIssue): void {
+  for (const [nodeIndex, node] of nodes.entries()) {
+    if (record(node)?.type !== 'condition') continue;
+    const id = nodeId(node);
+    const { cases, defaultPort } = conditionValues(node);
+    const seen = new Set<string>();
+    if (!cases) add({ code: 'invalid-condition-port', message: 'Condition ports must be unique, nonempty path-safe identifiers.', nodeId: id, path: `nodes.${nodeIndex}.config.cases` });
+    for (const [caseIndex, item] of (cases ?? []).entries()) {
+      const port = record(item)?.port;
+      if (!validConditionPort(port) || seen.has(port)) {
+        add({ code: 'invalid-condition-port', message: 'Condition ports must be unique, nonempty path-safe identifiers.', nodeId: id, path: `nodes.${nodeIndex}.config.cases.${caseIndex}.port` });
+      } else seen.add(port);
+    }
+    if (!validConditionPort(defaultPort) || seen.has(defaultPort)) {
+      add({ code: 'invalid-condition-port', message: 'Condition ports must be unique, nonempty path-safe identifiers.', nodeId: id, path: `nodes.${nodeIndex}.config.defaultPort` });
+    }
+  }
+}
+
+function checkBinding(value: unknown, path: string, id: string | undefined, context: BindingCheckContext,
+  self: 'self-allowed' | 'self-rejected' = 'self-rejected'): void {
+  const binding = record(value) as (RecordValue & Partial<Binding>) | undefined;
+  if (!binding || binding.source === 'fixed' || typeof binding.path !== 'string') return;
+  try { validateBindingPath(binding.path); }
+  catch { context.add({ code: 'invalid-binding-path', message: 'Binding path is invalid.', nodeId: id, path }); }
+  if (binding.source === 'input' && binding.path.length > 0) {
+    const key = binding.path.split('.')[0]!;
+    if (!context.declared.has(key)) context.add({ code: 'undeclared-input', message: 'Input binding references an undeclared Workflow input.', nodeId: id, path });
+  }
+  if (binding.source !== 'node' || typeof binding.nodeId !== 'string' || !id) return;
+  if (!context.known.has(binding.nodeId)) {
+    context.add({ code: 'unknown-node-binding', message: 'Node binding references an unknown node.', nodeId: id, path });
+  } else if (binding.nodeId === id ? self === 'self-rejected' : !walk([id], context.graph.reverse).has(binding.nodeId)) {
+    context.add({ code: 'non-predecessor-binding', message: 'Node binding must reference a reachable predecessor.', nodeId: id, path });
+  }
+}
+
+function addNodeBindingIssues(node: WorkflowNode, nodeIndex: number, context: BindingCheckContext): void {
+  const value = record(node);
+  const config = record(value?.config);
+  const id = nodeId(node);
+  const base = `nodes.${nodeIndex}.config`;
+  if (value?.type === 'employee') {
+    for (const key of ['employee', 'engine', 'model', 'effort']) checkBinding(config?.[key], `${base}.${key}`, id, context);
+    const continued = record(config?.continueFrom)?.nodeId;
+    if (typeof continued === 'string' && !context.known.has(continued)) context.add({ code: 'unknown-continue-node', message: 'Continuation references an unknown node.', nodeId: id, path: `${base}.continueFrom.nodeId` });
+  } else if (value?.type === 'workflow-call') {
+    for (const key of ['workflowId', 'items', 'concurrency']) checkBinding(config?.[key], `${base}.${key}`, id, context);
+    for (const [key, binding] of Object.entries(record(config?.input) ?? {})) checkBinding(binding, `${base}.input.${key}`, id, context);
+    const continueWhile = record(config?.iterate)?.continueWhile;
+    for (const [index, predicate] of (Array.isArray(continueWhile) ? continueWhile : []).entries()) {
+      const itemPath = `${base}.iterate.continueWhile.${index}`;
+      checkBinding(record(predicate)?.left, `${itemPath}.left`, id, context, 'self-allowed');
+      checkBinding(record(predicate)?.right, `${itemPath}.right`, id, context, 'self-allowed');
+    }
+  } else if (value?.type === 'condition') {
+    const cases = Array.isArray(config?.cases) ? config.cases : [];
+    for (const [caseIndex, item] of cases.entries()) {
+      const predicates = Array.isArray(record(item)?.all) ? record(item)!.all as unknown[] : [];
+      for (const [predicateIndex, predicate] of predicates.entries()) {
+        const itemPath = `${base}.cases.${caseIndex}.all.${predicateIndex}`;
+        checkBinding(record(predicate)?.left, `${itemPath}.left`, id, context);
+        checkBinding(record(predicate)?.right, `${itemPath}.right`, id, context);
+      }
+    }
+  } else if (value?.type === 'approval') checkBinding(config?.approver, `${base}.approver`, id, context);
+  else if (value?.type === 'wait' && config?.mode === 'until') checkBinding(config.timestamp, `${base}.timestamp`, id, context);
+  else if (value?.type === 'end') checkBinding(config?.output, `${base}.output`, id, context);
+}
+
+function addBindingIssues(definition: WorkflowDefinition, nodes: WorkflowNode[], graph: Graph, add: AddIssue): void {
+  const rawInputs = record(definition)?.inputs;
+  const declared = new Set((Array.isArray(rawInputs) ? rawInputs : [])
+    .map((item) => record(item)?.key).filter((key): key is string => typeof key === 'string'));
+  const known = new Set(nodes.map(nodeId).filter((id): id is string => id !== undefined));
+  const context = { declared, graph, known, add };
+  for (const [nodeIndex, node] of nodes.entries()) addNodeBindingIssues(node, nodeIndex, context);
+}
+
+function inspectEdges(nodes: WorkflowNode[], edges: WorkflowEdge[], add: AddIssue): ValidEdge[] {
+  const byId = new Map(nodes.map((node) => [nodeId(node), node]).filter((item): item is [string, WorkflowNode] => item[0] !== undefined));
+  const routes = new Set<string>();
+  const ordinaryIncoming = new Set<string>();
+  const valid: ValidEdge[] = [];
+  for (const [edgeIndex, edge] of edges.entries()) {
+    const part = edgeParts(edge);
+    if (!part) continue;
+    const source = byId.get(part.fromId);
+    const target = byId.get(part.toId);
+    if (!source) add({ code: 'unknown-source-node', message: 'Edge source must reference an existing node.', nodeId: part.fromId, edgeId: part.id });
+    if (!target) add({ code: 'unknown-target-node', message: 'Edge target must reference an existing node.', nodeId: part.toId, edgeId: part.id });
+    const sourcePortValid = source ? portsOf(source).includes(part.fromPort) : false;
+    if (source && !sourcePortValid) add({ code: 'invalid-source-port', message: 'Edge source port is not available on its source node.', nodeId: part.fromId, edgeId: part.id });
+    const targetPortValid = part.toPort === 'input';
+    if (!targetPortValid) add({ code: 'invalid-target-port', message: 'Edge target port must be input.', nodeId: part.toId, edgeId: part.id });
+    if (record(source)?.type === 'end') add({ code: 'end-outgoing', message: 'End nodes cannot have outgoing edges.', nodeId: part.fromId, edgeId: part.id });
+    if (!source || !target || !sourcePortValid || !targetPortValid) continue;
+    const route = JSON.stringify([part.fromId, part.fromPort, part.toId, part.toPort]);
+    if (routes.has(route)) {
+      add({ code: 'duplicate-edge', message: 'Edge duplicates an earlier authored route.', nodeId: part.fromId, edgeId: part.id });
+      continue;
+    }
+    routes.add(route);
+    const targetType = record(target)?.type;
+    if (targetType === 'trigger') {
+      add({ code: 'trigger-incoming', message: 'Trigger nodes cannot have incoming edges.', nodeId: part.toId, edgeId: part.id });
+      continue;
+    }
+    if (targetType !== 'merge' && ordinaryIncoming.has(part.toId)) {
+      add({ code: 'multiple-incoming', message: 'Node accepts at most one incoming edge.', nodeId: part.toId, edgeId: part.id });
+      continue;
+    }
+    if (targetType !== 'merge') ordinaryIncoming.add(part.toId);
+    valid.push({ ...part, edgeIndex, source, target });
+  }
+  return valid;
+}
+
+function buildGraph(nodes: WorkflowNode[], edges: ValidEdge[]): Graph {
+  const ids = nodes.map(nodeId).filter((id): id is string => id !== undefined);
+  const outgoing = new Map(ids.map((id) => [id, [] as ValidEdge[]]));
+  const incoming = new Map(ids.map((id) => [id, [] as ValidEdge[]]));
+  const forward = new Map(ids.map((id) => [id, [] as string[]]));
+  const reverse = new Map(ids.map((id) => [id, [] as string[]]));
+  for (const edge of edges) {
+    outgoing.get(edge.fromId)?.push(edge);
+    incoming.get(edge.toId)?.push(edge);
+    forward.get(edge.fromId)?.push(edge.toId);
+    reverse.get(edge.toId)?.push(edge.fromId);
+  }
+  return { outgoing, incoming, forward, reverse };
+}
+
+function walk(starts: string[], links: Map<string, string[]>): Set<string> {
+  const visited = new Set<string>();
+  const stack = [...starts].reverse();
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (visited.has(id)) continue;
+    visited.add(id);
+    const next = links.get(id) ?? [];
+    for (let index = next.length - 1; index >= 0; index -= 1) stack.push(next[index]!);
+  }
+  return visited;
+}
+
+function addCycleIssues(nodes: WorkflowNode[], graph: Graph, add: AddIssue): void {
+  const color = new Map<string, 0 | 1 | 2>();
+  for (const node of nodes) {
+    const start = nodeId(node);
+    if (!start || color.has(start)) continue;
+    color.set(start, 1);
+    const stack: Array<{ id: string; next: number }> = [{ id: start, next: 0 }];
+    while (stack.length > 0) {
+      const frame = stack.at(-1)!;
+      const edges = graph.outgoing.get(frame.id) ?? [];
+      if (frame.next >= edges.length) {
+        color.set(frame.id, 2);
+        stack.pop();
+        continue;
+      }
+      const edge = edges[frame.next++]!;
+      if (color.get(edge.toId) === 1) add({ code: 'cycle', message: 'Workflow graph must not contain directed cycles.', nodeId: edge.toId, edgeId: edge.id });
+      else if (!color.has(edge.toId)) {
+        color.set(edge.toId, 1);
+        stack.push({ id: edge.toId, next: 0 });
+      }
+    }
+  }
+}
+
+function addCardinalityIssues(nodes: WorkflowNode[], graph: Graph, add: AddIssue): void {
+  for (const node of nodes) {
+    const id = nodeId(node);
+    if (!id) continue;
+    const incoming = graph.incoming.get(id) ?? [];
+    const type = record(node)?.type;
+    if (type === 'merge' && new Set(incoming.map((edge) => edge.fromId)).size < 2) {
+      add({ code: 'merge-predecessors', message: 'Merge nodes require at least two distinct predecessor nodes.', nodeId: id });
+    }
+  }
+}
+
+function addReachabilityIssues(nodes: WorkflowNode[], graph: Graph, add: AddIssue): void {
+  const triggers = nodes.filter((node): node is Extract<WorkflowNode, { type: 'trigger' }> => node.type === 'trigger');
+  const triggerIds = triggers.map(nodeId).filter((id): id is string => id !== undefined);
+  const endIds = nodes.filter((node) => record(node)?.type === 'end').map(nodeId).filter((id): id is string => id !== undefined);
+  if (triggers.length === 0) add({ code: 'trigger-count', message: 'Workflow must contain at least one Trigger.' });
+  const triggerKinds = new Set<string>();
+  for (const trigger of triggers) {
+    if (triggerKinds.has(trigger.config.kind)) {
+      add({ code: 'duplicate-trigger-kind', message: `Workflow must contain at most one ${trigger.config.kind} Trigger.`, nodeId: trigger.id });
+    }
+    triggerKinds.add(trigger.config.kind);
+  }
+  const reachable = walk(triggerIds, graph.forward);
+  const reachesEnd = walk(endIds, graph.reverse);
+  if (!endIds.some((id) => reachable.has(id))) add({ code: 'missing-end-path', message: 'A Trigger must have a directed path to an End.' });
+  for (const node of nodes) {
+    const id = nodeId(node);
+    if (!id) continue;
+    const type = record(node)?.type;
+    if (type !== 'trigger' && !reachable.has(id)) add({ code: 'unreachable-node', message: 'Node is not reachable from a Trigger.', nodeId: id });
+    if (type !== 'end' && reachable.has(id) && !reachesEnd.has(id)) add({ code: 'dead-node', message: 'Reachable non-End node has no path to an End.', nodeId: id });
+  }
+}
+
+function issueRanks<T extends { id?: unknown }>(items: T[]): Map<string, number> {
+  const ranks = new Map<string, number>();
+  for (const [index, item] of items.entries()) {
+    const id = record(item)?.id;
+    if (typeof id === 'string' && !ranks.has(id)) ranks.set(id, index);
+  }
+  return ranks;
+}
+
+function finalizeIssues(issues: WorkflowValidationIssue[], nodes: WorkflowNode[], edges: WorkflowEdge[]): WorkflowValidationIssue[] {
+  const nodeRanks = issueRanks(nodes as Array<{ id?: unknown }>);
+  const edgeRanks = issueRanks(edges as Array<{ id?: unknown }>);
+  const unique = new Map<string, WorkflowValidationIssue>();
+  for (const item of issues) {
+    const key = JSON.stringify([item.code, item.nodeId ?? null, item.edgeId ?? null, item.path ?? null]);
+    if (!unique.has(key)) unique.set(key, item);
+  }
+  const rank = (value: string | undefined, ranks: Map<string, number>) => value === undefined ? Number.MAX_SAFE_INTEGER : (ranks.get(value) ?? Number.MAX_SAFE_INTEGER);
+  return [...unique.values()].sort((left, right) => {
+    const leftGlobal = left.nodeId === undefined && left.edgeId === undefined;
+    const rightGlobal = right.nodeId === undefined && right.edgeId === undefined;
+    return Number(leftGlobal) - Number(rightGlobal)
+      || rank(left.nodeId, nodeRanks) - rank(right.nodeId, nodeRanks)
+      || rank(left.edgeId, edgeRanks) - rank(right.edgeId, edgeRanks)
+      || left.code.localeCompare(right.code)
+      || (left.path ?? '').localeCompare(right.path ?? '')
+      || left.message.localeCompare(right.message);
+  });
+}
+
+/** A Schedule trigger declares the same two strings a Cron job does, so Cron's
+ *  validator owns them here too — otherwise `z.string()` lets an unparseable
+ *  expression become a durable enabled row that only fails when it is armed. */
+export function scheduleTriggerIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  const issues: WorkflowValidationIssue[] = [];
+  for (const node of safeDefinition(definition)?.nodes ?? []) {
+    if (node.type !== 'trigger' || node.config.kind !== 'schedule') continue;
+    for (const error of validateCronSchedule({ schedule: node.config.cron, timezone: node.config.timezone })) {
+      issues.push({ code: 'invalid-schedule', message: error.message, nodeId: node.id,
+        path: error.field === 'schedule' ? 'config.cron' : 'config.timezone' });
+    }
+  }
+  return issues;
+}
+
+/** `unlabeled` and `label` contradict each other, so a trigger setting both can
+ *  never fire. A silently unarmable definition is worse than a rejected save:
+ *  nothing distinguishes it from a Todo that simply has not moved yet. */
+export function todoTriggerFilterIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  const safe = safeDefinition(definition);
+  if (!safe) return [];
+  return safe.nodes.flatMap((node, index) => node.type === 'trigger' && node.config.kind === 'todo-status'
+    && node.config.unlabeled !== undefined && node.config.label !== undefined
+    ? [{
+        code: 'conflicting-todo-filters',
+        message: 'A todo-status trigger cannot set both unlabeled and label: a Todo carrying no labels can never carry the one named. Set only one.',
+        nodeId: node.id,
+        path: `nodes.${index}.config.unlabeled`,
+      }]
+    : []);
+}
+
+/** A `todo-comment` Wait resumes on a comment on the run's bound Todo, and only
+ *  some Trigger kinds can bind one. `schedule` and `event` never do, so a node
+ *  they alone can reach could only ever time out — refused here rather than at
+ *  the run, where the operator sees it days later. A node no Trigger reaches
+ *  yet is a mid-edit draft and stays saveable; the `unreachable-node` rule owns
+ *  that case. */
+export function todoCommentWaitTriggerIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  const safe = safeDefinition(definition);
+  if (!safe) return [];
+  const nodes = nodesOf(safe);
+  const graph = buildGraph(nodes, inspectEdges(nodes, edgesOf(safe), () => {}));
+  const bindsTodo = new Map(nodes.filter((node) => node.type === 'trigger')
+    .map((node) => [node.id, node.config.kind !== 'schedule' && node.config.kind !== 'event']));
+  const issues: WorkflowValidationIssue[] = [];
+  for (const [index, node] of nodes.entries()) {
+    if (node.type !== 'wait' || node.config.mode !== 'todo-comment') continue;
+    const reaching = [...walk([node.id], graph.reverse)].filter((id) => bindsTodo.has(id));
+    if (reaching.length === 0 || reaching.some((id) => bindsTodo.get(id))) continue;
+    issues.push({ code: 'todo-comment-wait-trigger',
+      message: 'A Wait node that waits for a Todo comment must be reachable from a Trigger that binds a Todo.',
+      nodeId: node.id, path: `nodes.${index}.config.mode` });
+  }
+  return issues;
+}
+
+export function validateExecutableWorkflow(definition: WorkflowDefinition): { ok: boolean; issues: WorkflowValidationIssue[] } {
+  const safe = safeDefinition(definition);
+  if (!safe) return {
+    ok: false,
+    issues: [{ code: 'invalid-definition', message: INVALID_DEFINITION_MESSAGE }],
+  };
+  const nodes = nodesOf(safe);
+  const edges = edgesOf(safe);
+  const collected: WorkflowValidationIssue[] = [];
+  const add: AddIssue = (item) => { collected.push(item); };
+  addConditionIssues(nodes, add);
+  const validEdges = inspectEdges(nodes, edges, add);
+  const graph = buildGraph(nodes, validEdges);
+  addBindingIssues(safe, nodes, graph, add);
+  addCycleIssues(nodes, graph, add);
+  addCardinalityIssues(nodes, graph, add);
+  addReachabilityIssues(nodes, graph, add);
+  for (const item of [scheduleTriggerIssues(safe), todoTriggerFilterIssues(safe), workflowCallSaveIssues(safe),
+    workflowCallIterationIssues(safe), todoCommentWaitTriggerIssues(safe), endRequirementIssues(safe)].flat()) add(item);
+  const issues = finalizeIssues(collected, nodes, edges);
+  return { ok: issues.length === 0, issues };
+}
+
+export function topologicalOrder(definition: WorkflowDefinition): string[] {
+  const safe = safeDefinition(definition);
+  if (!safe) throw new Error(INVALID_DEFINITION_MESSAGE);
+  const nodes = nodesOf(safe);
+  const edges = edgesOf(safe);
+  const ids = nodes.map(nodeId);
+  if (ids.some((id) => id === undefined) || new Set(ids).size !== ids.length) throw new Error(REFERENCE_MESSAGE);
+  const authored = new Map((ids as string[]).map((id, index) => [id, index]));
+  const outgoing = new Map((ids as string[]).map((id) => [id, [] as string[]]));
+  const indegree = new Map((ids as string[]).map((id) => [id, 0]));
+  for (const edge of edges) {
+    const part = edgeParts(edge);
+    if (!part || !authored.has(part.fromId) || !authored.has(part.toId)) throw new Error(REFERENCE_MESSAGE);
+    outgoing.get(part.fromId)!.push(part.toId);
+    indegree.set(part.toId, indegree.get(part.toId)! + 1);
+  }
+  const ready = (ids as string[]).filter((id) => indegree.get(id) === 0);
+  const ordered: string[] = [];
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    ordered.push(id);
+    for (const target of outgoing.get(id)!) {
+      const remaining = indegree.get(target)! - 1;
+      indegree.set(target, remaining);
+      if (remaining === 0) {
+        ready.push(target);
+        ready.sort((left, right) => authored.get(left)! - authored.get(right)!);
+      }
+    }
+  }
+  if (ordered.length !== nodes.length) throw new Error(CYCLE_MESSAGE);
+  return ordered;
+}

--- a/packages/jimmy/src/workflows/wait-comment-output.ts
+++ b/packages/jimmy/src/workflows/wait-comment-output.ts
@@ -1,0 +1,40 @@
+import { formatAttachmentRef } from "./attachment-ref.js";
+import type { WorkflowNode, WorkflowNodeOutput } from "./model.js";
+
+/**
+ * What a `todo-comment` Wait completes with. Its own module because the two
+ * endings have to agree: `attachments` rides both, so a downstream binding on
+ * it resolves whether the operator answered or the deadline did — a Condition
+ * on the timeout path must not throw `missing-value`.
+ */
+
+/** A parked Wait hands the operator's reply straight into downstream prompts, so
+ *  a pasted essay must not become the run's whole context. */
+const MAX_WAIT_COMMENT_CHARS = 4_000;
+
+function boundedComment(body: string): string {
+  return body.length <= MAX_WAIT_COMMENT_CHARS ? body : `${body.slice(0, MAX_WAIT_COMMENT_CHARS)}\n… (truncated)`;
+}
+
+/** The operator answered. Their files come through as refs — never bytes, so
+ *  nothing binary ever enters the run. */
+export function commentReplyOutput(
+  todoId: string,
+  comment: { id: string; body: string; attachments: ReadonlyArray<{ id: string; mime: string }> },
+): WorkflowNodeOutput {
+  const body = boundedComment(comment.body);
+  return { text: body, fields: {
+    outcome: "reply",
+    commentId: comment.id,
+    comment: body,
+    attachments: comment.attachments.map((item) => formatAttachmentRef({ ...item, workItemId: todoId })),
+  } };
+}
+
+/** A Wait that reaches its own `resumeAt`. Only `todo-comment` distinguishes
+ *  the two ways it can end, and it says so on the way out. */
+export function waitDueOutput(node: WorkflowNode | undefined): WorkflowNodeOutput {
+  return node?.type === "wait" && node.config.mode === "todo-comment"
+    ? { text: "", fields: { outcome: "timeout", attachments: [] } }
+    : { text: "", fields: {} };
+}

--- a/packages/jimmy/src/workflows/wire.ts
+++ b/packages/jimmy/src/workflows/wire.ts
@@ -1,0 +1,89 @@
+/**
+ * The Workflow HTTP wire contract, expressed off the canonical schemas and
+ * records rather than restated beside them.
+ *
+ * There is no serializer layer: `json()` in `gateway/route-helpers.ts` is a bare
+ * `JSON.stringify` of whatever the repository returned. So the repository types
+ * *are* what goes over the wire. What this module declares rather than
+ * re-exports is only what no canonical module already names: the run-detail
+ * projections from `gateway/workflow-api.ts`, the two list-endpoint shapes,
+ * and the trigger-kind alias the schema keeps private.
+ *
+ * Every line is `export type`, and that is load-bearing rather than stylistic:
+ * `model.ts` value-imports `node:util/types` through `normalizeJson()`.
+ * `packages/web` consumes this module and its Vite config carries no Node
+ * polyfills, so dropping the `type` keyword on one line is a Rollup failure,
+ * not a warning. For the same reason nothing here reaches the storage layer:
+ * the two list-endpoint shapes are declared below and the repository imports
+ * them back, rather than this module importing the module that owns the DB.
+ */
+import type { WorkflowAttemptRecord, WorkflowRunDetail, WorkflowRunRecord, WorkflowRunStatus } from './runtime.js';
+
+export type {
+  Binding,
+  ConditionPredicate,
+  JsonValue,
+  WorkflowDefinition,
+  WorkflowNode,
+  WorkflowNodeOutput,
+  WorkflowOutputSchema,
+} from './model.js';
+
+export type {
+  ResolvedEmployeeConfig,
+  WorkflowApprovalRecord,
+  WorkflowAttemptStatus,
+  WorkflowChildRunSummary,
+  WorkflowError,
+  WorkflowNodeRunRecord,
+  WorkflowNodeRunStatus,
+  WorkflowRunDetail,
+  WorkflowRunRecord,
+  WorkflowRunStatus,
+} from './runtime.js';
+
+export type { WorkflowValidationIssue } from './issues.js';
+
+/** `GET /api/workflows` — the definition list. `description` and `retiredAt` are
+ *  normalized to `null` here where the definition leaves them absent. */
+export interface WorkflowDefinitionSummary {
+  id: string; title: string; description: string | null; revision: number; enabled: boolean;
+  retiredAt: string | null; createdAt: string; updatedAt: string;
+}
+
+/** `GET /api/workflows/:id/runs` — the run list. */
+export interface WorkflowRunSummary {
+  id: string; workflowId: string; workflowTitle: string; definitionRevision: number; status: WorkflowRunStatus;
+  trigger: { nodeId: string; kind: WorkflowTriggerKind };
+  startedAt: string; endedAt: string | null;
+  currentOrFailingNode: {
+    nodeId: string; label: string; employeeId: string | null; state: 'current' | 'failing';
+  } | null;
+}
+
+/** How a run was started. The schema keeps the trigger arms private, and the
+ *  run record is the surface that carries the kind, so it is the handle. */
+export type WorkflowTriggerKind = WorkflowRunRecord['trigger']['kind'];
+
+/** An attempt as every route sends it: `withoutAttemptInput()` drops `input`,
+ *  which always repeats the value already on the attempt's own node run. */
+export type WorkflowAttemptWire = Omit<WorkflowAttemptRecord, 'input'>;
+
+/** `GET /api/workflows/:id/runs/:runId?view=full` — `fullRunDetail()`. */
+export type WorkflowRunDetailWire = Omit<WorkflowRunDetail, 'attempts'> & {
+  attempts: WorkflowAttemptWire[];
+  spendUsd: number;
+};
+
+/** The same route without `?view=full` — `leanRunDetail()`. The definition
+ *  snapshot and the interpolated prompts are both immutable once written, so
+ *  polling carries them forward from one full fetch instead of re-sending. */
+export type WorkflowRunLeanWire = Omit<WorkflowRunDetailWire, 'definition' | 'attempts'> & {
+  attempts: Omit<WorkflowAttemptWire, 'promptText'>[];
+};
+
+/** What the run routes that own no projection return. `POST /runs`, the
+ *  approval decision, cancel, rerun and retry all send `service.*()` verbatim,
+ *  so their bodies carry `attempts[].input` and no `spendUsd` — unlike the read
+ *  route beside them. Typed as it behaves; reconciling the two is ICI-1190. */
+export type WorkflowRunDetailUnprojectedWire = WorkflowRunDetail;

--- a/packages/jimmy/src/workflows/workflow-call.ts
+++ b/packages/jimmy/src/workflows/workflow-call.ts
@@ -1,0 +1,165 @@
+import { resolveBinding, type WorkflowBindingContext } from "./bindings.js";
+import { readCapacitySnapshot, resolveFanoutConcurrency, type FanoutConcurrency } from "./capacity.js";
+import type { JsonValue, WorkflowCallNode, WorkflowIteration, WorkflowNodeOutput } from "./model.js";
+import { bindingContext, resolveString } from "./node-dispatch.js";
+import { predicatesHold } from "./predicates.js";
+import type { WorkflowChildRunSummary, WorkflowRunDetail } from "./runtime.js";
+
+/**
+ * What a Workflow Call node resolves to before the runner acts on it.
+ *
+ * The node has two shapes and they are exclusive. `items` is fan-out: a width
+ * known up front, every child independent, all of them in flight at once up to
+ * the concurrency ceiling. `iterate` is a loop: a depth discovered as it goes,
+ * one child at a time, each round free to read what the round before it
+ * returned. Both spend the same machinery — a child run per unit of work, keyed
+ * by `itemIndex` — which is why they share a file and a node type.
+ */
+
+/** How many children at once, and over what. `[null]` is the single-call case:
+ *  not a special path, just a fan-out of width one. */
+export interface FanoutPlan {
+  workflowId: string;
+  concurrency: FanoutConcurrency;
+  items: JsonValue[];
+  hasItems: boolean;
+}
+
+type CapacityReader = (() => Parameters<typeof readCapacitySnapshot>[0]) | undefined;
+
+export function fanoutPlan(run: WorkflowRunDetail, node: WorkflowCallNode, capacity: CapacityReader,
+  activeChildren: number): FanoutPlan {
+  const context = bindingContext(run);
+  const workflowId = resolveString(node.config.workflowId, context, "Workflow Call target");
+  const concurrency = resolveFanoutConcurrency(node, context, capacity ? readCapacitySnapshot(capacity(), activeChildren) : null);
+  if (!node.config.items) return { workflowId, concurrency, items: [null], hasItems: false };
+  const items = resolveBinding(node.config.items, context);
+  if (!Array.isArray(items)) throw new Error(`Workflow Call ${node.id} items must resolve to an array.`);
+  if (items.length > 100) throw new Error(`Workflow Call ${node.id} items may contain at most 100 entries.`);
+  return { workflowId, concurrency, items, hasItems: true };
+}
+
+export function fanoutInput(run: WorkflowRunDetail, node: WorkflowCallNode, plan: FanoutPlan, index: number): Record<string, JsonValue> {
+  const base = bindingContext(run);
+  const context: WorkflowBindingContext = {
+    ...base,
+    trigger: {
+      ...base.trigger,
+      itemIndex: index,
+      ...(plan.hasItems ? { item: plan.items[index]! } : {}),
+    },
+  };
+  return mapCallInput(node, context);
+}
+
+function mapCallInput(node: WorkflowCallNode, context: WorkflowBindingContext): Record<string, JsonValue> {
+  return Object.fromEntries(Object.entries(node.config.input ?? {})
+    .map(([key, binding]) => [key, resolveBinding(binding, context)]));
+}
+
+export function callChildren(run: WorkflowRunDetail, nodeId: string): WorkflowChildRunSummary[] {
+  return run.childRuns.filter((child) => child.nodeId === nodeId);
+}
+
+export function childTerminal(child: WorkflowChildRunSummary): boolean {
+  return ["completed", "failed", "cancelled"].includes(child.status);
+}
+
+export function validateFanoutChildren(node: WorkflowCallNode, plan: FanoutPlan, children: WorkflowChildRunSummary[]): void {
+  if (children.some((child) => child.itemIndex !== undefined && child.itemIndex >= plan.items.length)) {
+    throw new Error(`Workflow Call ${node.id} has a child outside its item range.`);
+  }
+}
+
+/** The node's loop settings, with the bound proved present. Validation refuses
+ *  to make a definition with `iterate` executable until it carries one, so a node
+ *  reaching the runner without it got here some other way and says so. */
+export function iterationSettings(node: WorkflowCallNode): Required<WorkflowIteration> {
+  const iterate = node.config.iterate;
+  if (iterate?.maxRounds === undefined) {
+    throw new Error(`Workflow Call ${node.id} iterates without a maxRounds bound. Set one on the node.`);
+  }
+  return { maxRounds: iterate.maxRounds, continueWhile: iterate.continueWhile };
+}
+
+/** What the node reads as, both while `continueWhile` is being asked and after
+ *  the last round settles — one shape, so a predicate and a downstream binding
+ *  name the same path. `last` is the round that just finished; `rounds` is the
+ *  audit trail, one entry per child run in the order they ran. */
+function iterationFields(children: readonly WorkflowChildRunSummary[], maxRounds: number): Record<string, JsonValue> {
+  const rounds = children.map((child, index) => ({
+    round: index + 1,
+    runId: child.runId,
+    workflowId: child.workflowId,
+    status: child.status === "completed" ? "succeeded" : child.status,
+    fields: child.endOutput ?? {},
+  }));
+  return {
+    round: children.length,
+    maxRounds,
+    last: children.at(-1)?.endOutput ?? {},
+    rounds,
+  };
+}
+
+/** Ask the round that just finished whether it wants another. The node stands
+ *  for its own latest output while the predicates read it — the one place a
+ *  Workflow Call binds to itself, and only because the round has already run. */
+function wantsAnotherRound(run: WorkflowRunDetail, node: WorkflowCallNode, settings: Required<WorkflowIteration>,
+  fields: Record<string, JsonValue>): boolean {
+  const base = bindingContext(run);
+  const context: WorkflowBindingContext = {
+    ...base,
+    nodes: { ...base.nodes, [node.id]: { status: "running", output: { text: "", fields }, error: null } },
+  };
+  return predicatesHold(settings.continueWhile, context);
+}
+
+export type IterationStep =
+  | { kind: "run"; round: number; input: Record<string, JsonValue>; workflowId: string }
+  | { kind: "settle"; port: "success" | "exhausted"; output: WorkflowNodeOutput };
+
+/** The whole loop decision, in one place: run the next round, leave through
+ *  `success` because nothing asked for another, or leave through `exhausted`
+ *  because the bound ran out while something still did. Exhaustion is a route,
+ *  not a failure — the run carries on down whatever the author wired there.
+ *
+ *  A round that did not complete is neither. `continueWhile` reads the round's
+ *  output, and a broken round has none, so letting it fall through would read a
+ *  crashed body as a loop that finished cleanly — and asking a body that just
+ *  failed for another round is worse. Both stop here, loudly. */
+export function iterationStep(run: WorkflowRunDetail, node: WorkflowCallNode,
+  children: readonly WorkflowChildRunSummary[]): IterationStep {
+  const settings = iterationSettings(node);
+  const { maxRounds } = settings;
+  const broken = children.find((child) => child.status !== "completed");
+  if (broken) {
+    throw new Error(`Workflow Call ${node.id} round ${children.indexOf(broken) + 1} ${broken.status} `
+      + `(run ${broken.runId})${broken.error ? `: ${broken.error.message}` : ""}. `
+      + `A loop cannot judge a round that did not finish; fix the target Workflow or retry the round.`);
+  }
+  if (children.length > 0) {
+    const fields = iterationFields(children, maxRounds);
+    if (!wantsAnotherRound(run, node, settings, fields)) return { kind: "settle", port: "success", output: iterationOutput(fields, "success") };
+    if (children.length >= maxRounds) return { kind: "settle", port: "exhausted", output: iterationOutput(fields, "exhausted") };
+  }
+  // One round at a time, so the fan-out concurrency ceiling has nothing to say here.
+  const workflowId = resolveString(node.config.workflowId, bindingContext(run), "Workflow Call target");
+  return { kind: "run", round: children.length + 1, workflowId, input: iterationInput(run, node, children.length + 1, maxRounds) };
+}
+
+function iterationOutput(fields: Record<string, JsonValue>, port: "success" | "exhausted"): WorkflowNodeOutput {
+  return { text: "", fields: { ...fields, port, exhausted: port === "exhausted" } };
+}
+
+/** The round's own view of itself, mapped into the target's inputs. This is what
+ *  lets the last round say something the first one did not — the difference a
+ *  duplicated round-2 node exists to express today. */
+function iterationInput(run: WorkflowRunDetail, node: WorkflowCallNode, round: number, maxRounds: number): Record<string, JsonValue> {
+  const base = bindingContext(run);
+  const context: WorkflowBindingContext = {
+    ...base,
+    trigger: { ...base.trigger, itemIndex: round - 1, round, maxRounds },
+  };
+  return mapCallInput(node, context);
+}

--- a/packages/jimmy/vitest.config.ts
+++ b/packages/jimmy/vitest.config.ts
@@ -5,5 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/__tests__/**/*.test.ts'],
+    globalSetup: './vitest.global-setup.ts',
+    setupFiles: ['./vitest.setup.ts'],
   },
 })

--- a/packages/jimmy/vitest.global-setup.ts
+++ b/packages/jimmy/vitest.global-setup.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Redirect the ryoko home to a throwaway directory BEFORE any test worker
+ * loads shared/paths.ts — without this, suites that touch the session
+ * registry or the workflow store write into the real ~/.ryoko.
+ * (Ported rationale from upstream jinn's vitest.global-setup.ts.)
+ */
+export default function setup(): () => void {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ryoko-vitest-home-'));
+  // JINN_HOME only: RYOKO_HOME outranks it in resolveHome(), and upstream-authored
+  // suites re-point JINN_HOME at their own temp roots — a lingering RYOKO_HOME
+  // would silently override every one of them.
+  delete process.env.RYOKO_HOME;
+  process.env.JINN_HOME = home;
+  return () => {
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+  };
+}

--- a/packages/jimmy/vitest.setup.ts
+++ b/packages/jimmy/vitest.setup.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Per-worker home isolation. The globalSetup hands every fork the same temp
+ * root; suites in CONCURRENT forks would then share one sessions registry, and
+ * a boot sweep in one file (restart-redispatch's recoverStaleWorkflowAttempt-
+ * Sessions) can stamp `interrupted` over another file's mid-turn session.
+ * Runs before the test module is imported, so shared/paths.ts resolves the
+ * per-process home. A test file that re-points JINN_HOME at its own mkdtemp
+ * still wins — it does so before dynamically importing the modules under test.
+ */
+const base = process.env.JINN_HOME;
+if (base) {
+  const workerHome = path.join(base, `w-${process.pid}`);
+  fs.mkdirSync(workerHome, { recursive: true });
+  process.env.JINN_HOME = workerHome;
+}

--- a/packages/jimmy/vitest.setup.ts
+++ b/packages/jimmy/vitest.setup.ts
@@ -12,7 +12,12 @@ import path from 'node:path';
  */
 const base = process.env.JINN_HOME;
 if (base) {
-  const workerHome = path.join(base, `w-${process.pid}`);
+  // Pool ID first: under a threads pool every worker shares one PID, so PID
+  // alone would collapse the isolation this file exists to provide. The PID
+  // stays as a suffix so the forks pool (isolate: true — a fresh fork per test
+  // file) also separates sequential files that reuse a pool slot.
+  const worker = `${process.env.VITEST_POOL_ID ?? '0'}-${process.pid}`;
+  const workerHome = path.join(base, `w-${worker}`);
   fs.mkdirSync(workerHome, { recursive: true });
   process.env.JINN_HOME = workerHome;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       ws:
         specifier: ^8.21.3
         version: 8.21.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
@@ -3415,6 +3418,9 @@ packages:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -6639,6 +6645,8 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.18)(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## 概要

上流 `hristo2612/jinn` (`12c1b976`) の Workflow 基盤を OpenRyoko へ移植する縦切り第1弾（backend core）。
評価と設計判断は [docs/plans/2026-08-28-workflow-port-evaluation.md](https://github.com/rsensui2/OpenRyoko/blob/feat/workflow-port/docs/plans/2026-08-28-workflow-port-evaluation.md)、経緯は同 `2026-08-28-generic-task-routing-handoff.md` を参照。

**動機**: タスクの性質に応じて「決定的判定 / 軽量モデル / Opus級」を選べる基盤。Employee ノード単位の engine / model / effort / fallback 指定と、LLM を呼ばない Condition 分岐により、「Sonnet で判定 → 必要な時だけ Opus」を製品機能として表現できる。

## 変更内容

- **workflows/ core（49ファイル）**: trigger（manual / schedule / event）、ノード7種（Employee / Workflow Call / Condition / Merge / Approval / Wait / End）、repository + migrations（better-sqlite3）、runner / service / trigger-service。相対 import のためほぼ無改変
- **work-items shim（9ファイル・169行）**: 型は上流忠実・実装は不活性。event feed が常に空のため todo-status trigger は発火しない（work-items 8.8k 行を持ち込まない設計判断）
- **sessions 適応（唯一の実適応部分）**: registry に workflow attempt 関数群 + スキーマ移行（nullable/default 列の追加のみ）、manager に `runWorkflowAttempt` 等5メソッド。上流の attempt-token フェンスの代わりに queue の sessionKey 直列化 + 永続 dispatch claim + settle stamping で担保。attempt-continuation は単一 `engineSessionId` モデルに適応（codex 継続はコールド起動）
- **gateway**: `workflow-api.ts` + HTTP ヘルパ移植、`api.ts` / `server.ts` 配線
- **オプトイン**: `config.workflows.enabled`（既定 false）。無効時は DB 作成・trigger arming・API ルートすべて無し。既存 Cron / Slack respond-policy / MEMORY 注入には非干渉
- **テスト**: 上流42ファイル（811件）移植 + **vitest テストホーム隔離**（globalSetup + per-fork 分離 + paths.ts の fail-closed ガード。これまで `src/**/__tests__` のスイートは実 `~/.ryoko` に書ける状態だった）

## テスト

- [x] `tsc --noEmit` クリーン
- [x] 全テスト 143ファイル / 1,644件 green（うち Workflow 新規 811件）
- [x] 既存テストへの回帰なし

## スコープ外（後続PR）

- PR#2: Next.js 最小 UI（一覧・run 詳細・手動発火・JSON 定義エディタ）
- PR#3: 利用量帰属拡張（attempt 単位 token + 推定値表示）
- jimmy ネイティブの縦切り統合テスト（上流 workflow-vertical.test.ts は upstream MCP identity 結合が深く除外）
- todo-status trigger の実装（work-items 移植が前提）
- codex の attempt continuation（rollout 追跡の移植が前提）