### PR TITLE
fix(deps): node-pty の spawn-helper の実行権限を postinstall で復元（upstream jinn からの移植）

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=22"
   },
   "scripts": {
+    "postinstall": "node scripts/fix-prebuild-permissions.mjs",
     "build": "turbo build && rm -rf packages/jimmy/dist/web && cp -r packages/web/out packages/jimmy/dist/web",
     "dev": "turbo dev",
     "lint": "turbo lint",

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -14,10 +14,12 @@
   "types": "./dist/src/index.d.ts",
   "files": [
     "dist/",
-    "template/"
+    "template/",
+    "scripts/"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json && cp -r assets dist/assets && cp -r ../web/out dist/web",
+    "postinstall": "node scripts/fix-prebuild-permissions.mjs",
     "dev": "tsc && (tsc --watch &) && node --watch-path=dist dist/bin/jimmy.js start",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/jimmy/scripts/fix-prebuild-permissions.mjs
+++ b/packages/jimmy/scripts/fix-prebuild-permissions.mjs
@@ -1,0 +1,122 @@
+// Restore the executable bit on node-pty's spawn-helper after install.
+//
+// node-pty ships prebuilds/<platform>/spawn-helper with mode 0644 in its npm
+// tarball, and neither npm nor pnpm nor node-pty's own install scripts turn
+// it back into an executable. On macOS the native module then fails at the
+// first PTY start (posix_spawnp EACCES) — i.e. the gateway crashes the first
+// time a chat session starts an engine.
+//
+// This runs as the `postinstall` of the published package, so it covers both
+// layouts:
+//   - npm:  <this package>/node_modules/node-pty  (also hoisted / global)
+//   - pnpm: <workspace>/node_modules/.pnpm/node-pty@*/node_modules/node-pty
+// It resolves node-pty the way Node would (so hoisting and symlinks are
+// followed) and additionally scans any pnpm store found walking up from the
+// package directory. Everything is non-fatal: an install must never break
+// because a chmod could not be applied.
+import { chmod, readdir, realpath, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const MAX_WALK_UP = 6;
+const verbose = process.env.npm_config_loglevel === "verbose" || process.env.FIX_PREBUILD_VERBOSE === "1";
+
+function log(message) {
+  if (verbose) process.stdout.write(`fix-prebuild-permissions: ${message}\n`);
+}
+
+async function directories(target) {
+  try {
+    const entries = await readdir(target, { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory() || entry.isSymbolicLink()).map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+// Where Node would load node-pty from, seen from `base` — covers the npm
+// layout (nested, hoisted, or `npm install -g`) and a linked pnpm dependency.
+async function resolvedNodePty(base) {
+  const require = createRequire(path.join(base, "package.json"));
+  try {
+    return path.dirname(await realpath(require.resolve("node-pty/package.json")));
+  } catch {
+    // An "exports" map may hide package.json; resolve the entry point instead
+    // and walk up to the package root.
+  }
+  try {
+    let dir = path.dirname(await realpath(require.resolve("node-pty")));
+    for (let depth = 0; depth < MAX_WALK_UP; depth += 1) {
+      if (path.basename(dir) === "node-pty") return dir;
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // not installed here — the pnpm store scan may still find it
+  }
+  return null;
+}
+
+// Every node-pty version in a pnpm store found walking up from `base` — for a
+// workspace install where the dependency may not (yet) be linked into this
+// package's own node_modules.
+async function pnpmStoreNodePtys(base) {
+  const found = [];
+  let dir = base;
+  for (let depth = 0; depth < MAX_WALK_UP; depth += 1) {
+    const store = path.join(dir, "node_modules", ".pnpm");
+    for (const entry of await directories(store)) {
+      if (!entry.startsWith("node-pty@")) continue;
+      const candidate = path.join(store, entry, "node_modules", "node-pty");
+      try {
+        found.push(await realpath(candidate));
+      } catch {
+        // dangling entry — not ours to fix
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return found;
+}
+
+async function makeExecutable(file) {
+  try {
+    const info = await stat(file);
+    if (!info.isFile()) return false;
+    if ((info.mode & 0o111) === 0o111) return false; // already fine
+    await chmod(file, 0o755);
+    return true;
+  } catch {
+    // No spawn-helper for this prebuild, or no permission to change it.
+    return false;
+  }
+}
+
+async function main() {
+  if (process.platform === "win32") return; // no executable bit to restore
+
+  const base = process.cwd(); // npm and pnpm run lifecycle scripts inside the package directory
+  const candidates = new Set();
+  const resolved = await resolvedNodePty(base);
+  if (resolved) candidates.add(resolved);
+  for (const dir of await pnpmStoreNodePtys(base)) candidates.add(dir);
+
+  let fixed = 0;
+  let seen = 0;
+  for (const dir of candidates) {
+    const prebuilds = path.join(dir, "prebuilds");
+    for (const platform of await directories(prebuilds)) {
+      seen += 1;
+      if (await makeExecutable(path.join(prebuilds, platform, "spawn-helper"))) fixed += 1;
+    }
+  }
+  log(`${candidates.size} node-pty location(s), ${seen} prebuild dir(s), ${fixed} spawn-helper(s) made executable`);
+}
+
+main().catch((error) => {
+  // Never fail an install over this.
+  log(`skipped: ${error instanceof Error ? error.message : String(error)}`);
+});

--- a/packages/jimmy/src/__tests__/fix-prebuild-permissions.test.ts
+++ b/packages/jimmy/src/__tests__/fix-prebuild-permissions.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+/* node-pty ships prebuilds/<platform>/spawn-helper as 0644 and nothing on the
+ * install path restores the executable bit — on macOS the first PTY start then
+ * fails. The published package's postinstall has to fix that in BOTH layouts
+ * it gets installed into: plain npm (nested / hoisted / global) and a pnpm
+ * workspace (symlink into the .pnpm store). These tests build each layout in a
+ * temp dir and run the real script the way npm/pnpm do — cwd = package dir. */
+
+const SCRIPT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../scripts/fix-prebuild-permissions.mjs");
+const created: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fix-prebuild-"));
+  created.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of created.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** A minimal node-pty package: resolvable main + prebuilds with 0644 helpers. */
+function fakeNodePty(root: string, platforms: string[]): string[] {
+  fs.mkdirSync(path.join(root, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "node-pty", version: "1.1.0", main: "lib/index.js" }));
+  fs.writeFileSync(path.join(root, "lib", "index.js"), "module.exports = {};\n");
+  return platforms.map((platform) => {
+    const dir = path.join(root, "prebuilds", platform);
+    fs.mkdirSync(dir, { recursive: true });
+    const helper = path.join(dir, "spawn-helper");
+    fs.writeFileSync(helper, "#!/bin/sh\n");
+    fs.chmodSync(helper, 0o644);
+    return helper;
+  });
+}
+
+function packageDir(root: string): string {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "openryoko", version: "0.0.0" }));
+  return root;
+}
+
+function run(cwd: string): string {
+  return execFileSync(process.execPath, [SCRIPT], { cwd, env: { ...process.env, FIX_PREBUILD_VERBOSE: "1" }, encoding: "utf8" });
+}
+
+const mode = (file: string): number => fs.statSync(file).mode & 0o777;
+
+describe.skipIf(process.platform === "win32")("scripts/fix-prebuild-permissions.mjs", () => {
+  it("makes spawn-helper executable in the npm layout (<package>/node_modules/node-pty)", () => {
+    const pkg = packageDir(tmpDir());
+    const helpers = fakeNodePty(path.join(pkg, "node_modules", "node-pty"), ["darwin-arm64", "darwin-x64"]);
+    expect(helpers.map(mode)).toEqual([0o644, 0o644]);
+    const out = run(pkg);
+    expect(helpers.map(mode)).toEqual([0o755, 0o755]);
+    expect(out).toContain("2 spawn-helper(s) made executable");
+  });
+
+  it("follows a hoisted dependency (node-pty in a parent node_modules, as npm does in a project)", () => {
+    const project = tmpDir();
+    const [helper] = fakeNodePty(path.join(project, "node_modules", "node-pty"), ["darwin-arm64"]);
+    const pkg = packageDir(path.join(project, "node_modules", "openryoko"));
+    run(pkg);
+    expect(mode(helper)).toBe(0o755);
+  });
+
+  it("follows the pnpm workspace layout (package's node_modules/node-pty is a symlink into the .pnpm store)", () => {
+    const workspace = tmpDir();
+    const store = path.join(workspace, "node_modules", ".pnpm", "node-pty@1.1.0", "node_modules", "node-pty");
+    const [helper] = fakeNodePty(store, ["darwin-arm64"]);
+    const pkg = packageDir(path.join(workspace, "packages", "jimmy"));
+    fs.mkdirSync(path.join(pkg, "node_modules"));
+    fs.symlinkSync(path.relative(path.join(pkg, "node_modules"), store), path.join(pkg, "node_modules", "node-pty"));
+    run(pkg);
+    expect(mode(helper)).toBe(0o755); // the store file, through the symlink
+  });
+
+  it("finds a pnpm store above the package even when node-pty is not linked into it", () => {
+    const workspace = tmpDir();
+    const [helper] = fakeNodePty(path.join(workspace, "node_modules", ".pnpm", "node-pty@1.1.0", "node_modules", "node-pty"), ["darwin-x64"]);
+    const pkg = packageDir(path.join(workspace, "packages", "jimmy"));
+    run(pkg);
+    expect(mode(helper)).toBe(0o755);
+  });
+
+  it("leaves an already-executable helper alone and reports nothing fixed", () => {
+    const pkg = packageDir(tmpDir());
+    const [helper] = fakeNodePty(path.join(pkg, "node_modules", "node-pty"), ["darwin-arm64"]);
+    fs.chmodSync(helper, 0o755);
+    const out = run(pkg);
+    expect(mode(helper)).toBe(0o755);
+    expect(out).toContain("0 spawn-helper(s) made executable");
+  });
+
+  it("exits 0 and touches nothing when node-pty is absent", () => {
+    const pkg = packageDir(tmpDir());
+    expect(() => run(pkg)).not.toThrow();
+    expect(fs.existsSync(path.join(pkg, "node_modules"))).toBe(false);
+  });
+});

--- a/scripts/fix-prebuild-permissions.mjs
+++ b/scripts/fix-prebuild-permissions.mjs
@@ -1,0 +1,49 @@
+// Restore the executable bit on node-pty's spawn-helper after install.
+//
+// This replaces a shell one-liner:
+//
+//   chmod +x node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true
+//
+// pnpm runs package scripts through cmd.exe on Windows, where `chmod` and glob
+// expansion do not exist, so that line failed there. It failed harmlessly —
+// `|| true` swallowed it, and Windows has no executable bit to restore — but a
+// postinstall that always errors is noise in every Windows install log.
+//
+// Behaviour is otherwise deliberately unchanged: every prebuild directory is
+// still visited, not just the current platform's, because a workspace can be
+// installed on one machine and mounted on another. Missing files and chmod
+// failures stay non-fatal, as `2>/dev/null || true` made them.
+import { chmod, readdir } from "node:fs/promises";
+import path from "node:path";
+
+if (process.platform === "win32") process.exit(0);
+
+const pnpmRoot = path.join(process.cwd(), "node_modules", ".pnpm");
+
+async function directories(target) {
+  try {
+    const entries = await readdir(target, { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+let fixed = 0;
+for (const pkg of await directories(pnpmRoot)) {
+  if (!pkg.startsWith("node-pty@")) continue;
+  const prebuilds = path.join(pnpmRoot, pkg, "node_modules", "node-pty", "prebuilds");
+  for (const platform of await directories(prebuilds)) {
+    try {
+      await chmod(path.join(prebuilds, platform, "spawn-helper"), 0o755);
+      fixed += 1;
+    } catch {
+      // No spawn-helper for this prebuild, or no permission to change it.
+      // Neither is fatal: the shell version discarded both.
+    }
+  }
+}
+
+if (process.env.npm_config_loglevel === "verbose") {
+  process.stdout.write(`fix-prebuild-permissions: ${fixed} spawn-helper(s)\n`);
+}


### PR DESCRIPTION
## Summary
- pnpm が `node-pty` の同梱バイナリ `spawn-helper` から実行ビットを剥がすため、初回の PTY 起動で gateway デーモンがクラッシュする問題を修正
- upstream jinn の `scripts/fix-prebuild-permissions.mjs` をそのまま移植し、ルート `package.json` に `postinstall` を追加

## Problem
pnpm は install 時に `node-pty` のプリビルドバイナリ `spawn-helper` の実行ビットを落とします。+x がないと node-pty 内部の `posix_spawnp` が失敗し、**最初に PTY を起動した時点で gateway デーモンが落ちます**（チャットセッションが Claude エンジンを起動したタイミングなど）。

この修正は upstream jinn には入っていますが、OpenRyoko 側には取り込まれていませんでした。現在の `main` にはルート／`packages/jimmy` のどちらにも `postinstall` がありません。

## 移植元（upstream jinn）
| コミット | 日付 | 内容 |
|---|---|---|
| `3f076d3b52e7593ad1ecdca1f12145022c44499c` | 2026-05-18 | ルート `package.json` に `chmod` ワンライナーの `postinstall` を追加 |
| `d7c090a2a7563ce4a459ac45860a3aab3b1c51ef` | 2026-07-29 (jinn#104) | それを `scripts/fix-prebuild-permissions.mjs` に置き換え |

本 PR は**後者の形をそのまま**持ち込んでいます。ワンライナー版は Windows で必ず失敗するためです（cmd.exe に `chmod` も glob 展開も存在しない）。`|| true` で握り潰されるので実害はないものの、毎回インストールログにノイズが残ります。移植版は `win32` で即 `exit(0)` するのでその問題がありません。

なお、より古い経緯として `packages/jimmy/package.json` 側にも同種の postinstall が存在した時期がありますが（`a07b997`）、こちらは削除済みで、かつ `find` に `-L` がなく `.pnpm` の symlink を辿らないため pnpm workspace では機能していなかった可能性が高いです。ワークスペースのルートに置き、pnpm ストアを直接走査する現行の形が確実です。

## 挙動
upstream から意図的に据え置いています。

- 現行プラットフォーム以外の prebuild ディレクトリも走査する（あるマシンで install したワークスペースを別マシンでマウントする場合に備えるため）
- ファイル不在や chmod 失敗は非致命（元の `2>/dev/null || true` と同じ扱い）
- `npm_config_loglevel=verbose` のときだけ処理件数を出力

## Test plan
- [x] 実地確認: `spawn-helper` 2件から `chmod -x` で実行ビットを落とした状態を作り、`pnpm run postinstall` で `-rw-r--r--` → `-rwxr-xr-x` に復元されることを確認
- [x] スクリプト単体実行でも同様に復元（`fix-prebuild-permissions: 2 spawn-helper(s)`）
- [x] `pnpm --filter openryoko typecheck` pass
- [x] `pnpm --filter openryoko test` 147 files / 1692 tests 全 pass

> Note: 検証は node@22 で実施しています。Node 26 系では `better-sqlite3` のネイティブバインディングが ABI 不一致で読めず、本変更とは無関係に多数のテストが落ちます。
