### PR TITLE
fix(slack): respondTo.channel が mention/never のときチャンネルのリアクションを処理しない

### DIFF
--- a/packages/jimmy/src/connectors/slack/__tests__/respond-policy.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/respond-policy.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateRespondPolicy,
   hasMentionScope,
   respondPolicyNeedsTracking,
+  shouldHandleReaction,
 } from "../respond-policy.js";
 import type { SlackRespondToConfig } from "../../../shared/types.js";
 
@@ -176,5 +177,39 @@ describe("hasMentionScope / respondPolicyNeedsTracking", () => {
   it("needs tracking only when engaged-thread continuation is on", () => {
     expect(respondPolicyNeedsTracking({ channel: "mention" })).toBe(true);
     expect(respondPolicyNeedsTracking({ channel: "mention", engagedThreads: false })).toBe(false);
+  });
+});
+
+describe("shouldHandleReaction", () => {
+  // Reactions carry no @-mention, so a mention-gated channel scope can never
+  // be satisfied on this path. Without the gate a secondary bot sharing
+  // channels with the primary bot double-handles every channel reaction.
+
+  it("handles channel reactions when the channel scope is always", () => {
+    expect(shouldHandleReaction({ channel: "always" }, "C123")).toBe(true);
+  });
+
+  it("ignores channel reactions when the channel scope is mention", () => {
+    expect(shouldHandleReaction({ channel: "mention" }, "C123")).toBe(false);
+  });
+
+  it("ignores channel reactions when the channel scope is never", () => {
+    expect(shouldHandleReaction({ channel: "never" }, "C123")).toBe(false);
+  });
+
+  it("always handles DM reactions regardless of the channel scope", () => {
+    expect(shouldHandleReaction({ channel: "mention" }, "D123")).toBe(true);
+    expect(shouldHandleReaction({ channel: "never" }, "D123")).toBe(true);
+  });
+
+  it("defaults to handling when respondTo is absent or invalid (legacy behavior)", () => {
+    expect(shouldHandleReaction(undefined, "C123")).toBe(true);
+    expect(shouldHandleReaction({} as SlackRespondToConfig, "C123")).toBe(true);
+  });
+
+  it("gates a DM-scope setting independently of the channel scope", () => {
+    // im="never" does not silence DM reactions: the reaction path is gated on
+    // the channel scope only, matching the pre-existing behavior.
+    expect(shouldHandleReaction({ im: "never", channel: "always" }, "D123")).toBe(true);
   });
 });

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -21,7 +21,9 @@ import {
 import {
   evaluateRespondPolicy,
   hasMentionScope,
+  resolveRespondMode,
   respondPolicyNeedsTracking,
+  shouldHandleReaction,
 } from "./respond-policy.js";
 import { isOperatorSpeaker } from "../../shared/operator-match.js";
 import { explicitThread } from "../../shared/threading.js";
@@ -645,6 +647,15 @@ export class SlackConnector implements Connector {
 
       // Skip bot's own reactions
       if (this.botUserId && event.user === this.botUserId) return;
+
+      // A mention-gated channel scope cannot be satisfied by a reaction, which
+      // carries no @-mention; see shouldHandleReaction.
+      if (!shouldHandleReaction(this.respondTo, event.item.channel)) {
+        logger.debug(
+          `[slack] respondTo.channel=${resolveRespondMode(this.respondTo, "channel")} — ignoring channel reaction on ${event.item.channel}:${event.item.ts}`,
+        );
+        return;
+      }
 
       if (!this.handler) return;
 

--- a/packages/jimmy/src/connectors/slack/respond-policy.ts
+++ b/packages/jimmy/src/connectors/slack/respond-policy.ts
@@ -72,3 +72,26 @@ export function evaluateRespondPolicy(input: RespondPolicyInput): RespondDecisio
   }
   return { allow: true };
 }
+
+/**
+ * True when a reaction event should be handled at all.
+ *
+ * Reactions carry no @-mention, so a channel scope of "mention" (or "never")
+ * can never be satisfied here — the message-path gate in
+ * `evaluateRespondPolicy` has no equivalent on the reaction path. Without this
+ * check a secondary bot sharing channels with the primary bot double-handles
+ * every channel reaction; the primary bot (channel="always") owns them.
+ *
+ * `reaction_added` reports only `item.channel`, with no `channel_type`, so the
+ * scope has to be inferred from the id prefix. Only DMs ("D…") are
+ * distinguishable; group DMs fall under the channel scope rather than mpim.
+ * That is deliberate — the conservative side of the gate — and matches how
+ * the reaction path behaved before this scope existed.
+ */
+export function shouldHandleReaction(
+  config: SlackRespondToConfig | undefined,
+  itemChannel: string,
+): boolean {
+  if (itemChannel.startsWith("D")) return true;
+  return resolveRespondMode(config, "channel") === "always";
+}


### PR DESCRIPTION
## Summary
- `respondTo` の mention ゲートがメッセージ経路にしか無く、リアクション経路が素通りしていた問題を修正
- 判定を `respond-policy.ts` に `shouldHandleReaction` として切り出し、単体テストを追加

## Problem
`respondTo.channel` に `mention` を設定すると、チャンネルではメンションされたときだけ応答するようになります。ただしこのゲート（`evaluateRespondPolicy`）は**メッセージ経路にしか存在しません**。

リアクション（絵文字）には `@-mention` を付けようがないため、`channel: "mention"` を満たすことが原理的にありません。にもかかわらず `reaction_added` のハンドラはこのゲートを通らず、設定と無関係にすべてのチャンネルリアクションを処理していました。**設定と挙動が食い違っている状態**です。

実害が出るのは複数 Bot を同じワークスペースで運用している場合です。主 Bot（`channel: "always"`）と副 Bot（`channel: "mention"`）が同じチャンネルに居ると、**絵文字が1つ付くたびに両方が反応します**。

### 再現手順
1. 同一ワークスペースに2つの Bot を接続し、どちらも同じチャンネルに参加させる
2. 主 Bot は `respondTo.channel: always`、副 Bot は `respondTo.channel: mention` に設定する
3. そのチャンネルのメッセージに、トリガーとなる絵文字を1つ付ける
4. 修正前は両方の Bot がリアクションを処理する（副 Bot は `mention` 設定なので処理すべきでない）

単一 Bot 運用でも、`channel: "mention"` にしているのにチャンネルの絵文字には反応してしまう点は同じです。

## Solution
`respond-policy.ts` に判定関数を追加し、リアクションハンドラの入口で評価します。

```ts
export function shouldHandleReaction(
  config: SlackRespondToConfig | undefined,
  itemChannel: string,
): boolean {
  if (itemChannel.startsWith("D")) return true;
  return resolveRespondMode(config, "channel") === "always";
}
```

`respond-policy.ts` は既に「ネットワークアクセスと LLM triage の手前で走る決定的なゲート」を集めたモジュールなので、そこに置くのが素直だと判断しました。純粋関数なのでテストも書けます。

### スコープ推定について
`reaction_added` は `item.channel` しか持たず、メッセージイベントと違って `channel_type` がありません。そのためスコープは id の接頭辞から推定する必要があります。確実に判別できるのは DM（`"D…"`）だけで、**グループDMは `mpim` ではなく `channel` スコープ側に入ります**。

これは意図的に保守側へ倒したものです。このスコープが存在しなかった頃の挙動（＝全部処理する）から変わるのは `channel` を `always` 以外にした人だけで、その人は明示的にチャンネルでの応答を絞っています。DM は従来どおり常に通します。

## Test plan
- [x] `shouldHandleReaction` の単体テスト6件を追加（always / mention / never / DM / config 不在・不正 / im スコープとの独立性）
- [x] `pnpm --filter openryoko typecheck` pass
- [x] `pnpm --filter openryoko test` 147 files / 1698 tests 全 pass（main の 1692 + 新規 6）
- [x] 同等のゲートを関数化前のインライン実装として、投稿者の 2 Bot 構成で 2026-08-04 から稼働中
  （本 PR はそれを `shouldHandleReaction` に切り出したもので、判定条件は同一。切り出し後の形での実機投入はこれから）

> Note: 検証は node@22 で実施しています。Node 26 系では `better-sqlite3` のネイティブバインディングが ABI 不一致で読めず、本変更とは無関係に多数のテストが落ちます。

