### PR TITLE
fix(build): order web build before package assembly

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -44,6 +44,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@openryoko/web": "workspace:*",
     "@types/better-sqlite3": "^7.6.0",
     "@types/busboy": "^1.5.4",
     "@types/js-yaml": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@openryoko/web':
+        specifier: workspace:*
+        version: link:../web
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13


### PR DESCRIPTION
## Summary
- declare `@openryoko/web` as a workspace dev dependency of the CLI package
- let Turborepo apply the existing `^build` dependency before copying `packages/web/out`
- update the frozen pnpm lockfile

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (147 CLI files / 1,692 tests; 12 web files / 85 tests)

Linear: https://linear.app/tekion-jp/issue/TEK-558