### PR TITLE
feat(onboarding): 初回ウィザードを「動くところまで」に — エンジン確認・Slack 接続・最初の自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 .next/
 .turbo/

--- a/packages/jimmy/node_modules
+++ b/packages/jimmy/node_modules
@@ -1,1 +1,0 @@
-/Users/sensuiryousuke/jinn-dev/packages/jimmy/node_modules

--- a/packages/jimmy/node_modules
+++ b/packages/jimmy/node_modules
@@ -1,0 +1,1 @@
+/Users/sensuiryousuke/jinn-dev/packages/jimmy/node_modules

--- a/packages/jimmy/src/gateway/__tests__/onboarding-engines-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-engines-api.test.ts
@@ -1,11 +1,15 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it } from "vitest";
-import { handleApiRequest, type ApiContext } from "../api.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleApiRequest, _resetEngineProbeCache, type ApiContext } from "../api.js";
 
-/* The onboarding wizard's "does the engine actually run" check. /api/status
- * hard-codes available:true; this route resolves the binary and runs it, so
- * the wizard can show a real ✓/✗ instead of echoing config. */
+/* The onboarding wizard's "is the engine installed and does it start" check.
+ * /api/status hard-codes available:true; this route resolves the binary and
+ * runs it. It is deliberately NOT a login-validity check — it reports what it
+ * can observe locally, never spends tokens, and says so in `auth.note`. */
 
 function fakeGet(pathname: string): IncomingMessage {
   const readable = Readable.from([]) as unknown as IncomingMessage;
@@ -28,37 +32,109 @@ function fakeResponse(): { res: ServerResponse; read: () => { status: number; bo
   return { res, read: () => ({ status, body: chunks.length ? JSON.parse(chunks.join("")) : null }) };
 }
 
+interface Probe { name: string; installed: boolean; runnable: boolean; version?: string; error?: string; auth?: Record<string, unknown> }
+interface Payload { default: string; probedAt: string; engines: Probe[] }
+
+function contextFor(engines: Record<string, unknown>): ApiContext {
+  return {
+    getConfig: () => ({ gateway: {}, connectors: {}, engines: { default: "claude", ...engines } }),
+    connectors: new Map(), sessionManager: {}, emit: () => {}, startTime: Date.now(),
+  } as unknown as ApiContext;
+}
+
+async function probe(context: ApiContext): Promise<Payload> {
+  const { res, read } = fakeResponse();
+  await handleApiRequest(fakeGet("/api/onboarding/engines"), res, context);
+  const { status, body } = read();
+  expect(status).toBe(200);
+  return body as Payload;
+}
+
+let scratch: string;
+const savedEnv = { CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR, ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY };
+
+beforeEach(() => {
+  _resetEngineProbeCache();
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), "ryoko-onboarding-engines-"));
+  delete process.env.ANTHROPIC_API_KEY;
+  process.env.CLAUDE_CONFIG_DIR = path.join(scratch, "claude-config"); // no credentials → "none"
+});
+
+afterEach(() => {
+  process.env.CLAUDE_CONFIG_DIR = savedEnv.CLAUDE_CONFIG_DIR;
+  if (savedEnv.ANTHROPIC_API_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = savedEnv.ANTHROPIC_API_KEY;
+  fs.rmSync(scratch, { recursive: true, force: true });
+  _resetEngineProbeCache();
+});
+
+/** A stand-in binary: exits with the given code, printing a version line. */
+function fakeBin(name: string, exitCode: number): string {
+  const file = path.join(scratch, name);
+  fs.writeFileSync(file, `#!/bin/sh\necho "${name} 9.9.9"\nexit ${exitCode}\n`, { mode: 0o755 });
+  return file;
+}
+
 describe("GET /api/onboarding/engines", () => {
-  it("reports runnable engines with a version, and missing binaries as not installed", async () => {
-    const context = {
-      getConfig: () => ({
-        gateway: {}, connectors: {},
-        engines: {
-          default: "claude",
-          claude: { bin: process.execPath, model: "opus" }, // node itself: always runnable
-          codex: { bin: "ryoko-no-such-binary-xyz", model: "gpt" },
-        },
-      }),
-      connectors: new Map(), sessionManager: {}, emit: () => {}, startTime: Date.now(),
-    } as unknown as ApiContext;
-
-    const { res, read } = fakeResponse();
-    await handleApiRequest(fakeGet("/api/onboarding/engines"), res, context);
-
-    const { status, body } = read();
-    expect(status).toBe(200);
-    const payload = body as { default: string; engines: Array<Record<string, unknown>> };
+  it("reports runnable engines with a version, missing binaries as not installed, and no unconfigured engines", async () => {
+    const payload = await probe(contextFor({
+      claude: { bin: process.execPath, model: "opus" }, // node itself: always runnable
+      codex: { bin: "ryoko-no-such-binary-xyz", model: "gpt" },
+    }));
     expect(payload.default).toBe("claude");
     const claude = payload.engines.find((engine) => engine.name === "claude")!;
-    expect(claude.installed).toBe(true);
-    expect(claude.runnable).toBe(true);
+    expect(claude).toMatchObject({ installed: true, runnable: true });
     expect(String(claude.version)).toMatch(/^v?\d+/);
-    expect(claude.auth).toBeDefined(); // login state is reported alongside
     const codex = payload.engines.find((engine) => engine.name === "codex")!;
-    expect(codex.installed).toBe(false);
-    expect(codex.runnable).toBe(false);
+    expect(codex).toMatchObject({ installed: false, runnable: false });
     expect(String(codex.error)).toContain("PATH");
-    // gemini is not configured → not listed
     expect(payload.engines.some((engine) => engine.name === "gemini")).toBe(false);
+  });
+
+  it("marks a binary that starts but exits non-zero as installed-but-not-runnable", async () => {
+    const broken = fakeBin("broken-engine", 3);
+    const payload = await probe(contextFor({ claude: { bin: broken, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } }));
+    const claude = payload.engines.find((engine) => engine.name === "claude")!;
+    expect(claude).toMatchObject({ installed: true, runnable: false });
+    expect(claude.error).toBeDefined();
+    expect(claude.auth).toBeUndefined(); // login is only observed for engines that start
+  });
+
+  it("projects Claude login state without ever returning the credential itself", async () => {
+    const dir = path.join(scratch, "claude-config");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, ".credentials.json"), JSON.stringify({
+      claudeAiOauth: { accessToken: "sk-ant-oat-SECRET", refreshToken: "sk-ant-ort-SECRET", expiresAt: Date.now() + 3_600_000 },
+    }));
+    const payload = await probe(contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } }));
+    const claude = payload.engines.find((engine) => engine.name === "claude")!;
+    expect(claude.auth).toMatchObject({ method: "oauth", expired: false });
+    expect(String(claude.auth!.note)).toContain("有効性は初回実行時に判明"); // observed, not proven
+    expect(JSON.stringify(payload)).not.toContain("SECRET");
+  });
+
+  it("reports an expired OAuth session, and an env API key, as what they are", async () => {
+    const dir = path.join(scratch, "claude-config");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, ".credentials.json"), JSON.stringify({ claudeAiOauth: { expiresAt: Date.now() - 1000 } }));
+    let payload = await probe(contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } }));
+    expect(payload.engines.find((engine) => engine.name === "claude")!.auth).toMatchObject({ method: "oauth", expired: true });
+
+    _resetEngineProbeCache();
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api-SECRET";
+    payload = await probe(contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } }));
+    expect(payload.engines.find((engine) => engine.name === "claude")!.auth).toMatchObject({ method: "api-key" });
+    expect(JSON.stringify(payload)).not.toContain("SECRET");
+  });
+
+  it("shares one probe across concurrent requests and serves it from cache briefly", async () => {
+    const context = contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } });
+    const [first, second] = await Promise.all([probe(context), probe(context)]);
+    expect(second.probedAt).toBe(first.probedAt); // same in-flight probe
+    const third = await probe(context);
+    expect(third.probedAt).toBe(first.probedAt); // cached within the TTL
+    _resetEngineProbeCache();
+    const fourth = await probe(context);
+    expect(fourth.probedAt).not.toBe(first.probedAt); // a fresh probe after reset
   });
 });

--- a/packages/jimmy/src/gateway/__tests__/onboarding-engines-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-engines-api.test.ts
@@ -1,0 +1,64 @@
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import { handleApiRequest, type ApiContext } from "../api.js";
+
+/* The onboarding wizard's "does the engine actually run" check. /api/status
+ * hard-codes available:true; this route resolves the binary and runs it, so
+ * the wizard can show a real ✓/✗ instead of echoing config. */
+
+function fakeGet(pathname: string): IncomingMessage {
+  const readable = Readable.from([]) as unknown as IncomingMessage;
+  readable.headers = { host: "127.0.0.1" };
+  readable.method = "GET";
+  readable.url = pathname;
+  return readable;
+}
+
+function fakeResponse(): { res: ServerResponse; read: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const headers: Record<string, string> = {};
+  const res = {
+    writeHead(code: number) { status = code; return this; },
+    setHeader(name: string, value: string) { headers[name] = value; return this; },
+    getHeader(name: string) { return headers[name]; },
+    end(chunk?: unknown) { if (chunk) chunks.push(String(chunk)); },
+  } as unknown as ServerResponse;
+  return { res, read: () => ({ status, body: chunks.length ? JSON.parse(chunks.join("")) : null }) };
+}
+
+describe("GET /api/onboarding/engines", () => {
+  it("reports runnable engines with a version, and missing binaries as not installed", async () => {
+    const context = {
+      getConfig: () => ({
+        gateway: {}, connectors: {},
+        engines: {
+          default: "claude",
+          claude: { bin: process.execPath, model: "opus" }, // node itself: always runnable
+          codex: { bin: "ryoko-no-such-binary-xyz", model: "gpt" },
+        },
+      }),
+      connectors: new Map(), sessionManager: {}, emit: () => {}, startTime: Date.now(),
+    } as unknown as ApiContext;
+
+    const { res, read } = fakeResponse();
+    await handleApiRequest(fakeGet("/api/onboarding/engines"), res, context);
+
+    const { status, body } = read();
+    expect(status).toBe(200);
+    const payload = body as { default: string; engines: Array<Record<string, unknown>> };
+    expect(payload.default).toBe("claude");
+    const claude = payload.engines.find((engine) => engine.name === "claude")!;
+    expect(claude.installed).toBe(true);
+    expect(claude.runnable).toBe(true);
+    expect(String(claude.version)).toMatch(/^v?\d+/);
+    expect(claude.auth).toBeDefined(); // login state is reported alongside
+    const codex = payload.engines.find((engine) => engine.name === "codex")!;
+    expect(codex.installed).toBe(false);
+    expect(codex.runnable).toBe(false);
+    expect(String(codex.error)).toContain("PATH");
+    // gemini is not configured → not listed
+    expect(payload.engines.some((engine) => engine.name === "gemini")).toBe(false);
+  });
+});

--- a/packages/jimmy/src/gateway/__tests__/onboarding-engines-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-engines-api.test.ts
@@ -127,6 +127,14 @@ describe("GET /api/onboarding/engines", () => {
     expect(JSON.stringify(payload)).not.toContain("SECRET");
   });
 
+  it("does not answer a changed engine config from the previous config's cache", async () => {
+    const before = await probe(contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } }));
+    // Same process, no reset — only the config differs (codex now points at a real binary).
+    const after = await probe(contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: process.execPath, model: "gpt" } }));
+    expect(after.probedAt).not.toBe(before.probedAt);
+    expect(after.engines.find((engine) => engine.name === "codex")!.runnable).toBe(true);
+  });
+
   it("shares one probe across concurrent requests and serves it from cache briefly", async () => {
     const context = contextFor({ claude: { bin: process.execPath, model: "opus" }, codex: { bin: "nope-xyz", model: "gpt" } });
     const [first, second] = await Promise.all([probe(context), probe(context)]);

--- a/packages/jimmy/src/gateway/__tests__/onboarding-slack-connect-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-slack-connect-api.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONFIG_PATH } from "../../shared/paths.js";
+import { handleApiRequest, type ApiContext } from "../api.js";
+
+/* The whole Slack hookup as one server-side operation. The property under
+ * test: a failed attempt NEVER leaves config.yaml worse than it found it —
+ * bad tokens are refused before any write, and a connector that fails to
+ * start after a write gets the previous Slack block put back. */
+
+function fakePost(pathname: string, body: unknown): IncomingMessage {
+  const readable = Readable.from([Buffer.from(JSON.stringify(body))]) as unknown as IncomingMessage;
+  readable.headers = { host: "127.0.0.1", "content-type": "application/json" };
+  readable.method = "POST";
+  readable.url = pathname;
+  return readable;
+}
+
+function fakeResponse(): { res: ServerResponse; read: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const headers: Record<string, string> = {};
+  const res = {
+    writeHead(code: number) { status = code; return this; },
+    setHeader(name: string, value: string) { headers[name] = value; return this; },
+    getHeader(name: string) { return headers[name]; },
+    end(chunk?: unknown) { if (chunk) chunks.push(String(chunk)); },
+  } as unknown as ServerResponse;
+  return { res, read: () => ({ status, body: chunks.length ? JSON.parse(chunks.join("")) : null }) };
+}
+
+function stubSlack(botOk: boolean, appOk = true): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const method = String(url).split("/api/")[1]!;
+    const answer = method === "auth.test"
+      ? (botOk ? { ok: true, team: "TEKION", user: "ryoko" } : { ok: false, error: "invalid_auth" })
+      : (appOk ? { ok: true } : { ok: false, error: "invalid_auth" });
+    return { ok: true, status: 200, json: async () => answer } as Response;
+  }));
+}
+
+function readConfig(): { connectors?: { slack?: Record<string, unknown> } } {
+  return (yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8")) as { connectors?: { slack?: Record<string, unknown> } }) || {};
+}
+
+function contextWith(reload: () => Promise<{ started: string[]; stopped: string[]; errors: string[] }>): ApiContext {
+  return {
+    getConfig: () => ({ gateway: {}, connectors: {}, engines: { default: "claude", claude: { bin: "claude", model: "opus" }, codex: { bin: "codex", model: "gpt" } } }),
+    connectors: new Map(), sessionManager: {}, emit: () => {}, startTime: Date.now(),
+    reloadAllConnectors: reload,
+  } as unknown as ApiContext;
+}
+
+const PREVIOUS = { botToken: "xoxb-OLD", appToken: "xapp-OLD", allowFrom: "U123" };
+
+async function connect(context: ApiContext, botToken = "xoxb-NEW", appToken = "xapp-NEW"): Promise<Record<string, unknown>> {
+  const { res, read } = fakeResponse();
+  await handleApiRequest(fakePost("/api/onboarding/slack/connect", { botToken, appToken }), res, context);
+  const { status, body } = read();
+  expect(status).toBe(200);
+  return body as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, yaml.dump({ engines: { default: "claude" }, connectors: { slack: PREVIOUS } }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fs.rmSync(CONFIG_PATH, { force: true });
+});
+
+describe("POST /api/onboarding/slack/connect", () => {
+  it("refuses at verify and writes nothing when the bot token is bad", async () => {
+    stubSlack(false);
+    const reload = vi.fn();
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, stage: "verify", bot: { ok: false, error: "invalid_auth" } });
+    expect(reload).not.toHaveBeenCalled();
+    expect(readConfig().connectors?.slack).toEqual(PREVIOUS); // untouched
+  });
+
+  it("saves and reports the workspace when tokens verify and the connector starts", async () => {
+    stubSlack(true);
+    const reload = vi.fn().mockResolvedValue({ started: ["slack"], stopped: ["slack"], errors: [] });
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: true, team: "TEKION", user: "ryoko" });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(readConfig().connectors?.slack).toMatchObject({ botToken: "xoxb-NEW", appToken: "xapp-NEW", allowFrom: "U123" });
+  });
+
+  it("restores the previous Slack block when the connector fails to start after the save", async () => {
+    stubSlack(true);
+    const reload = vi.fn()
+      .mockResolvedValueOnce({ started: [], stopped: ["slack"], errors: ["slack: An API error occurred: invalid_auth"] })
+      .mockResolvedValueOnce({ started: ["slack"], stopped: [], errors: [] });
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: true });
+    expect(String(outcome.error)).toContain("invalid_auth");
+    expect(reload).toHaveBeenCalledTimes(2); // the failed start, then the rollback reload
+    expect(readConfig().connectors?.slack).toEqual(PREVIOUS);
+  });
+
+  it("treats a reload that throws as a failure and rolls back too", async () => {
+    stubSlack(true);
+    const reload = vi.fn()
+      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockResolvedValueOnce({ started: ["slack"], stopped: [], errors: [] });
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: true, error: "socket hang up" });
+    expect(readConfig().connectors?.slack).toEqual(PREVIOUS);
+  });
+
+  it("removes the Slack block again when there was none before a failed attempt", async () => {
+    fs.writeFileSync(CONFIG_PATH, yaml.dump({ engines: { default: "claude" }, connectors: {} }));
+    stubSlack(true);
+    const reload = vi.fn()
+      .mockResolvedValueOnce({ started: [], stopped: [], errors: ["slack: invalid_auth"] })
+      .mockResolvedValueOnce({ started: [], stopped: [], errors: [] });
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, rolledBack: true });
+    expect(readConfig().connectors?.slack).toBeUndefined();
+  });
+});

--- a/packages/jimmy/src/gateway/__tests__/onboarding-slack-connect-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-slack-connect-api.test.ts
@@ -100,7 +100,7 @@ describe("POST /api/onboarding/slack/connect", () => {
       .mockResolvedValueOnce({ started: [], stopped: ["slack"], errors: ["slack: An API error occurred: invalid_auth"] })
       .mockResolvedValueOnce({ started: ["slack"], stopped: [], errors: [] });
     const outcome = await connect(contextWith(reload));
-    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: true, restored: { disk: true, running: true } });
+    expect(outcome).toMatchObject({ ok: false, stage: "reload", previous: "config", rolledBack: true, restored: { disk: true, running: true } });
     expect(String(outcome.error)).toContain("invalid_auth");
     expect(reload).toHaveBeenCalledTimes(2); // the failed start, then the rollback reload
     expect(readConfig().connectors?.slack).toEqual(PREVIOUS);
@@ -112,7 +112,7 @@ describe("POST /api/onboarding/slack/connect", () => {
       .mockResolvedValueOnce({ started: [], stopped: ["slack"], errors: ["slack: invalid_auth"] })
       .mockResolvedValueOnce({ started: [], stopped: [], errors: ["slack: connect ETIMEDOUT"] }); // rollback reload also fails
     const outcome = await connect(contextWith(reload));
-    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: false, restored: { disk: true, running: false } });
+    expect(outcome).toMatchObject({ ok: false, stage: "reload", previous: "config", rolledBack: false, restored: { disk: true, running: false } });
     expect(String(outcome.rollbackError)).toContain("ETIMEDOUT");
     expect(readConfig().connectors?.slack).toEqual(PREVIOUS); // the file IS restored, and the result says so precisely
   });
@@ -205,7 +205,22 @@ describe("POST /api/onboarding/slack/connect", () => {
       .mockResolvedValueOnce({ started: [], stopped: [], errors: ["slack: invalid_auth"] })
       .mockResolvedValueOnce({ started: [], stopped: [], errors: [] });
     const outcome = await connect(contextWith(reload));
-    expect(outcome).toMatchObject({ ok: false, rolledBack: true });
+    // Undoing an attempt where nothing was configured before is its own
+    // state: the block is gone again and nothing is running — and the result
+    // says so instead of claiming a previous connection came back.
+    expect(outcome).toMatchObject({ ok: false, previous: "none", rolledBack: true, restored: { disk: true, running: false } });
     expect(readConfig().connectors?.slack).toBeUndefined();
+  });
+
+  it("does not call the removal a rollback when the reload after it fails too (no previous block)", async () => {
+    fs.writeFileSync(CONFIG_PATH, yaml.dump({ engines: { default: "claude" }, connectors: {} }));
+    stubSlack(true);
+    const reload = vi.fn()
+      .mockResolvedValueOnce({ started: [], stopped: [], errors: ["slack: invalid_auth"] })
+      .mockResolvedValueOnce({ started: [], stopped: [], errors: ["slack: stop timed out"] }); // the removal reload does not settle either
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, previous: "none", rolledBack: false, restored: { disk: true, running: false } });
+    expect(String(outcome.rollbackError)).toContain("stop timed out");
+    expect(readConfig().connectors?.slack).toBeUndefined(); // the file IS clean again; only the live side is reported as unsettled
   });
 });

--- a/packages/jimmy/src/gateway/__tests__/onboarding-slack-connect-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-slack-connect-api.test.ts
@@ -12,10 +12,10 @@ import { handleApiRequest, type ApiContext } from "../api.js";
  * bad tokens are refused before any write, and a connector that fails to
  * start after a write gets the previous Slack block put back. */
 
-function fakePost(pathname: string, body: unknown): IncomingMessage {
+function fakePost(pathname: string, body: unknown, method = "POST"): IncomingMessage {
   const readable = Readable.from([Buffer.from(JSON.stringify(body))]) as unknown as IncomingMessage;
   readable.headers = { host: "127.0.0.1", "content-type": "application/json" };
-  readable.method = "POST";
+  readable.method = method;
   readable.url = pathname;
   return readable;
 }
@@ -100,10 +100,92 @@ describe("POST /api/onboarding/slack/connect", () => {
       .mockResolvedValueOnce({ started: [], stopped: ["slack"], errors: ["slack: An API error occurred: invalid_auth"] })
       .mockResolvedValueOnce({ started: ["slack"], stopped: [], errors: [] });
     const outcome = await connect(contextWith(reload));
-    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: true });
+    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: true, restored: { disk: true, running: true } });
     expect(String(outcome.error)).toContain("invalid_auth");
     expect(reload).toHaveBeenCalledTimes(2); // the failed start, then the rollback reload
     expect(readConfig().connectors?.slack).toEqual(PREVIOUS);
+  });
+
+  it("does not call a rollback successful when the previous connector fails to come back", async () => {
+    stubSlack(true);
+    const reload = vi.fn()
+      .mockResolvedValueOnce({ started: [], stopped: ["slack"], errors: ["slack: invalid_auth"] })
+      .mockResolvedValueOnce({ started: [], stopped: [], errors: ["slack: connect ETIMEDOUT"] }); // rollback reload also fails
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, stage: "reload", rolledBack: false, restored: { disk: true, running: false } });
+    expect(String(outcome.rollbackError)).toContain("ETIMEDOUT");
+    expect(readConfig().connectors?.slack).toEqual(PREVIOUS); // the file IS restored, and the result says so precisely
+  });
+
+  it("leaves a Slack block that someone else wrote meanwhile alone instead of rolling over it", async () => {
+    stubSlack(true);
+    const THEIRS = { botToken: "xoxb-THEIRS", appToken: "xapp-THEIRS" };
+    const reload = vi.fn().mockImplementationOnce(async () => {
+      // An out-of-band editor (vim, the CLI) rewrites the block while our
+      // connector reload is in flight — the lock only covers API writers.
+      fs.writeFileSync(CONFIG_PATH, yaml.dump({ engines: { default: "claude" }, connectors: { slack: THEIRS } }));
+      return { started: [], stopped: [], errors: ["slack: invalid_auth"] };
+    });
+    const outcome = await connect(contextWith(reload));
+    expect(outcome).toMatchObject({ ok: false, rolledBack: false, restored: { disk: false, running: false } });
+    expect(String(outcome.rollbackSkipped)).toContain("concurrently");
+    expect(reload).toHaveBeenCalledTimes(1); // no rollback write, no second reload
+    expect(readConfig().connectors?.slack).toEqual(THEIRS);
+  });
+
+  it("serializes concurrent connects: the second one's reload starts only after the first fully settles", async () => {
+    stubSlack(true);
+    let inFlight = 0;
+    let overlapped = false;
+    const reload = vi.fn(async () => {
+      inFlight += 1;
+      if (inFlight > 1) overlapped = true;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      inFlight -= 1;
+      return { started: ["slack"], stopped: [], errors: [] };
+    });
+    const context = contextWith(reload);
+    const [first, second] = await Promise.all([
+      connect(context, "xoxb-ONE", "xapp-ONE"),
+      connect(context, "xoxb-TWO", "xapp-TWO"),
+    ]);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(overlapped).toBe(false);
+    expect(readConfig().connectors?.slack).toMatchObject({ botToken: "xoxb-TWO", appToken: "xapp-TWO" }); // last writer, in order
+  });
+
+  it("makes PUT /api/config wait for an in-flight connect (and never lose its write to the rollback)", async () => {
+    stubSlack(true);
+    let releaseReload!: () => void;
+    const reloadGate = new Promise<void>((resolve) => { releaseReload = resolve; });
+    let markReloadStarted!: () => void;
+    const reloadStarted = new Promise<void>((resolve) => { markReloadStarted = resolve; });
+    const reload = vi.fn()
+      .mockImplementationOnce(async () => { markReloadStarted(); await reloadGate; return { started: [], stopped: [], errors: ["slack: invalid_auth"] }; })
+      .mockResolvedValue({ started: ["slack"], stopped: [], errors: [] });
+    const context = contextWith(reload);
+
+    const connecting = connect(context, "xoxb-NEW", "xapp-NEW");
+    // connect verifies with Slack BEFORE taking the lock; wait until it is
+    // inside its critical section (first reload started) and THEN let a
+    // settings-page save come in — that is the interleaving under test.
+    await reloadStarted;
+    let putDone = false;
+    const putting = (async () => {
+      const { res } = fakeResponse();
+      await handleApiRequest(fakePost("/api/config", { portal: { portalName: "Ryoko2" } }, "PUT"), res, context);
+      putDone = true;
+    })();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(putDone).toBe(false); // blocked behind connect's critical section
+    releaseReload();
+    const outcome = await connecting;
+    await putting;
+    expect(outcome).toMatchObject({ rolledBack: true });
+    const cfg = yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8")) as { portal?: { portalName?: string }; connectors?: { slack?: unknown } };
+    expect(cfg.portal?.portalName).toBe("Ryoko2"); // the PUT landed AFTER the rollback and survived it
+    expect(cfg.connectors?.slack).toEqual(PREVIOUS);
   });
 
   it("treats a reload that throws as a failure and rolls back too", async () => {

--- a/packages/jimmy/src/gateway/__tests__/onboarding-slack-verify-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-slack-verify-api.test.ts
@@ -1,0 +1,89 @@
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleApiRequest, type ApiContext } from "../api.js";
+
+/* The wizard saves Slack tokens only after this route says BOTH are good.
+ * The connector itself only warns when auth.test fails (a valid app token
+ * alone starts Socket Mode), so a bot-token check that lives before the save
+ * is what stops "接続できました" from lying. */
+
+function fakePost(pathname: string, body: unknown): IncomingMessage {
+  const readable = Readable.from([Buffer.from(JSON.stringify(body))]) as unknown as IncomingMessage;
+  readable.headers = { host: "127.0.0.1", "content-type": "application/json" };
+  readable.method = "POST";
+  readable.url = pathname;
+  return readable;
+}
+
+function fakeResponse(): { res: ServerResponse; read: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const headers: Record<string, string> = {};
+  const res = {
+    writeHead(code: number) { status = code; return this; },
+    setHeader(name: string, value: string) { headers[name] = value; return this; },
+    getHeader(name: string) { return headers[name]; },
+    end(chunk?: unknown) { if (chunk) chunks.push(String(chunk)); },
+  } as unknown as ServerResponse;
+  return { res, read: () => ({ status, body: chunks.length ? JSON.parse(chunks.join("")) : null }) };
+}
+
+const context = {
+  getConfig: () => ({ gateway: {}, connectors: {}, engines: { default: "claude", claude: { bin: "claude", model: "opus" }, codex: { bin: "codex", model: "gpt" } } }),
+  connectors: new Map(), sessionManager: {}, emit: () => {}, startTime: Date.now(),
+} as unknown as ApiContext;
+
+function stubSlack(answers: Record<string, { ok: boolean; [key: string]: unknown }>): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string, init?: { headers?: Record<string, string> }) => {
+    const method = String(url).split("/api/")[1]!;
+    const token = init?.headers?.Authorization ?? "";
+    const answer = answers[`${method}:${token}`] ?? { ok: false, error: "invalid_auth" };
+    return { json: async () => answer } as Response;
+  }));
+}
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("POST /api/onboarding/slack/verify", () => {
+  it("reports a bad bot token even when the app token opens Socket Mode", async () => {
+    stubSlack({
+      "auth.test:Bearer xoxb-bad": { ok: false, error: "invalid_auth" },
+      "apps.connections.open:Bearer xapp-good": { ok: true, url: "wss://…" },
+    });
+    const { res, read } = fakeResponse();
+    await handleApiRequest(fakePost("/api/onboarding/slack/verify", { botToken: "xoxb-bad", appToken: "xapp-good" }), res, context);
+    const { status, body } = read();
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ ok: false, bot: { ok: false, error: "invalid_auth" }, app: { ok: true } });
+  });
+
+  it("answers ok with team/user when both tokens verify", async () => {
+    stubSlack({
+      "auth.test:Bearer xoxb-good": { ok: true, team: "TEKION", user: "ryoko" },
+      "apps.connections.open:Bearer xapp-good": { ok: true },
+    });
+    const { res, read } = fakeResponse();
+    await handleApiRequest(fakePost("/api/onboarding/slack/verify", { botToken: "xoxb-good", appToken: "xapp-good" }), res, context);
+    expect(read().body).toMatchObject({ ok: true, bot: { ok: true, team: "TEKION", user: "ryoko" }, app: { ok: true } });
+  });
+
+  it("refuses tokens with the wrong prefix before calling Slack", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const { res, read } = fakeResponse();
+    await handleApiRequest(fakePost("/api/onboarding/slack/verify", { botToken: "xapp-swapped", appToken: "xoxb-swapped" }), res, context);
+    expect(read().status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("turns a network failure into a per-token error, not a 500", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("getaddrinfo ENOTFOUND slack.com"); }));
+    const { res, read } = fakeResponse();
+    await handleApiRequest(fakePost("/api/onboarding/slack/verify", { botToken: "xoxb-x", appToken: "xapp-x" }), res, context);
+    const { status, body } = read();
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ ok: false, bot: { ok: false }, app: { ok: false } });
+    expect(String((body as { bot: { error: string } }).bot.error)).toContain("ENOTFOUND");
+  });
+});

--- a/packages/jimmy/src/gateway/__tests__/onboarding-slack-verify-api.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/onboarding-slack-verify-api.test.ts
@@ -39,7 +39,7 @@ function stubSlack(answers: Record<string, { ok: boolean; [key: string]: unknown
     const method = String(url).split("/api/")[1]!;
     const token = init?.headers?.Authorization ?? "";
     const answer = answers[`${method}:${token}`] ?? { ok: false, error: "invalid_auth" };
-    return { json: async () => answer } as Response;
+    return { ok: true, status: 200, json: async () => answer } as Response;
   }));
 }
 
@@ -77,13 +77,20 @@ describe("POST /api/onboarding/slack/verify", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("turns a network failure into a per-token error, not a 500", async () => {
+  it("turns a network failure into a normalized per-token code, never a 500 or a raw message", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("getaddrinfo ENOTFOUND slack.com"); }));
     const { res, read } = fakeResponse();
     await handleApiRequest(fakePost("/api/onboarding/slack/verify", { botToken: "xoxb-x", appToken: "xapp-x" }), res, context);
     const { status, body } = read();
     expect(status).toBe(200);
-    expect(body).toMatchObject({ ok: false, bot: { ok: false }, app: { ok: false } });
-    expect(String((body as { bot: { error: string } }).bot.error)).toContain("ENOTFOUND");
+    expect(body).toMatchObject({ ok: false, bot: { ok: false, error: "network_error" }, app: { ok: false, error: "network_error" } });
+    expect(JSON.stringify(body)).not.toContain("ENOTFOUND");
+  });
+
+  it("treats a non-2xx HTTP answer as a failure even if the body were to say ok", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500, json: async () => ({ ok: true }) }) as Response));
+    const { res, read } = fakeResponse();
+    await handleApiRequest(fakePost("/api/onboarding/slack/verify", { botToken: "xoxb-x", appToken: "xapp-x" }), res, context);
+    expect(read().body).toMatchObject({ ok: false, bot: { ok: false, error: "http_500" }, app: { ok: false, error: "http_500" } });
   });
 });

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage as HttpRequest, ServerResponse } from "node:http";
 import http from "node:http";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import yaml from "js-yaml";
 import cron from "node-cron";
@@ -495,6 +496,54 @@ export async function handleApiRequest(
           && workflowVerifyAuth(req.headers, context.authToken, context.authHome));
       if (await handleWorkflowApi(req, res, { method, pathname, url },
         { service: context.workflowService, authenticated })) return;
+    }
+
+    // GET /api/onboarding/engines — can each configured engine actually run?
+    // Installed (binary resolves), runnable (`--version` answers), and for
+    // Claude whether a subscription login / API key is present. This is the
+    // onboarding wizard's "does it work" check; /api/status only echoes config.
+    if (method === "GET" && pathname === "/api/onboarding/engines") {
+      const config = context.getConfig();
+      const { tryResolveBin } = await import("../shared/resolveBin.js");
+      const { execFile } = await import("node:child_process");
+      const probe = (name: string, bin: string | undefined): Promise<Record<string, unknown>> => new Promise((resolve) => {
+        if (!bin) { resolve({ name, configured: false, installed: false, runnable: false }); return; }
+        const resolved = tryResolveBin(bin);
+        if (!resolved) { resolve({ name, configured: true, installed: false, runnable: false, bin, error: `${bin} が PATH にありません` }); return; }
+        execFile(resolved, ["--version"], { timeout: 8_000, windowsHide: true }, (err, stdout, stderr) => {
+          if (err) {
+            resolve({ name, configured: true, installed: true, runnable: false, bin: resolved,
+              error: (stderr || err.message).toString().trim().split("\n")[0] });
+            return;
+          }
+          resolve({ name, configured: true, installed: true, runnable: true, bin: resolved,
+            version: stdout.toString().trim().split("\n")[0] });
+        });
+      });
+      const claudeAuth = (): Record<string, unknown> => {
+        if (process.env.ANTHROPIC_API_KEY) return { method: "api-key" };
+        try {
+          const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+          const raw = fs.readFileSync(path.join(dir, ".credentials.json"), "utf-8");
+          const expiresAt = JSON.parse(raw)?.claudeAiOauth?.expiresAt;
+          if (typeof expiresAt === "number" && expiresAt > 0) {
+            return { method: "oauth", expiresAt: new Date(expiresAt).toISOString(), expired: expiresAt < Date.now() };
+          }
+          return { method: "unknown" };
+        } catch {
+          return { method: "none" };
+        }
+      };
+      const [claude, codex, gemini] = await Promise.all([
+        probe("claude", config.engines.claude?.bin),
+        probe("codex", config.engines.codex?.bin),
+        probe("gemini", config.engines.gemini?.bin),
+      ]);
+      res.setHeader("Cache-Control", "no-store");
+      return json(res, {
+        default: config.engines.default,
+        engines: [{ ...claude, auth: claudeAuth() }, codex, ...(gemini.configured ? [gemini] : [])],
+      });
     }
 
     // GET /api/automation/templates — the fill-in-the-blanks workflow shapes.

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -1890,6 +1890,10 @@ Handle this as a priority request from a colleague.`;
       if (body.engines !== undefined && (typeof body.engines !== "object" || Array.isArray(body.engines))) {
         return badRequest(res, "engines must be an object");
       }
+      // Every read→merge→write→reload of config.yaml runs under one lock, so a
+      // concurrent writer (another PUT, the onboarding Slack connect and its
+      // rollback) can never interleave with — or be overwritten by — this one.
+      return withConfigLock(async () => {
       // Deep-merge incoming config with existing config to preserve
       // fields not included in the update (e.g. connector tokens).
       let existing: Record<string, unknown> = {};
@@ -1974,6 +1978,7 @@ Handle this as a priority request from a colleague.`;
       }
 
       return json(res, { status: "ok" });
+      });
     }
 
     // GET /api/logs
@@ -3239,6 +3244,19 @@ async function runWebSession(
 
 
 // ---------------------------------------------------------------------------
+// Config write serialization (fork addition)
+// ---------------------------------------------------------------------------
+
+/** One writer at a time for config.yaml + connector reload. The chain never
+ *  rejects: a failing writer settles its own promise and the next waiter runs. */
+let configWriteChain: Promise<void> = Promise.resolve();
+export function withConfigLock<T>(work: () => Promise<T>): Promise<T> {
+  const run = configWriteChain.then(work, work);
+  configWriteChain = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+// ---------------------------------------------------------------------------
 // Onboarding probes (fork addition)
 // ---------------------------------------------------------------------------
 
@@ -3430,7 +3448,15 @@ interface SlackConnectResult {
   ok: boolean;
   stage?: "verify" | "reload";
   error?: string;
+  /** True only when the previous Slack block is back on disk AND its
+   *  connector came back up. */
   rolledBack?: boolean;
+  /** What the rollback achieved, separately: the file, and the live connector. */
+  restored?: { disk: boolean; running: boolean };
+  rollbackError?: string;
+  /** Set when the on-disk Slack block was changed by someone else between our
+   *  write and the rollback — we leave their value alone. */
+  rollbackSkipped?: string;
   team?: string;
   user?: string;
   bot?: SlackVerifyResult["bot"];
@@ -3446,24 +3472,56 @@ function slackFailure(outcome: ConfigPatchOutcome): string | null {
   return null;
 }
 
+function readSlackBlock(): Record<string, unknown> | null {
+  try {
+    const current = (yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8")) as { connectors?: { slack?: Record<string, unknown> } }) || {};
+    return current.connectors?.slack ?? null;
+  } catch {
+    return null;
+  }
+}
+
 async function connectSlack(context: ApiContext, botToken: string, appToken: string): Promise<SlackConnectResult> {
   const verified = await verifySlackTokens(botToken, appToken);
   if (!verified.ok) return { ok: false, stage: "verify", error: "token verification failed", bot: verified.bot, app: verified.app };
 
-  let previousSlack: Record<string, unknown> | null = null;
-  try {
-    const current = (yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8")) as { connectors?: { slack?: Record<string, unknown> } }) || {};
-    previousSlack = current.connectors?.slack ?? null;
-  } catch { /* no config yet */ }
+  // Snapshot → write → reload → (rollback) is ONE critical section: a PUT
+  // /api/config or a second connect waits for it, so the snapshot we would
+  // restore can never be older than what a concurrent writer put down.
+  return withConfigLock(async () => {
+    const previousSlack = readSlackBlock();
+    const outcome = await writeConfigPatchAndReload(context, { connectors: { slack: { botToken, appToken } } });
+    const failure = slackFailure(outcome);
+    if (!failure) return { ok: true, team: verified.bot.team, user: verified.bot.user };
 
-  const outcome = await writeConfigPatchAndReload(context, { connectors: { slack: { botToken, appToken } } });
-  const failure = slackFailure(outcome);
-  if (!failure) return { ok: true, team: verified.bot.team, user: verified.bot.user };
-
-  // The connector did not come up on tokens Slack itself accepted — put the
-  // previous configuration back (or remove the block if there was none) and
-  // reload again, so a working install is never left broken by a failed try.
-  logger.warn(`[onboarding] Slack connect failed after save (${failure}) — restoring previous Slack config`);
-  await writeConfigPatchAndReload(context, { connectors: { slack: previousSlack ?? null } });
-  return { ok: false, stage: "reload", error: failure, rolledBack: true };
+    // The connector did not come up on tokens Slack itself accepted. Put the
+    // previous configuration back (or remove the block if there was none) —
+    // but only if the block on disk is still OURS: an out-of-band editor may
+    // have written something else meanwhile, and that is theirs to keep.
+    const onDisk = readSlackBlock();
+    if (onDisk?.botToken !== botToken || onDisk?.appToken !== appToken) {
+      logger.warn(`[onboarding] Slack connect failed (${failure}) but the Slack config changed concurrently — leaving it as is`);
+      return { ok: false, stage: "reload", error: failure, rolledBack: false,
+        restored: { disk: false, running: false }, rollbackSkipped: "config changed concurrently" };
+    }
+    logger.warn(`[onboarding] Slack connect failed after save (${failure}) — restoring previous Slack config`);
+    let rollback: ConfigPatchOutcome;
+    try {
+      rollback = await writeConfigPatchAndReload(context, { connectors: { slack: previousSlack ?? null } });
+    } catch (err) {
+      const rollbackError = err instanceof Error ? err.message : String(err);
+      logger.error(`[onboarding] Slack rollback write failed: ${rollbackError}`);
+      return { ok: false, stage: "reload", error: failure, rolledBack: false,
+        restored: { disk: false, running: false }, rollbackError };
+    }
+    // The rollback is only a rollback if the previous connector actually came
+    // back up; a partial/errored second reload is reported as such.
+    const rollbackFailure = previousSlack ? slackFailure(rollback) : null;
+    if (rollbackFailure) {
+      logger.error(`[onboarding] Slack rollback wrote the previous config but the connector did not start: ${rollbackFailure}`);
+      return { ok: false, stage: "reload", error: failure, rolledBack: false,
+        restored: { disk: true, running: false }, rollbackError: rollbackFailure };
+    }
+    return { ok: false, stage: "reload", error: failure, rolledBack: true, restored: { disk: true, running: Boolean(previousSlack) } };
+  });
 }

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -3448,10 +3448,19 @@ interface SlackConnectResult {
   ok: boolean;
   stage?: "verify" | "reload";
   error?: string;
-  /** True only when the previous Slack block is back on disk AND its
-   *  connector came back up. */
+  /** What was on disk before this attempt: an existing Slack block, or none.
+   *  Tells the caller what a rollback means here — "the old connection is
+   *  back" vs "the attempt was undone and Slack is unconfigured again". */
+  previous?: "config" | "none";
+  /** True only when the pre-attempt state is fully back: the file (the old
+   *  block restored, or removed again for previous:"none") AND the live
+   *  connectors settled on it without a Slack error — the old connector
+   *  running again for "config", nothing left to run for "none". Never true
+   *  when the second reload reported a failure. */
   rolledBack?: boolean;
-  /** What the rollback achieved, separately: the file, and the live connector. */
+  /** What the rollback achieved, separately: the file, and the live
+   *  connector. running is always false for previous:"none" — there is no
+   *  previous connector to bring back. */
   restored?: { disk: boolean; running: boolean };
   rollbackError?: string;
   /** Set when the on-disk Slack block was changed by someone else between our
@@ -3490,6 +3499,7 @@ async function connectSlack(context: ApiContext, botToken: string, appToken: str
   // restore can never be older than what a concurrent writer put down.
   return withConfigLock(async () => {
     const previousSlack = readSlackBlock();
+    const previous = previousSlack ? ("config" as const) : ("none" as const);
     const outcome = await writeConfigPatchAndReload(context, { connectors: { slack: { botToken, appToken } } });
     const failure = slackFailure(outcome);
     if (!failure) return { ok: true, team: verified.bot.team, user: verified.bot.user };
@@ -3501,27 +3511,30 @@ async function connectSlack(context: ApiContext, botToken: string, appToken: str
     const onDisk = readSlackBlock();
     if (onDisk?.botToken !== botToken || onDisk?.appToken !== appToken) {
       logger.warn(`[onboarding] Slack connect failed (${failure}) but the Slack config changed concurrently — leaving it as is`);
-      return { ok: false, stage: "reload", error: failure, rolledBack: false,
+      return { ok: false, stage: "reload", error: failure, previous, rolledBack: false,
         restored: { disk: false, running: false }, rollbackSkipped: "config changed concurrently" };
     }
-    logger.warn(`[onboarding] Slack connect failed after save (${failure}) — restoring previous Slack config`);
+    logger.warn(`[onboarding] Slack connect failed after save (${failure}) — ${previous === "config" ? "restoring previous Slack config" : "removing the Slack block again"}`);
     let rollback: ConfigPatchOutcome;
     try {
       rollback = await writeConfigPatchAndReload(context, { connectors: { slack: previousSlack ?? null } });
     } catch (err) {
       const rollbackError = err instanceof Error ? err.message : String(err);
       logger.error(`[onboarding] Slack rollback write failed: ${rollbackError}`);
-      return { ok: false, stage: "reload", error: failure, rolledBack: false,
+      return { ok: false, stage: "reload", error: failure, previous, rolledBack: false,
         restored: { disk: false, running: false }, rollbackError };
     }
-    // The rollback is only a rollback if the previous connector actually came
-    // back up; a partial/errored second reload is reported as such.
-    const rollbackFailure = previousSlack ? slackFailure(rollback) : null;
+    // The rollback is only a rollback if the live side settled on the restored
+    // file: the previous connector came back up (previous:"config"), or the
+    // removal reload finished without a Slack error (previous:"none"). A
+    // partial/errored second reload is reported as such in both cases — the
+    // file is back, the connectors are not known to be.
+    const rollbackFailure = slackFailure(rollback);
     if (rollbackFailure) {
-      logger.error(`[onboarding] Slack rollback wrote the previous config but the connector did not start: ${rollbackFailure}`);
-      return { ok: false, stage: "reload", error: failure, rolledBack: false,
+      logger.error(`[onboarding] Slack rollback wrote the previous config but the connectors did not settle on it: ${rollbackFailure}`);
+      return { ok: false, stage: "reload", error: failure, previous, rolledBack: false,
         restored: { disk: true, running: false }, rollbackError: rollbackFailure };
     }
-    return { ok: false, stage: "reload", error: failure, rolledBack: true, restored: { disk: true, running: Boolean(previousSlack) } };
+    return { ok: false, stage: "reload", error: failure, previous, rolledBack: true, restored: { disk: true, running: previous === "config" } };
   });
 }

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -498,55 +498,38 @@ export async function handleApiRequest(
         { service: context.workflowService, authenticated })) return;
     }
 
-    // GET /api/onboarding/engines — can each configured engine actually run?
-    // Installed (binary resolves), runnable (`--version` answers), and for
-    // Claude whether a subscription login / API key is present. This is the
-    // onboarding wizard's "does it work" check; /api/status only echoes config.
+    // GET /api/onboarding/engines — is each configured engine INSTALLED and
+    // STARTABLE, and what login state can be observed locally? This is an
+    // install check with the best available auth signal — the wizard words it
+    // that way. It never spends tokens or reaches the network. One probe runs
+    // at a time (shared in-flight promise) and the result is cached briefly,
+    // so a burst of requests spawns one set of child processes, not many.
     if (method === "GET" && pathname === "/api/onboarding/engines") {
       const config = context.getConfig();
-      const { tryResolveBin } = await import("../shared/resolveBin.js");
-      const { execFile } = await import("node:child_process");
-      const probe = (name: string, bin: string | undefined): Promise<Record<string, unknown>> => new Promise((resolve) => {
-        if (!bin) { resolve({ name, configured: false, installed: false, runnable: false }); return; }
-        const resolved = tryResolveBin(bin);
-        if (!resolved) { resolve({ name, configured: true, installed: false, runnable: false, bin, error: `${bin} が PATH にありません` }); return; }
-        execFile(resolved, ["--version"], { timeout: 8_000, windowsHide: true }, (err, stdout, stderr) => {
-          if (err) {
-            resolve({ name, configured: true, installed: true, runnable: false, bin: resolved,
-              error: (stderr || err.message).toString().trim().split("\n")[0] });
-            return;
-          }
-          resolve({ name, configured: true, installed: true, runnable: true, bin: resolved,
-            version: stdout.toString().trim().split("\n")[0] });
-        });
-      });
-      const claudeAuth = (): Record<string, unknown> => {
-        if (process.env.ANTHROPIC_API_KEY) return { method: "api-key" };
-        try {
-          const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
-          const raw = fs.readFileSync(path.join(dir, ".credentials.json"), "utf-8");
-          const expiresAt = JSON.parse(raw)?.claudeAiOauth?.expiresAt;
-          if (typeof expiresAt === "number" && expiresAt > 0) {
-            return { method: "oauth", expiresAt: new Date(expiresAt).toISOString(), expired: expiresAt < Date.now() };
-          }
-          return { method: "unknown" };
-        } catch {
-          return { method: "none" };
-        }
-      };
-      const [claude, codex, gemini] = await Promise.all([
-        probe("claude", config.engines.claude?.bin),
-        probe("codex", config.engines.codex?.bin),
-        probe("gemini", config.engines.gemini?.bin),
-      ]);
       res.setHeader("Cache-Control", "no-store");
-      return json(res, {
-        default: config.engines.default,
-        engines: [{ ...claude, auth: claudeAuth() }, codex, ...(gemini.configured ? [gemini] : [])],
-      });
+      return json(res, await probeOnboardingEngines(config));
     }
 
-    // GET /api/automation/templates — the fill-in-the-blanks workflow shapes.
+    // POST /api/onboarding/slack/verify — prove BOTH Slack tokens before
+    // anything is saved: auth.test for the bot token, apps.connections.open
+    // for the app token (Socket Mode). Nothing is written here; the wizard
+    // saves only after both answer ok, so a wrong token can never overwrite a
+    // working connection.
+    if (method === "POST" && pathname === "/api/onboarding/slack/verify") {
+      const { readJsonBody } = await import("./http-helpers.js");
+      const read = await readJsonBody(req, res, { maxBytes: 16 * 1024 });
+      if (!read.ok) return;
+      const body = read.body as { botToken?: unknown; appToken?: unknown } | null;
+      const botToken = typeof body?.botToken === "string" ? body.botToken.trim() : "";
+      const appToken = typeof body?.appToken === "string" ? body.appToken.trim() : "";
+      if (!botToken.startsWith("xoxb-") || !appToken.startsWith("xapp-")) {
+        return badRequest(res, "botToken must start with xoxb- and appToken with xapp-");
+      }
+      res.setHeader("Cache-Control", "no-store");
+      return json(res, await verifySlackTokens(botToken, appToken));
+    }
+
+    // GET /api/automation/templates — the fill-in-the-blanks workflow shapes.    // GET /api/automation/templates — the fill-in-the-blanks workflow shapes.
     // Lives outside /api/workflows so a definition id can never shadow it.
     if (method === "GET" && pathname === "/api/automation/templates") {
       const { AUTOMATION_TEMPLATES } = await import("../workflows/templates.js");
@@ -3232,4 +3215,134 @@ async function runWebSession(
     });
     logger.error(`Web session ${currentSession.id} error: ${errMsg}`);
   }
+}
+
+
+// ---------------------------------------------------------------------------
+// Onboarding probes (fork addition)
+// ---------------------------------------------------------------------------
+
+interface EngineProbeResult {
+  name: string;
+  configured: boolean;
+  installed: boolean;
+  runnable: boolean;
+  bin?: string;
+  version?: string;
+  error?: string;
+  auth?: { method: "api-key" | "oauth" | "chatgpt" | "none" | "unknown"; expiresAt?: string; expired?: boolean; note: string };
+}
+
+const ENGINE_PROBE_TTL_MS = 10_000;
+let engineProbeInFlight: Promise<{ default: string; probedAt: string; engines: EngineProbeResult[] }> | null = null;
+let engineProbeCache: { at: number; value: { default: string; probedAt: string; engines: EngineProbeResult[] } } | null = null;
+
+function runBinary(bin: string, args: string[], timeoutMs: number): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    import("node:child_process").then(({ execFile }) => {
+      execFile(bin, args, { timeout: timeoutMs, windowsHide: true }, (err, stdout, stderr) => {
+        resolve({ ok: !err, stdout: String(stdout ?? ""), stderr: String(stderr ?? err?.message ?? "") });
+      });
+    });
+  });
+}
+
+async function probeEngine(name: string, bin: string | undefined): Promise<EngineProbeResult> {
+  if (!bin) return { name, configured: false, installed: false, runnable: false };
+  const { tryResolveBin } = await import("../shared/resolveBin.js");
+  const resolved = tryResolveBin(bin);
+  if (!resolved) return { name, configured: true, installed: false, runnable: false, bin, error: `${bin} が PATH にありません` };
+  const version = await runBinary(resolved, ["--version"], 8_000);
+  if (!version.ok) {
+    return { name, configured: true, installed: true, runnable: false, bin: resolved,
+      error: version.stderr.trim().split("\n")[0] || "起動に失敗しました" };
+  }
+  return { name, configured: true, installed: true, runnable: true, bin: resolved, version: version.stdout.trim().split("\n")[0] };
+}
+
+/** What can be observed about Claude's login WITHOUT spending anything: an API
+ *  key in the environment, or the subscription OAuth file's expiry. Neither
+ *  proves the credential still works — the note says so. */
+function observeClaudeAuth(): NonNullable<EngineProbeResult["auth"]> {
+  if (process.env.ANTHROPIC_API_KEY) return { method: "api-key", note: "API キーが設定されています（有効性は初回実行時に判明）" };
+  try {
+    const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+    const raw = fs.readFileSync(path.join(dir, ".credentials.json"), "utf-8");
+    const expiresAt = JSON.parse(raw)?.claudeAiOauth?.expiresAt;
+    if (typeof expiresAt === "number" && expiresAt > 0) {
+      const expired = expiresAt < Date.now();
+      return { method: "oauth", expiresAt: new Date(expiresAt).toISOString(), expired,
+        note: expired ? "ログインの期限が切れています（claude を一度起動すると更新されます）" : "ログイン情報があります（有効性は初回実行時に判明）" };
+    }
+    return { method: "unknown", note: "ログイン情報の形式を判定できませんでした" };
+  } catch {
+    return { method: "none", note: "ログイン情報が見つかりません（端末で claude と入力してログイン）" };
+  }
+}
+
+/** `codex login status` answers with its exit code — the one engine that can
+ *  be asked directly, still without spending anything. */
+async function observeCodexAuth(resolvedBin: string): Promise<NonNullable<EngineProbeResult["auth"]>> {
+  const status = await runBinary(resolvedBin, ["login", "status"], 8_000);
+  if (status.ok) return { method: "chatgpt", note: (status.stdout.trim().split("\n")[0] || "ログイン済み") };
+  return { method: "none", note: "未ログインです（端末で codex login を実行）" };
+}
+
+async function probeOnboardingEngines(config: JinnConfig): Promise<{ default: string; probedAt: string; engines: EngineProbeResult[] }> {
+  if (engineProbeCache && Date.now() - engineProbeCache.at < ENGINE_PROBE_TTL_MS) return engineProbeCache.value;
+  if (engineProbeInFlight) return engineProbeInFlight;
+  engineProbeInFlight = (async () => {
+    const [claude, codex, gemini] = await Promise.all([
+      probeEngine("claude", config.engines.claude?.bin),
+      probeEngine("codex", config.engines.codex?.bin),
+      probeEngine("gemini", config.engines.gemini?.bin),
+    ]);
+    if (claude.runnable) claude.auth = observeClaudeAuth();
+    if (codex.runnable && codex.bin) codex.auth = await observeCodexAuth(codex.bin);
+    const value = {
+      default: config.engines.default, probedAt: new Date().toISOString(),
+      engines: [claude, codex, ...(gemini.configured ? [gemini] : [])],
+    };
+    engineProbeCache = { at: Date.now(), value };
+    return value;
+  })().finally(() => { engineProbeInFlight = null; });
+  return engineProbeInFlight;
+}
+
+/** Exposed for tests: forget the cached probe. */
+export function _resetEngineProbeCache(): void {
+  engineProbeCache = null;
+  engineProbeInFlight = null;
+}
+
+interface SlackVerifyResult {
+  ok: boolean;
+  bot: { ok: boolean; team?: string; user?: string; error?: string };
+  app: { ok: boolean; error?: string };
+}
+
+async function slackApi(method: string, token: string): Promise<{ ok: boolean; error?: string; [key: string]: unknown }> {
+  try {
+    const response = await fetch(`https://slack.com/api/${method}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/x-www-form-urlencoded" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    const payload = await response.json() as { ok?: boolean; error?: string; [key: string]: unknown };
+    return { ...payload, ok: payload.ok === true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function verifySlackTokens(botToken: string, appToken: string): Promise<SlackVerifyResult> {
+  const [bot, app] = await Promise.all([
+    slackApi("auth.test", botToken),
+    slackApi("apps.connections.open", appToken),
+  ]);
+  const botResult = bot.ok
+    ? { ok: true, team: typeof bot.team === "string" ? bot.team : undefined, user: typeof bot.user === "string" ? bot.user : undefined }
+    : { ok: false, error: bot.error ?? "auth.test failed" };
+  const appResult = app.ok ? { ok: true } : { ok: false, error: app.error ?? "apps.connections.open failed" };
+  return { ok: botResult.ok && appResult.ok, bot: botResult, app: appResult };
 }

--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -510,6 +510,25 @@ export async function handleApiRequest(
       return json(res, await probeOnboardingEngines(config));
     }
 
+    // POST /api/onboarding/slack/connect — the whole Slack hookup as ONE
+    // server-side operation: verify both tokens, save, reload, and if the
+    // connector still fails to start, put the previous Slack config back and
+    // reload again. The wizard calls only this, so "a wrong token never
+    // overwrites a working connection" holds across the verify→save gap too.
+    if (method === "POST" && pathname === "/api/onboarding/slack/connect") {
+      const { readJsonBody } = await import("./http-helpers.js");
+      const read = await readJsonBody(req, res, { maxBytes: 16 * 1024 });
+      if (!read.ok) return;
+      const body = read.body as { botToken?: unknown; appToken?: unknown } | null;
+      const botToken = typeof body?.botToken === "string" ? body.botToken.trim() : "";
+      const appToken = typeof body?.appToken === "string" ? body.appToken.trim() : "";
+      if (!botToken.startsWith("xoxb-") || !appToken.startsWith("xapp-")) {
+        return badRequest(res, "botToken must start with xoxb- and appToken with xapp-");
+      }
+      res.setHeader("Cache-Control", "no-store");
+      return json(res, await connectSlack(context, botToken, appToken));
+    }
+
     // POST /api/onboarding/slack/verify — prove BOTH Slack tokens before
     // anything is saved: auth.test for the bot token, apps.connections.open
     // for the app token (Socket Mode). Nothing is written here; the wizard
@@ -1910,6 +1929,7 @@ Handle this as a priority request from a colleague.`;
 
       fs.writeFileSync(CONFIG_PATH, yamlStr);
       invalidateModelRegistry(); // models/engines may have changed — rebuild on next read
+      _resetEngineProbeCache(); // engine bins may have changed — the onboarding probe must re-run
       logger.info("Config updated via API");
 
       if (connectorsChanged && context.reloadAllConnectors) {
@@ -3234,8 +3254,19 @@ interface EngineProbeResult {
 }
 
 const ENGINE_PROBE_TTL_MS = 10_000;
-let engineProbeInFlight: Promise<{ default: string; probedAt: string; engines: EngineProbeResult[] }> | null = null;
-let engineProbeCache: { at: number; value: { default: string; probedAt: string; engines: EngineProbeResult[] } } | null = null;
+type EngineProbePayload = { default: string; probedAt: string; engines: EngineProbeResult[] };
+/** Cache and in-flight probe are keyed by the engine config they were taken
+ *  under, so a bin/default change is never answered from a stale result — and
+ *  a probe started under the old config only ever caches under the old key. */
+let engineProbeInFlight: { key: string; promise: Promise<EngineProbePayload> } | null = null;
+let engineProbeCache: { key: string; at: number; value: EngineProbePayload } | null = null;
+
+function engineProbeKey(config: JinnConfig): string {
+  return JSON.stringify({
+    default: config.engines.default,
+    claude: config.engines.claude?.bin, codex: config.engines.codex?.bin, gemini: config.engines.gemini?.bin,
+  });
+}
 
 function runBinary(bin: string, args: string[], timeoutMs: number): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
@@ -3288,10 +3319,13 @@ async function observeCodexAuth(resolvedBin: string): Promise<NonNullable<Engine
   return { method: "none", note: "未ログインです（端末で codex login を実行）" };
 }
 
-async function probeOnboardingEngines(config: JinnConfig): Promise<{ default: string; probedAt: string; engines: EngineProbeResult[] }> {
-  if (engineProbeCache && Date.now() - engineProbeCache.at < ENGINE_PROBE_TTL_MS) return engineProbeCache.value;
-  if (engineProbeInFlight) return engineProbeInFlight;
-  engineProbeInFlight = (async () => {
+async function probeOnboardingEngines(config: JinnConfig): Promise<EngineProbePayload> {
+  const key = engineProbeKey(config);
+  if (engineProbeCache && engineProbeCache.key === key && Date.now() - engineProbeCache.at < ENGINE_PROBE_TTL_MS) {
+    return engineProbeCache.value;
+  }
+  if (engineProbeInFlight && engineProbeInFlight.key === key) return engineProbeInFlight.promise;
+  const promise = (async () => {
     const [claude, codex, gemini] = await Promise.all([
       probeEngine("claude", config.engines.claude?.bin),
       probeEngine("codex", config.engines.codex?.bin),
@@ -3299,14 +3333,20 @@ async function probeOnboardingEngines(config: JinnConfig): Promise<{ default: st
     ]);
     if (claude.runnable) claude.auth = observeClaudeAuth();
     if (codex.runnable && codex.bin) codex.auth = await observeCodexAuth(codex.bin);
-    const value = {
+    const value: EngineProbePayload = {
       default: config.engines.default, probedAt: new Date().toISOString(),
       engines: [claude, codex, ...(gemini.configured ? [gemini] : [])],
     };
-    engineProbeCache = { at: Date.now(), value };
+    // Only the newest config's probe may become "the" cache; a probe that ran
+    // under a config since replaced must not resurrect a stale answer.
+    if (!engineProbeCache || engineProbeCache.key === key || engineProbeInFlight?.key === key) {
+      engineProbeCache = { key, at: Date.now(), value };
+    }
     return value;
-  })().finally(() => { engineProbeInFlight = null; });
-  return engineProbeInFlight;
+  })();
+  engineProbeInFlight = { key, promise };
+  promise.finally(() => { if (engineProbeInFlight?.promise === promise) engineProbeInFlight = null; });
+  return promise;
 }
 
 /** Exposed for tests: forget the cached probe. */
@@ -3328,10 +3368,17 @@ async function slackApi(method: string, token: string): Promise<{ ok: boolean; e
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/x-www-form-urlencoded" },
       signal: AbortSignal.timeout(10_000),
     });
+    if (!response.ok) {
+      logger.warn(`[onboarding] Slack ${method} answered HTTP ${response.status}`);
+      return { ok: false, error: `http_${response.status}` };
+    }
     const payload = await response.json() as { ok?: boolean; error?: string; [key: string]: unknown };
     return { ...payload, ok: payload.ok === true };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    // The raw message (DNS, TLS, timeout details) goes to the log; the client
+    // gets a stable, non-leaky code.
+    logger.warn(`[onboarding] Slack ${method} request failed: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, error: "network_error" };
   }
 }
 
@@ -3345,4 +3392,78 @@ async function verifySlackTokens(botToken: string, appToken: string): Promise<Sl
     : { ok: false, error: bot.error ?? "auth.test failed" };
   const appResult = app.ok ? { ok: true } : { ok: false, error: app.error ?? "apps.connections.open failed" };
   return { ok: botResult.ok && appResult.ok, bot: botResult, app: appResult };
+}
+
+interface ConfigPatchOutcome {
+  status: "ok" | "partial";
+  connectorsReload?: { started: string[]; stopped: string[]; errors: string[] };
+  connectorsReloadError?: string;
+}
+
+/** Merge a patch into config.yaml and reload connectors — the same steps
+ *  PUT /api/config performs, callable from a server-side flow that has to
+ *  read the outcome and possibly undo the write. */
+async function writeConfigPatchAndReload(context: ApiContext, patch: Record<string, unknown>): Promise<ConfigPatchOutcome> {
+  let existing: Record<string, unknown> = {};
+  try {
+    existing = (yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8")) as Record<string, unknown>) || {};
+  } catch { /* first write */ }
+  const merged = deepMerge(existing, patch);
+  context.suppressNextConnectorReload?.();
+  fs.writeFileSync(CONFIG_PATH, yaml.dump(merged));
+  invalidateModelRegistry();
+  _resetEngineProbeCache();
+  if (!context.reloadAllConnectors) return { status: "ok" };
+  try {
+    const reload = await context.reloadAllConnectors();
+    context.config = context.getConfig();
+    context.emit("connectors:reloaded", reload);
+    if (reload.errors.length > 0) context.clearSuppressNextConnectorReload?.();
+    return { status: reload.errors.length > 0 ? "partial" : "ok", connectorsReload: reload };
+  } catch (err) {
+    context.clearSuppressNextConnectorReload?.();
+    return { status: "ok", connectorsReloadError: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+interface SlackConnectResult {
+  ok: boolean;
+  stage?: "verify" | "reload";
+  error?: string;
+  rolledBack?: boolean;
+  team?: string;
+  user?: string;
+  bot?: SlackVerifyResult["bot"];
+  app?: SlackVerifyResult["app"];
+}
+
+function slackFailure(outcome: ConfigPatchOutcome): string | null {
+  if (outcome.connectorsReloadError) return outcome.connectorsReloadError;
+  const errors = outcome.connectorsReload?.errors ?? [];
+  const slack = errors.find((line) => /slack/i.test(line));
+  if (slack) return slack;
+  if (outcome.status === "partial" && errors.length > 0) return errors.join(" | ");
+  return null;
+}
+
+async function connectSlack(context: ApiContext, botToken: string, appToken: string): Promise<SlackConnectResult> {
+  const verified = await verifySlackTokens(botToken, appToken);
+  if (!verified.ok) return { ok: false, stage: "verify", error: "token verification failed", bot: verified.bot, app: verified.app };
+
+  let previousSlack: Record<string, unknown> | null = null;
+  try {
+    const current = (yaml.load(fs.readFileSync(CONFIG_PATH, "utf-8")) as { connectors?: { slack?: Record<string, unknown> } }) || {};
+    previousSlack = current.connectors?.slack ?? null;
+  } catch { /* no config yet */ }
+
+  const outcome = await writeConfigPatchAndReload(context, { connectors: { slack: { botToken, appToken } } });
+  const failure = slackFailure(outcome);
+  if (!failure) return { ok: true, team: verified.bot.team, user: verified.bot.user };
+
+  // The connector did not come up on tokens Slack itself accepted — put the
+  // previous configuration back (or remove the block if there was none) and
+  // reload again, so a working install is never left broken by a failed try.
+  logger.warn(`[onboarding] Slack connect failed after save (${failure}) — restoring previous Slack config`);
+  await writeConfigPatchAndReload(context, { connectors: { slack: previousSlack ?? null } });
+  return { ok: false, stage: "reload", error: failure, rolledBack: true };
 }

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -873,26 +873,32 @@ export async function startGateway(
   let reloadInFlight: Promise<{ started: string[]; stopped: string[]; errors: string[] }> | null = null;
   let pendingReload = false;
 
-  // Coordination flag between the API config-save path and the file watcher.
-  // PUT /api/config eagerly reloads connectors for snappy UX, then sets this
-  // flag so the chokidar event for the same file write doesn't double-reload
-  // and race against the in-flight reload.
-  let suppressNextWatcherConnectorReload = false;
+  // Coordination between the API config-write paths and the file watcher.
+  // A writer that reloads connectors itself (PUT /api/config, the onboarding
+  // Slack connect and its rollback) arms one suppression per file write, and
+  // the watcher consumes one per event it skips. A COUNTER rather than a flag,
+  // so two writers in flight cannot clear each other's suppression: each
+  // arms and clears only its own. A safety timer drains everything in case a
+  // watcher event never arrives (chokidar coalesced two writes into one
+  // event, or missed it), so legitimate external edits are never suppressed
+  // for long. Known limit: when chokidar coalesces N writes into one event,
+  // N-1 suppressions remain until the timer drains them.
+  let suppressedWatcherConnectorReloads = 0;
   let suppressTimer: ReturnType<typeof setTimeout> | null = null;
-  function suppressNextConnectorReload(): void {
-    suppressNextWatcherConnectorReload = true;
+  function armSuppressDrainTimer(): void {
     if (suppressTimer) clearTimeout(suppressTimer);
-    // Auto-clear after 3s in case the watcher event never arrives (the file
-    // write was rolled back, chokidar missed it, etc.) — we don't want to
-    // permanently suppress legitimate future reloads.
     suppressTimer = setTimeout(() => {
-      suppressNextWatcherConnectorReload = false;
+      suppressedWatcherConnectorReloads = 0;
       suppressTimer = null;
     }, 3000);
   }
+  function suppressNextConnectorReload(): void {
+    suppressedWatcherConnectorReloads += 1;
+    armSuppressDrainTimer();
+  }
   function clearSuppressNextConnectorReload(): void {
-    suppressNextWatcherConnectorReload = false;
-    if (suppressTimer) {
+    if (suppressedWatcherConnectorReloads > 0) suppressedWatcherConnectorReloads -= 1;
+    if (suppressedWatcherConnectorReloads === 0 && suppressTimer) {
       clearTimeout(suppressTimer);
       suppressTimer = null;
     }
@@ -1169,13 +1175,13 @@ export async function startGateway(
         // triggered reloadAllConnectors itself and may still be mid-reconnect.
         // Skip our reload to avoid stop→start→stop→start churn and the
         // race that comes with two overlapping reloads.
-        if (suppressNextWatcherConnectorReload) {
-          suppressNextWatcherConnectorReload = false;
-          if (suppressTimer) {
+        if (suppressedWatcherConnectorReloads > 0) {
+          suppressedWatcherConnectorReloads -= 1;
+          if (suppressedWatcherConnectorReloads === 0 && suppressTimer) {
             clearTimeout(suppressTimer);
             suppressTimer = null;
           }
-          logger.debug("Skipping watcher-triggered connector reload (API just wrote config and reloaded)");
+          logger.debug("Skipping watcher-triggered connector reload (an API write just reloaded connectors itself)");
           return;
         }
 

--- a/packages/web/src/app/cron/page.tsx
+++ b/packages/web/src/app/cron/page.tsx
@@ -170,7 +170,23 @@ export default function CronPage() {
   const [updatedAgo, setUpdatedAgo] = useState("just now")
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date())
   const [wfCreating, setWfCreating] = useState(false)
+  const [wfInitialTemplate, setWfInitialTemplate] = useState<string | null>(null)
   const [wfCounts, setWfCounts] = useState({ total: 0, enabled: 0, disabled: 0, engineEnabled: true })
+
+  // Deep link from onboarding: /cron?create=<templateId> opens the creation
+  // panel on that template. The param is consumed once so a reload does not
+  // reopen the panel.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const params = new URLSearchParams(window.location.search)
+    const create = params.get("create")
+    if (!create) return
+    setWfInitialTemplate(create)
+    setWfCreating(true)
+    params.delete("create")
+    const rest = params.toString()
+    window.history.replaceState(null, "", `${window.location.pathname}${rest ? `?${rest}` : ""}`)
+  }, [])
   const [triggeringId, setTriggeringId] = useState<string | null>(null)
   const [employeeMap, setEmployeeMap] = useState<Map<string, Employee>>(new Map())
 
@@ -343,7 +359,8 @@ export default function CronPage() {
                 {/* Workflows live in the same list view, above the cron groups */}
                 <WorkflowsSection
                   creating={wfCreating}
-                  onCloseCreate={() => setWfCreating(false)}
+                  initialTemplateId={wfInitialTemplate}
+                  onCloseCreate={() => { setWfCreating(false); setWfInitialTemplate(null) }}
                   filter={filter}
                   onCountsChange={setWfCounts}
                 />

--- a/packages/web/src/components/crons/workflows-section.tsx
+++ b/packages/web/src/components/crons/workflows-section.tsx
@@ -277,13 +277,25 @@ function TemplateForm({
   )
 }
 
-function CreatePanel({ onCreated, onClose }: { onCreated: () => void; onClose: () => void }) {
+function CreatePanel({ onCreated, onClose, initialTemplateId }: {
+  onCreated: () => void
+  onClose: () => void
+  initialTemplateId?: string | null
+}) {
   const [templates, setTemplates] = useState<AutomationTemplateSpec[] | null>(null)
   const [selected, setSelected] = useState<AutomationTemplateSpec | null>(null)
 
   useEffect(() => {
-    api.getAutomationTemplates().then((result) => setTemplates(result.templates)).catch(() => setTemplates([]))
-  }, [])
+    api.getAutomationTemplates()
+      .then((result) => {
+        setTemplates(result.templates)
+        if (initialTemplateId) {
+          const preset = result.templates.find((template) => template.id === initialTemplateId)
+          if (preset) setSelected(preset)
+        }
+      })
+      .catch(() => setTemplates([]))
+  }, [initialTemplateId])
 
   return (
     <div className="rounded-[var(--radius-md)] border border-[var(--separator)] bg-[var(--material-regular)] p-[var(--space-4)] mb-[var(--space-3)]">
@@ -346,8 +358,9 @@ async function fetchAllWorkflows(): Promise<WorkflowSummary[]> {
   return items
 }
 
-export function WorkflowsSection({ creating, onCloseCreate, filter, onCountsChange }: {
+export function WorkflowsSection({ creating, initialTemplateId, onCloseCreate, filter, onCountsChange }: {
   creating: boolean
+  initialTemplateId?: string | null
   onCloseCreate: () => void
   filter: "all" | "enabled" | "disabled"
   onCountsChange?: (counts: WorkflowCounts) => void
@@ -440,7 +453,7 @@ export function WorkflowsSection({ creating, onCloseCreate, filter, onCountsChan
 
   return (
     <div className="mb-[var(--space-4)]">
-      {creating && <CreatePanel onCreated={() => { onCloseCreate(); refresh() }} onClose={onCloseCreate} />}
+      {creating && <CreatePanel initialTemplateId={initialTemplateId} onCreated={() => { onCloseCreate(); refresh() }} onClose={onCloseCreate} />}
       {notice && (
         <div className="text-[length:var(--text-caption1)] text-[var(--text-secondary)] mb-[var(--space-2)]">{notice}</div>
       )}

--- a/packages/web/src/components/onboarding-wizard.tsx
+++ b/packages/web/src/components/onboarding-wizard.tsx
@@ -161,6 +161,18 @@ function connectorHealth(status: unknown): ConnectorHealthMap {
   return connectors && typeof connectors === "object" ? (connectors as ConnectorHealthMap) : {}
 }
 
+/** Slack's error codes and our normalized ones, in words a person can act on. */
+function describeSlackError(code: string | undefined): string {
+  switch (code) {
+    case "invalid_auth": return "トークンが無効です"
+    case "not_authed": return "トークンが送られていません"
+    case "account_inactive": return "このトークンのアカウントは無効化されています"
+    case "network_error": return "Slack に接続できませんでした（ネットワークを確認）"
+    case undefined: return "確認に失敗しました"
+    default: return code.startsWith("http_") ? `Slack が HTTP ${code.slice(5)} を返しました` : code
+  }
+}
+
 function SlackStep() {
   const [botToken, setBotToken] = useState("")
   const [appToken, setAppToken] = useState("")
@@ -186,31 +198,30 @@ function SlackStep() {
     setBusy(true)
     setResult(null)
     try {
-      // 1. Prove both tokens BEFORE anything is saved — a wrong token must
-      //    never overwrite a working connection.
-      const verified = await api.verifySlackTokens(botToken, appToken)
-      if (!verified.ok) {
-        const parts = []
-        if (!verified.bot.ok) parts.push(`Bot Token: ${verified.bot.error ?? "auth.test に失敗"}`)
-        if (!verified.app.ok) parts.push(`App Token: ${verified.app.error ?? "Socket Mode 接続に失敗"}（アプリの Socket Mode が有効で、connections:write スコープがあるか確認）`)
-        setResult({ ok: false, message: `保存していません。${parts.join(" / ")}` })
+      // One server-side operation: verify both tokens → save → reload → if
+      // the connector still fails, the server restores the previous Slack
+      // config itself. Whatever comes back, nothing here has to guess.
+      const outcome = await api.connectSlack(botToken, appToken)
+      if (outcome.ok) {
+        setResult({
+          ok: true,
+          message: `接続できました（ワークスペース: ${outcome.team ?? "?"} / Bot: ${outcome.user ?? "?"}）。Slack で Ryoko にメンションしてみてください`,
+        })
         return
       }
-      // 2. Save. PUT /api/config reloads the connectors itself and reports
-      //    the outcome — read that instead of reloading again and guessing.
-      const saved = await api.updateConfig({ connectors: { slack: { botToken, appToken } } })
-      const errors = saved.connectorsReload?.errors ?? []
-      const slackError = errors.find((line) => /slack/i.test(line))
-      if (saved.status === "partial" && slackError) {
-        setResult({ ok: false, message: `トークンは正しいのに接続の起動に失敗しました: ${slackError}` })
+      if (outcome.stage === "verify") {
+        const parts = []
+        if (outcome.bot && !outcome.bot.ok) parts.push(`Bot Token: ${describeSlackError(outcome.bot.error)}`)
+        if (outcome.app && !outcome.app.ok) parts.push(`App Token: ${describeSlackError(outcome.app.error)}（アプリの Socket Mode が有効で、connections:write スコープがあるか確認）`)
+        setResult({ ok: false, message: `保存していません。${parts.join(" / ") || "トークンを確認できませんでした"}` })
         return
       }
       setResult({
-        ok: true,
-        message: `接続できました（ワークスペース: ${verified.bot.team ?? "?"} / Bot: ${verified.bot.user ?? "?"}）。Slack で Ryoko にメンションしてみてください`,
+        ok: false,
+        message: `トークンは正しいのに接続の起動に失敗しました: ${outcome.error ?? "不明なエラー"}${outcome.rolledBack ? "（以前の Slack 設定に戻しました）" : ""}`,
       })
     } catch (err) {
-      setResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
+      setResult({ ok: false, message: `接続処理でエラーが起きました: ${err instanceof Error ? err.message : String(err)}` })
     } finally {
       setBusy(false)
     }

--- a/packages/web/src/components/onboarding-wizard.tsx
+++ b/packages/web/src/components/onboarding-wizard.tsx
@@ -173,6 +173,18 @@ function describeSlackError(code: string | undefined): string {
   }
 }
 
+/** A save that Slack accepted but the connector could not start — and what
+ *  state the install was left in, stated honestly rather than optimistically. */
+function describeReloadFailure(outcome: { error?: string; rolledBack?: boolean; restored?: { disk: boolean; running: boolean }; rollbackError?: string; rollbackSkipped?: string }): string {
+  const head = `トークンは正しいのに接続の起動に失敗しました: ${outcome.error ?? "不明なエラー"}。`
+  if (outcome.rolledBack) return `${head}以前の Slack 設定に戻し、再接続しました。`
+  if (outcome.rollbackSkipped) return `${head}その間に設定が別の場所から変更されたため、元に戻す操作は行っていません。設定ページで現在の Slack 設定を確認してください。`
+  if (outcome.restored?.disk && !outcome.restored.running) {
+    return `${head}以前の設定はファイルに戻しましたが、その接続も起動できていません（${outcome.rollbackError ?? "原因不明"}）。設定ページで確認してください。`
+  }
+  return `${head}以前の設定に戻せませんでした（${outcome.rollbackError ?? "原因不明"}）。設定ページで Slack 設定を確認してください。`
+}
+
 function SlackStep() {
   const [botToken, setBotToken] = useState("")
   const [appToken, setAppToken] = useState("")
@@ -216,10 +228,7 @@ function SlackStep() {
         setResult({ ok: false, message: `保存していません。${parts.join(" / ") || "トークンを確認できませんでした"}` })
         return
       }
-      setResult({
-        ok: false,
-        message: `トークンは正しいのに接続の起動に失敗しました: ${outcome.error ?? "不明なエラー"}${outcome.rolledBack ? "（以前の Slack 設定に戻しました）" : ""}`,
-      })
+      setResult({ ok: false, message: describeReloadFailure(outcome) })
     } catch (err) {
       setResult({ ok: false, message: `接続処理でエラーが起きました: ${err instanceof Error ? err.message : String(err)}` })
     } finally {

--- a/packages/web/src/components/onboarding-wizard.tsx
+++ b/packages/web/src/components/onboarding-wizard.tsx
@@ -53,20 +53,18 @@ function engineHint(probe: EngineProbe): string | null {
     return probe.name === "claude"
       ? "npm install -g @anthropic-ai/claude-code でインストールし、claude と入力してログインしてください"
       : probe.name === "codex"
-        ? "npm install -g @openai/codex でインストールし、codex と入力してログインしてください"
+        ? "npm install -g @openai/codex でインストールし、codex login でログインしてください"
         : `${probe.name} をインストールして PATH を通してください`
   }
   if (!probe.runnable) return `起動できませんでした: ${probe.error ?? "不明なエラー"}`
-  if (probe.name === "claude" && probe.auth) {
-    if (probe.auth.method === "none") return "ログイン情報が見つかりません。端末で claude と入力してログインしてください"
-    if (probe.auth.method === "oauth" && probe.auth.expired) return "ログインの有効期限が切れています。claude を一度起動すると更新されます"
-  }
   return null
 }
 
+/** ✓ means "installed and starts". Login is shown as observed information,
+ *  never as a green light — a credential's validity only shows on first use. */
 function engineState(probe: EngineProbe): "ok" | "warn" | "fail" {
   if (!probe.installed || !probe.runnable) return "fail"
-  if (probe.name === "claude" && probe.auth && (probe.auth.method === "none" || probe.auth.expired)) return "warn"
+  if (probe.auth && (probe.auth.method === "none" || probe.auth.expired)) return "warn"
   return "ok"
 }
 
@@ -75,9 +73,11 @@ function EngineCheckStep({ active }: { active: boolean }) {
   const [defaultEngine, setDefaultEngine] = useState<string>("")
   const [error, setError] = useState<string | null>(null)
   const [checking, setChecking] = useState(false)
+  const [attempted, setAttempted] = useState(false)
 
   const check = useCallback(() => {
     setChecking(true)
+    setAttempted(true)
     setError(null)
     api.getOnboardingEngines()
       .then((result) => { setProbes(result.engines); setDefaultEngine(result.default) })
@@ -85,7 +85,9 @@ function EngineCheckStep({ active }: { active: boolean }) {
       .finally(() => setChecking(false))
   }, [])
 
-  useEffect(() => { if (active && probes === null && !checking) check() }, [active, probes, checking, check])
+  // One automatic probe when the step opens; after that only the button asks
+  // again — a failing gateway must not be hammered in a retry loop.
+  useEffect(() => { if (active && !attempted) check() }, [active, attempted, check])
 
   return (
     <div className="animate-fade-in">
@@ -93,7 +95,7 @@ function EngineCheckStep({ active }: { active: boolean }) {
         エンジンの確認
       </h2>
       <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
-        AI エンジンが実際に動くか確認します。ここが ✗ だと Ryoko は働けません。
+        AI エンジンがインストールされ、起動できるかを確認します（✓ = 起動できる）。ログインの有効性は最初の実行で判明します。ここが ✗ だと Ryoko は働けません。
       </p>
       {error && (
         <div className="text-[length:var(--text-footnote)] text-[var(--system-red)] mb-[var(--space-3)]">確認できませんでした: {error}</div>
@@ -121,10 +123,12 @@ function EngineCheckStep({ active }: { active: boolean }) {
                 </div>
                 <div className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)]">
                   {probe.version ?? (probe.installed ? "バージョン不明" : "未インストール")}
-                  {probe.name === "claude" && probe.auth && state === "ok" && (
-                    <span className="ml-2">・{probe.auth.method === "api-key" ? "API キー" : "ログイン済み"}</span>
-                  )}
                 </div>
+                {probe.auth && (
+                  <div className="text-[length:var(--text-caption1)] mt-0.5" style={{ color: state === "warn" ? color : "var(--text-secondary)" }}>
+                    ログイン: {probe.auth.note}
+                  </div>
+                )}
                 {hint && (
                   <div className="text-[length:var(--text-caption1)] mt-1 whitespace-pre-wrap" style={{ color }}>{hint}</div>
                 )}
@@ -162,13 +166,14 @@ function SlackStep() {
   const [appToken, setAppToken] = useState("")
   const [busy, setBusy] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
-  const [already, setAlready] = useState<string | null>(null)
+  const [already, setAlready] = useState(false)
+  const [replaceExisting, setReplaceExisting] = useState(false)
 
   useEffect(() => {
     api.getStatus()
       .then((status) => {
         const slack = connectorHealth(status).slack
-        if (slack && slack.status === "running") setAlready("Slack は既に接続されています")
+        if (slack && slack.status === "running") setAlready(true)
       })
       .catch(() => { /* status is optional here */ })
   }, [])
@@ -181,23 +186,36 @@ function SlackStep() {
     setBusy(true)
     setResult(null)
     try {
-      await api.updateConfig({ connectors: { slack: { botToken, appToken } } })
-      await api.reloadConnectors()
-      // Give Socket Mode a moment, then read the connector's own health.
-      await new Promise((resolve) => setTimeout(resolve, 2500))
-      const status = await api.getStatus()
-      const slack = connectorHealth(status).slack
-      if (slack?.status === "running") {
-        setResult({ ok: true, message: "接続できました。Slack で Ryoko にメンションしてみてください" })
-      } else {
-        setResult({ ok: false, message: `接続できていません（${slack?.status ?? "未起動"}${slack?.detail ? `: ${slack.detail}` : ""}）。トークンとアプリの Socket Mode 設定を確認してください` })
+      // 1. Prove both tokens BEFORE anything is saved — a wrong token must
+      //    never overwrite a working connection.
+      const verified = await api.verifySlackTokens(botToken, appToken)
+      if (!verified.ok) {
+        const parts = []
+        if (!verified.bot.ok) parts.push(`Bot Token: ${verified.bot.error ?? "auth.test に失敗"}`)
+        if (!verified.app.ok) parts.push(`App Token: ${verified.app.error ?? "Socket Mode 接続に失敗"}（アプリの Socket Mode が有効で、connections:write スコープがあるか確認）`)
+        setResult({ ok: false, message: `保存していません。${parts.join(" / ")}` })
+        return
       }
+      // 2. Save. PUT /api/config reloads the connectors itself and reports
+      //    the outcome — read that instead of reloading again and guessing.
+      const saved = await api.updateConfig({ connectors: { slack: { botToken, appToken } } })
+      const errors = saved.connectorsReload?.errors ?? []
+      const slackError = errors.find((line) => /slack/i.test(line))
+      if (saved.status === "partial" && slackError) {
+        setResult({ ok: false, message: `トークンは正しいのに接続の起動に失敗しました: ${slackError}` })
+        return
+      }
+      setResult({
+        ok: true,
+        message: `接続できました（ワークスペース: ${verified.bot.team ?? "?"} / Bot: ${verified.bot.user ?? "?"}）。Slack で Ryoko にメンションしてみてください`,
+      })
     } catch (err) {
       setResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
     } finally {
       setBusy(false)
     }
   }
+  const canConnect = Boolean(botToken && appToken) && (!already || replaceExisting)
 
   const inputClass = "apple-input w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)]"
 
@@ -210,7 +228,13 @@ function SlackStep() {
         Ryoko が働く場所です。Slack アプリ（Socket Mode）の2つのトークンを入れると、その場で接続を試します。あとで設定ページからでも構いません。
       </p>
       {already && (
-        <div className="text-[length:var(--text-footnote)] text-[var(--system-green)] mb-[var(--space-3)]">{already}</div>
+        <div className="mb-[var(--space-3)]">
+          <div className="text-[length:var(--text-footnote)] text-[var(--system-green)]">Slack は既に接続されています。「次へ」で構いません。</div>
+          <label className="flex items-center gap-2 mt-1 text-[length:var(--text-caption1)] text-[var(--text-secondary)] cursor-pointer">
+            <input type="checkbox" checked={replaceExisting} onChange={(e) => setReplaceExisting(e.target.checked)} />
+            既存の接続を新しいトークンで差し替える
+          </label>
+        </div>
       )}
       <div className="flex flex-col gap-[var(--space-3)]">
         <div>
@@ -228,15 +252,15 @@ function SlackStep() {
         <div>
           <button
             onClick={connect}
-            disabled={busy || !botToken || !appToken}
+            disabled={busy || !canConnect}
             className="inline-flex items-center gap-1.5 px-4 py-2 rounded-[var(--radius-md)] border-none cursor-pointer text-[length:var(--text-subheadline)] font-[var(--weight-semibold)]"
             style={{
-              background: busy || !botToken || !appToken ? "var(--fill-tertiary)" : "var(--accent)",
-              color: busy || !botToken || !appToken ? "var(--text-tertiary)" : "var(--accent-contrast)",
+              background: busy || !canConnect ? "var(--fill-tertiary)" : "var(--accent)",
+              color: busy || !canConnect ? "var(--text-tertiary)" : "var(--accent-contrast)",
             }}
           >
             {busy ? <Loader2 size={16} className="animate-spin" /> : null}
-            {busy ? "接続中…" : "接続する"}
+            {busy ? "確認して接続中…" : "確認して接続する"}
           </button>
         </div>
         {result && (
@@ -246,7 +270,7 @@ function SlackStep() {
         )}
       </div>
       <p className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mt-[var(--space-3)]">
-        トークンは config.yaml に保存され、画面には再表示されません。
+        両方のトークンを Slack に照会してから保存します（正しくないトークンは保存されません）。保存後は画面に再表示されません。
       </p>
     </div>
   )

--- a/packages/web/src/components/onboarding-wizard.tsx
+++ b/packages/web/src/components/onboarding-wizard.tsx
@@ -175,12 +175,22 @@ function describeSlackError(code: string | undefined): string {
 
 /** A save that Slack accepted but the connector could not start — and what
  *  state the install was left in, stated honestly rather than optimistically. */
-function describeReloadFailure(outcome: { error?: string; rolledBack?: boolean; restored?: { disk: boolean; running: boolean }; rollbackError?: string; rollbackSkipped?: string }): string {
+function describeReloadFailure(outcome: { error?: string; previous?: "config" | "none"; rolledBack?: boolean; restored?: { disk: boolean; running: boolean }; rollbackError?: string; rollbackSkipped?: string }): string {
   const head = `トークンは正しいのに接続の起動に失敗しました: ${outcome.error ?? "不明なエラー"}。`
-  if (outcome.rolledBack) return `${head}以前の Slack 設定に戻し、再接続しました。`
+  // "Rolled back" means two different things depending on what was there
+  // before: an old connection is running again, or Slack is simply
+  // unconfigured again. Say which.
+  const wasUnconfigured = outcome.previous === "none"
+  if (outcome.rolledBack) {
+    return wasUnconfigured
+      ? `${head}保存した設定は取り消し、接続前の状態（Slack 未接続）に戻しました。`
+      : `${head}以前の Slack 設定に戻し、再接続しました。`
+  }
   if (outcome.rollbackSkipped) return `${head}その間に設定が別の場所から変更されたため、元に戻す操作は行っていません。設定ページで現在の Slack 設定を確認してください。`
   if (outcome.restored?.disk && !outcome.restored.running) {
-    return `${head}以前の設定はファイルに戻しましたが、その接続も起動できていません（${outcome.rollbackError ?? "原因不明"}）。設定ページで確認してください。`
+    return wasUnconfigured
+      ? `${head}保存した設定はファイルから取り除きましたが、コネクタの再起動でエラーが出ています（${outcome.rollbackError ?? "原因不明"}）。設定ページで確認してください。`
+      : `${head}以前の設定はファイルに戻しましたが、その接続も起動できていません（${outcome.rollbackError ?? "原因不明"}）。設定ページで確認してください。`
   }
   return `${head}以前の設定に戻せませんでした（${outcome.rollbackError ?? "原因不明"}）。設定ページで Slack 設定を確認してください。`
 }

--- a/packages/web/src/components/onboarding-wizard.tsx
+++ b/packages/web/src/components/onboarding-wizard.tsx
@@ -1,5 +1,16 @@
 "use client"
 
+/**
+ * First-run wizard. Five steps, each of which moves the install closer to
+ * actually working — no cosmetics here (theme and accent live in Settings):
+ *
+ *   0 名前          who this portal is, and who you are
+ *   1 エンジン確認   can Claude / Codex actually run (binary, version, login)
+ *   2 Slack 接続    real tokens, real connect, real result
+ *   3 最初の自動化   pick a template; the automation page finishes it
+ *   4 完了          what is now available
+ */
+
 import { useCallback, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import {
@@ -10,54 +21,301 @@ import {
   DollarSign,
   Activity,
   Check,
+  X,
   ArrowLeft,
   ArrowRight,
   Rocket,
-  Target,
-  LayoutGrid,
-  Ear,
-  Settings as SettingsIcon,
+  RefreshCw,
+  Loader2,
 } from "lucide-react"
 import { useSettings } from "@/app/settings-provider"
-import { useTheme } from "@/app/providers"
-import { THEMES } from "@/lib/themes"
-import { api } from "@/lib/api"
-
-// ---------------------------------------------------------------------------
-// Accent color presets
-// ---------------------------------------------------------------------------
-
-const ACCENT_PRESETS = [
-  { label: "Red", value: "#EF4444" },
-  { label: "Orange", value: "#F97316" },
-  { label: "Amber", value: "#F59E0B" },
-  { label: "Yellow", value: "#EAB308" },
-  { label: "Lime", value: "#84CC16" },
-  { label: "Green", value: "#22C55E" },
-  { label: "Emerald", value: "#10B981" },
-  { label: "Cyan", value: "#06B6D4" },
-  { label: "Blue", value: "#3B82F6" },
-  { label: "Indigo", value: "#6366F1" },
-  { label: "Violet", value: "#8B5CF6" },
-  { label: "Pink", value: "#EC4899" },
-]
-
-// ---------------------------------------------------------------------------
-// Feature cards for overview step
-// ---------------------------------------------------------------------------
+import { api, type AutomationTemplateSpec, type EngineProbe } from "@/lib/api"
 
 const FEATURES = [
   { icon: MessageSquare, name: "チャット", desc: "従業員との直接対話" },
   { icon: Users, name: "組織", desc: "AIチームの組織図をビジュアル表示" },
   { icon: Columns3, name: "カンバン", desc: "タスクボードで作業を管理" },
-  { icon: Clock, name: "スケジュール", desc: "cronジョブとステータス監視" },
+  { icon: Clock, name: "自動化", desc: "定期ジョブとワークフロー。テンプレートから作成" },
   { icon: DollarSign, name: "コスト", desc: "トークン使用量とコストの追跡" },
   { icon: Activity, name: "アクティビティ", desc: "リアルタイムログ・イベントストリーム" },
 ]
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+const TOTAL_STEPS = 5
+
+const ENGINE_LABEL: Record<string, string> = { claude: "Claude Code", codex: "Codex", gemini: "Gemini" }
+
+/* ------------------------------------------------------------------ */
+/*  Step 1: engine check                                               */
+/* ------------------------------------------------------------------ */
+
+function engineHint(probe: EngineProbe): string | null {
+  if (!probe.installed) {
+    return probe.name === "claude"
+      ? "npm install -g @anthropic-ai/claude-code でインストールし、claude と入力してログインしてください"
+      : probe.name === "codex"
+        ? "npm install -g @openai/codex でインストールし、codex と入力してログインしてください"
+        : `${probe.name} をインストールして PATH を通してください`
+  }
+  if (!probe.runnable) return `起動できませんでした: ${probe.error ?? "不明なエラー"}`
+  if (probe.name === "claude" && probe.auth) {
+    if (probe.auth.method === "none") return "ログイン情報が見つかりません。端末で claude と入力してログインしてください"
+    if (probe.auth.method === "oauth" && probe.auth.expired) return "ログインの有効期限が切れています。claude を一度起動すると更新されます"
+  }
+  return null
+}
+
+function engineState(probe: EngineProbe): "ok" | "warn" | "fail" {
+  if (!probe.installed || !probe.runnable) return "fail"
+  if (probe.name === "claude" && probe.auth && (probe.auth.method === "none" || probe.auth.expired)) return "warn"
+  return "ok"
+}
+
+function EngineCheckStep({ active }: { active: boolean }) {
+  const [probes, setProbes] = useState<EngineProbe[] | null>(null)
+  const [defaultEngine, setDefaultEngine] = useState<string>("")
+  const [error, setError] = useState<string | null>(null)
+  const [checking, setChecking] = useState(false)
+
+  const check = useCallback(() => {
+    setChecking(true)
+    setError(null)
+    api.getOnboardingEngines()
+      .then((result) => { setProbes(result.engines); setDefaultEngine(result.default) })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setChecking(false))
+  }, [])
+
+  useEffect(() => { if (active && probes === null && !checking) check() }, [active, probes, checking, check])
+
+  return (
+    <div className="animate-fade-in">
+      <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
+        エンジンの確認
+      </h2>
+      <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
+        AI エンジンが実際に動くか確認します。ここが ✗ だと Ryoko は働けません。
+      </p>
+      {error && (
+        <div className="text-[length:var(--text-footnote)] text-[var(--system-red)] mb-[var(--space-3)]">確認できませんでした: {error}</div>
+      )}
+      <div className="flex flex-col gap-[var(--space-2)]">
+        {probes === null && !error ? (
+          <div className="flex items-center gap-2 text-[length:var(--text-footnote)] text-[var(--text-secondary)]">
+            <Loader2 size={16} className="animate-spin" /> 確認中…
+          </div>
+        ) : (probes ?? []).map((probe) => {
+          const state = engineState(probe)
+          const hint = engineHint(probe)
+          const color = state === "ok" ? "var(--system-green)" : state === "warn" ? "var(--system-orange)" : "var(--system-red)"
+          return (
+            <div key={probe.name} className="flex items-start gap-[var(--space-3)] p-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] border border-[var(--separator)]">
+              <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0" style={{ background: `color-mix(in srgb, ${color} 18%, transparent)`, color }}>
+                {state === "fail" ? <X size={16} /> : <Check size={16} />}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-[length:var(--text-subheadline)] font-[var(--weight-semibold)] text-[var(--text-primary)]">
+                  {ENGINE_LABEL[probe.name] ?? probe.name}
+                  {probe.name === defaultEngine && (
+                    <span className="ml-2 text-[length:var(--text-caption2)] px-1.5 py-px rounded bg-[var(--accent-fill)] text-[var(--accent)]">既定</span>
+                  )}
+                </div>
+                <div className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)]">
+                  {probe.version ?? (probe.installed ? "バージョン不明" : "未インストール")}
+                  {probe.name === "claude" && probe.auth && state === "ok" && (
+                    <span className="ml-2">・{probe.auth.method === "api-key" ? "API キー" : "ログイン済み"}</span>
+                  )}
+                </div>
+                {hint && (
+                  <div className="text-[length:var(--text-caption1)] mt-1 whitespace-pre-wrap" style={{ color }}>{hint}</div>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <button
+        onClick={check}
+        disabled={checking}
+        className="mt-[var(--space-3)] inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-sm)] bg-[var(--fill-tertiary)] text-[var(--text-secondary)] border-none cursor-pointer text-[length:var(--text-footnote)]"
+      >
+        <RefreshCw size={14} className={checking ? "animate-spin" : ""} /> 再確認
+      </button>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Step 2: Slack                                                      */
+/* ------------------------------------------------------------------ */
+
+type ConnectorHealthMap = Record<string, { status: string; detail?: string } | undefined>
+
+/** /api/status carries per-connector health under `connectors`; the shared
+ *  client type does not declare it, so read it defensively here. */
+function connectorHealth(status: unknown): ConnectorHealthMap {
+  const connectors = (status as { connectors?: unknown })?.connectors
+  return connectors && typeof connectors === "object" ? (connectors as ConnectorHealthMap) : {}
+}
+
+function SlackStep() {
+  const [botToken, setBotToken] = useState("")
+  const [appToken, setAppToken] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
+  const [already, setAlready] = useState<string | null>(null)
+
+  useEffect(() => {
+    api.getStatus()
+      .then((status) => {
+        const slack = connectorHealth(status).slack
+        if (slack && slack.status === "running") setAlready("Slack は既に接続されています")
+      })
+      .catch(() => { /* status is optional here */ })
+  }, [])
+
+  const connect = async () => {
+    if (!botToken.startsWith("xoxb-") || !appToken.startsWith("xapp-")) {
+      setResult({ ok: false, message: "Bot Token は xoxb-、App Token は xapp- で始まります" })
+      return
+    }
+    setBusy(true)
+    setResult(null)
+    try {
+      await api.updateConfig({ connectors: { slack: { botToken, appToken } } })
+      await api.reloadConnectors()
+      // Give Socket Mode a moment, then read the connector's own health.
+      await new Promise((resolve) => setTimeout(resolve, 2500))
+      const status = await api.getStatus()
+      const slack = connectorHealth(status).slack
+      if (slack?.status === "running") {
+        setResult({ ok: true, message: "接続できました。Slack で Ryoko にメンションしてみてください" })
+      } else {
+        setResult({ ok: false, message: `接続できていません（${slack?.status ?? "未起動"}${slack?.detail ? `: ${slack.detail}` : ""}）。トークンとアプリの Socket Mode 設定を確認してください` })
+      }
+    } catch (err) {
+      setResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const inputClass = "apple-input w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)]"
+
+  return (
+    <div className="animate-fade-in">
+      <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
+        Slack につなぐ
+      </h2>
+      <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
+        Ryoko が働く場所です。Slack アプリ（Socket Mode）の2つのトークンを入れると、その場で接続を試します。あとで設定ページからでも構いません。
+      </p>
+      {already && (
+        <div className="text-[length:var(--text-footnote)] text-[var(--system-green)] mb-[var(--space-3)]">{already}</div>
+      )}
+      <div className="flex flex-col gap-[var(--space-3)]">
+        <div>
+          <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]" htmlFor="ob-slack-bot">
+            Bot User OAuth Token <span className="text-[var(--text-quaternary)]">xoxb-…</span>
+          </label>
+          <input id="ob-slack-bot" type="password" className={inputClass} value={botToken} onChange={(e) => setBotToken(e.target.value.trim())} placeholder="xoxb-" autoComplete="off" />
+        </div>
+        <div>
+          <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]" htmlFor="ob-slack-app">
+            App-Level Token <span className="text-[var(--text-quaternary)]">xapp-…（connections:write）</span>
+          </label>
+          <input id="ob-slack-app" type="password" className={inputClass} value={appToken} onChange={(e) => setAppToken(e.target.value.trim())} placeholder="xapp-" autoComplete="off" />
+        </div>
+        <div>
+          <button
+            onClick={connect}
+            disabled={busy || !botToken || !appToken}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-[var(--radius-md)] border-none cursor-pointer text-[length:var(--text-subheadline)] font-[var(--weight-semibold)]"
+            style={{
+              background: busy || !botToken || !appToken ? "var(--fill-tertiary)" : "var(--accent)",
+              color: busy || !botToken || !appToken ? "var(--text-tertiary)" : "var(--accent-contrast)",
+            }}
+          >
+            {busy ? <Loader2 size={16} className="animate-spin" /> : null}
+            {busy ? "接続中…" : "接続する"}
+          </button>
+        </div>
+        {result && (
+          <div className="text-[length:var(--text-footnote)] whitespace-pre-wrap" style={{ color: result.ok ? "var(--system-green)" : "var(--system-red)" }}>
+            {result.message}
+          </div>
+        )}
+      </div>
+      <p className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mt-[var(--space-3)]">
+        トークンは config.yaml に保存され、画面には再表示されません。
+      </p>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Step 3: first automation                                           */
+/* ------------------------------------------------------------------ */
+
+function FirstAutomationStep({ selected, onSelect }: {
+  selected: string | null
+  onSelect: (id: string | null) => void
+}) {
+  const [templates, setTemplates] = useState<AutomationTemplateSpec[] | null>(null)
+  const [engineEnabled, setEngineEnabled] = useState(true)
+
+  useEffect(() => {
+    api.getAutomationTemplates()
+      .then((result) => { setTemplates(result.templates); setEngineEnabled(result.workflowsEnabled) })
+      .catch(() => setTemplates([]))
+  }, [])
+
+  return (
+    <div className="animate-fade-in">
+      <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
+        最初の自動化
+      </h2>
+      <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
+        Ryoko に任せる仕事の型を1つ選んでください。「はじめる」を押すと自動化ページで穴埋めするだけで動きます。あとで選んでも構いません。
+      </p>
+      {!engineEnabled ? (
+        <div className="p-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] border border-[var(--separator)] text-[length:var(--text-footnote)] text-[var(--text-secondary)]">
+          ワークフロー（判定を挟んで必要な時だけ AI が動く自動化）は現在オフです。定期ジョブは自動化ページから、ワークフローは <code className="px-1 rounded bg-[var(--fill-tertiary)]">config.yaml</code> に <code className="px-1 rounded bg-[var(--fill-tertiary)]">workflows: {"{ enabled: true }"}</code> を追記して再起動すると使えます。
+        </div>
+      ) : templates === null ? (
+        <div className="flex items-center gap-2 text-[length:var(--text-footnote)] text-[var(--text-secondary)]">
+          <Loader2 size={16} className="animate-spin" /> 読み込み中…
+        </div>
+      ) : (
+        <div className="flex flex-col gap-[var(--space-2)]">
+          {templates.map((template) => {
+            const isActive = selected === template.id
+            return (
+              <button
+                key={template.id}
+                onClick={() => onSelect(isActive ? null : template.id)}
+                className="text-left p-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] cursor-pointer transition-all duration-150"
+                style={{ border: isActive ? "2px solid var(--accent)" : "2px solid var(--separator)" }}
+              >
+                <div className="text-[length:var(--text-subheadline)] font-[var(--weight-semibold)]" style={{ color: isActive ? "var(--accent)" : "var(--text-primary)" }}>
+                  {template.name}
+                </div>
+                <div className="text-[length:var(--text-caption1)] text-[var(--text-secondary)] mt-0.5">こういう時: {template.when}</div>
+                <div className="text-[length:var(--text-caption2)] text-[var(--text-tertiary)] mt-1">{template.flow}</div>
+              </button>
+            )
+          })}
+          <div className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mt-1">
+            {selected ? "「はじめる」で自動化ページの作成フォームへ移動します" : "選ばずに「はじめる」を押すとチャットへ移動します"}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Wizard                                                             */
+/* ------------------------------------------------------------------ */
 
 interface OnboardingWizardProps {
   forceOpen?: boolean
@@ -65,49 +323,18 @@ interface OnboardingWizardProps {
 }
 
 export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) {
-  const {
-    settings,
-    setPortalName,
-    setOperatorName,
-    setAccentColor,
-    setLanguage,
-  } = useSettings()
-  const { theme, setTheme } = useTheme()
+  const { settings, setPortalName, setOperatorName, setLanguage } = useSettings()
   const router = useRouter()
 
   const [visible, setVisible] = useState(false)
   const [step, setStep] = useState(0)
-  const [direction, setDirection] = useState<"forward" | "back">("forward")
 
-  // Local input values
   const [localName, setLocalName] = useState("")
   const [localOperator, setLocalOperator] = useState("")
   const [localLanguage, setLocalLanguage] = useState(settings.language ?? "Japanese")
+  const [firstTemplate, setFirstTemplate] = useState<string | null>(null)
 
-  const TOTAL_STEPS = 5
-
-  // Slack feature cards rendered on the Slack-awareness step. Awareness
-  // only — no actual tokens collected here; the wizard runs before the
-  // user has even set up a Slack App.
-  const SLACK_FEATURES = [
-    {
-      icon: Target,
-      title: "自然言語 /goal",
-      desc: "「最後までやって」等で自律完遂タスク。複数ターンの進捗が個別のSlackメッセージで届く",
-    },
-    {
-      icon: LayoutGrid,
-      title: "Agents View Canvas",
-      desc: "今動いている全Ryokoセッションをチャンネルの Canvas タブで一覧。30秒ごとに自動更新",
-    },
-    {
-      icon: Ear,
-      title: "空気読みトリアージ",
-      desc: "メンションされない限り基本沈黙。役立てる話題にだけ介入するから邪魔にならない",
-    },
-  ]
-
-  // First-run detection — check server-side flag, not just localStorage
+  // First-run detection — server-side flag, not just localStorage
   useEffect(() => {
     if (forceOpen) {
       setLocalName(settings.portalName ?? "")
@@ -115,11 +342,7 @@ export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) 
       setVisible(true)
       return
     }
-    // If localStorage says onboarded, trust it (fast path)
-    if (typeof window !== "undefined" && localStorage.getItem("jinn-onboarded")) {
-      return
-    }
-    // Otherwise check server — the onboarded flag persists across browsers
+    if (typeof window !== "undefined" && localStorage.getItem("jinn-onboarded")) return
     api.getOnboarding().then((data) => {
       if (data.onboarded) {
         localStorage.setItem("jinn-onboarded", "true")
@@ -127,345 +350,105 @@ export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) 
         setVisible(true)
       }
     }).catch(() => {
-      // Fallback: show wizard if we can't reach the server and no localStorage flag
-      if (!localStorage.getItem("jinn-onboarded")) {
-        setVisible(true)
-      }
+      if (!localStorage.getItem("jinn-onboarded")) setVisible(true)
     })
   }, [forceOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleNext = useCallback(() => {
-    // Commit name/operator/language on step 0
     if (step === 0) {
       setPortalName(localName || null)
       setOperatorName(localOperator || null)
       setLanguage(localLanguage || "Japanese")
     }
-
     if (step < TOTAL_STEPS - 1) {
-      setDirection("forward")
       setStep(step + 1)
-    } else {
-      // Complete — persist to backend config
-      api.completeOnboarding({
-        portalName: localName || undefined,
-        operatorName: localOperator || undefined,
-        language: localLanguage || undefined,
-      }).catch(() => {
-        // Best-effort: localStorage still has the values
-      })
-      if (!forceOpen) {
-        localStorage.setItem("jinn-onboarded", "true")
-      }
-      setVisible(false)
-      onClose?.()
-      router.push("/chat")
+      return
     }
-  }, [
-    step,
-    localName,
-    localOperator,
-    forceOpen,
-    onClose,
-    setPortalName,
-    setOperatorName,
-    router,
-  ])
+    api.completeOnboarding({
+      portalName: localName || undefined,
+      operatorName: localOperator || undefined,
+      language: localLanguage || undefined,
+    }).catch(() => { /* best-effort: localStorage still has the values */ })
+    if (!forceOpen) localStorage.setItem("jinn-onboarded", "true")
+    setVisible(false)
+    onClose?.()
+    router.push(firstTemplate ? `/cron?create=${encodeURIComponent(firstTemplate)}` : "/chat")
+  }, [step, localName, localOperator, localLanguage, firstTemplate, forceOpen, onClose, setPortalName, setOperatorName, setLanguage, router])
 
-  const handleBack = useCallback(() => {
-    if (step > 0) {
-      setDirection("back")
-      setStep(step - 1)
-    }
-  }, [step])
+  const handleBack = useCallback(() => { if (step > 0) setStep(step - 1) }, [step])
 
   if (!visible) return null
 
+  const inputClass = "apple-input w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)]"
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      style={{
-        backdropFilter: "blur(12px)",
-        WebkitBackdropFilter: "blur(12px)",
-      }}
-    >
-      <div
-        className="animate-fade-in w-full max-w-[520px] mx-[var(--space-4)] bg-[var(--material-regular)] rounded-[var(--radius-lg)] border border-[var(--separator)] overflow-hidden flex flex-col max-h-[90vh]"
-        style={{
-          boxShadow: "0 24px 48px rgba(0,0,0,0.3)",
-        }}
-      >
-        {/* Step indicator dots */}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" style={{ backdropFilter: "blur(12px)", WebkitBackdropFilter: "blur(12px)" }}>
+      <div className="animate-fade-in w-full max-w-[520px] mx-[var(--space-4)] bg-[var(--material-regular)] rounded-[var(--radius-lg)] border border-[var(--separator)] overflow-hidden flex flex-col max-h-[90vh]" style={{ boxShadow: "0 24px 48px rgba(0,0,0,0.3)" }}>
+        {/* Step indicator */}
         <div className="flex justify-center gap-2 pt-[var(--space-4)] px-[var(--space-4)]">
           {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
             <div
               key={i}
               className="h-2 rounded-full transition-all duration-200"
-              style={{
-                width: i === step ? 24 : 8,
-                background:
-                  i === step
-                    ? "var(--accent)"
-                    : i < step
-                      ? "var(--accent)"
-                      : "var(--fill-tertiary)",
-                opacity: i < step ? 0.5 : 1,
-              }}
+              style={{ width: i === step ? 24 : 8, background: i <= step ? "var(--accent)" : "var(--fill-tertiary)", opacity: i < step ? 0.5 : 1 }}
             />
           ))}
         </div>
 
-        {/* Step content */}
         <div className="px-[var(--space-5)] pt-[var(--space-5)] pb-[var(--space-4)] overflow-y-auto flex-1">
-          {/* Step 0: Welcome */}
           {step === 0 && (
-            <div
-              key="step-0"
-              className="animate-fade-in text-center"
-            >
-              <div className="text-[56px] mb-[var(--space-3)] leading-none">
-                {"\ud83e\udd16"}
-              </div>
+            <div key="step-0" className="animate-fade-in text-center">
+              <div className="text-[56px] mb-[var(--space-3)] leading-none">{"🤖"}</div>
               <h2 className="text-[length:var(--text-large-title)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-2)]">
                 {localName || "Ryoko"} へようこそ
               </h2>
               <p className="text-[length:var(--text-body)] text-[var(--text-secondary)] leading-[var(--leading-relaxed)] max-w-[400px] mx-auto mb-[var(--space-5)]">
-                あなたのAIチーム管理ポータル。さっそくセットアップしましょう。
+                あなたの AI チーム管理ポータル。動くところまで、この場で仕上げます。
               </p>
-
               <div className="flex flex-col gap-[var(--space-3)] text-left">
                 <div>
-                  <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]">
-                    ポータル名
-                  </label>
-                  <input
-                    type="text"
-                    className="apple-input w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)]"
-                    placeholder="Ryoko"
-                    value={localName}
-                    onChange={(e) => setLocalName(e.target.value)}
-                    autoFocus
-                  />
+                  <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]">ポータル名</label>
+                  <input type="text" className={inputClass} placeholder="Ryoko" value={localName} onChange={(e) => setLocalName(e.target.value)} autoFocus />
                 </div>
-
                 <div>
-                  <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]">
-                    あなたの呼び名は？
-                  </label>
-                  <input
-                    type="text"
-                    className="apple-input w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)]"
-                    placeholder="お名前"
-                    value={localOperator}
-                    onChange={(e) => setLocalOperator(e.target.value)}
-                  />
+                  <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]">あなたの呼び名は？</label>
+                  <input type="text" className={inputClass} placeholder="お名前" value={localOperator} onChange={(e) => setLocalOperator(e.target.value)} />
                 </div>
-
                 <div>
-                  <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]">
-                    使用言語
-                  </label>
-                  <select
-                    value={localLanguage}
-                    onChange={(e) => setLocalLanguage(e.target.value)}
-                    className="w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)] cursor-pointer"
-                  >
-                    <option value="English">English</option>
-                    <option value="Spanish">Spanish</option>
-                    <option value="French">French</option>
-                    <option value="German">German</option>
-                    <option value="Portuguese">Portuguese</option>
-                    <option value="Italian">Italian</option>
-                    <option value="Dutch">Dutch</option>
-                    <option value="Russian">Russian</option>
-                    <option value="Chinese">Chinese</option>
-                    <option value="Japanese">Japanese</option>
-                    <option value="Korean">Korean</option>
-                    <option value="Arabic">Arabic</option>
-                    <option value="Hindi">Hindi</option>
-                    <option value="Bulgarian">Bulgarian</option>
+                  <label className="block text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mb-[var(--space-1)]">使用言語</label>
+                  <select value={localLanguage} onChange={(e) => setLocalLanguage(e.target.value)} className="w-full bg-[var(--bg-secondary)] border border-[var(--separator)] rounded-[var(--radius-sm)] px-3 py-2 text-[length:var(--text-body)] text-[var(--text-primary)] cursor-pointer">
+                    {["Japanese", "English", "Spanish", "French", "German", "Portuguese", "Italian", "Dutch", "Russian", "Chinese", "Korean", "Arabic", "Hindi", "Bulgarian"].map((lang) => (
+                      <option key={lang} value={lang}>{lang}</option>
+                    ))}
                   </select>
                 </div>
               </div>
             </div>
           )}
 
-          {/* Step 1: Theme */}
-          {step === 1 && (
-            <div key="step-1" className="animate-fade-in">
-              <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
-                テーマを選択
-              </h2>
-              <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
-                お好みの見た目を選んでください。即座に反映されます。
-              </p>
+          {step === 1 && <EngineCheckStep active={step === 1} />}
+          {step === 2 && <SlackStep />}
+          {step === 3 && <FirstAutomationStep selected={firstTemplate} onSelect={setFirstTemplate} />}
 
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(130px,1fr))] gap-[var(--space-3)]">
-                {THEMES.map((t) => {
-                  const isActive = theme === t.id
-                  return (
-                    <button
-                      key={t.id}
-                      onClick={() => setTheme(t.id)}
-                      className="flex flex-col items-center gap-[var(--space-2)] px-[var(--space-3)] py-[var(--space-4)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] cursor-pointer transition-all duration-150"
-                      style={{
-                        border: isActive
-                          ? "2px solid var(--accent)"
-                          : "2px solid var(--separator)",
-                      }}
-                    >
-                      <span className="text-[28px]">{t.emoji}</span>
-                      <span
-                        className="text-[length:var(--text-footnote)]"
-                        style={{
-                          fontWeight: isActive
-                            ? "var(--weight-semibold)"
-                            : "var(--weight-medium)",
-                          color: isActive
-                            ? "var(--accent)"
-                            : "var(--text-secondary)",
-                        }}
-                      >
-                        {t.label}
-                      </span>
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Step 2: Accent Color */}
-          {step === 2 && (
-            <div key="step-2" className="animate-fade-in">
-              <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
-                アクセントカラーを選択
-              </h2>
-              <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
-                お好きな色でパーソナライズしてください。
-              </p>
-
-              <div className="grid grid-cols-6 gap-[var(--space-3)] justify-items-center">
-                {ACCENT_PRESETS.map((preset) => {
-                  const isActive = settings.accentColor === preset.value
-                  return (
-                    <button
-                      key={preset.value}
-                      onClick={() => setAccentColor(preset.value)}
-                      aria-label={preset.label}
-                      title={preset.label}
-                      className="w-10 h-10 rounded-full border-none cursor-pointer flex items-center justify-center transition-all duration-100"
-                      style={{
-                        background: preset.value,
-                        outline: isActive
-                          ? `3px solid ${preset.value}`
-                          : "none",
-                        outlineOffset: 3,
-                      }}
-                    >
-                      {isActive && (
-                        <Check size={18} color="#fff" strokeWidth={3} />
-                      )}
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Step 3: Slack integration awareness */}
-          {step === 3 && (
-            <div key="step-3" className="animate-fade-in">
-              <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
-                Slackを繋げると…
-              </h2>
-              <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
-                Ryoko の真価は Slack に住まわせたときに出ます。後で Settings →
-                Slack から有効化できます。
-              </p>
-
-              <div className="flex flex-col gap-[var(--space-2)] mb-[var(--space-4)]">
-                {SLACK_FEATURES.map((f) => {
-                  const Icon = f.icon
-                  return (
-                    <div
-                      key={f.title}
-                      className="flex items-start gap-[var(--space-3)] p-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] border border-[var(--separator)]"
-                    >
-                      <div className="w-9 h-9 rounded-lg bg-[var(--accent-fill)] flex items-center justify-center shrink-0">
-                        <Icon size={18} className="text-[var(--accent)]" />
-                      </div>
-                      <div className="min-w-0">
-                        <div className="text-[length:var(--text-subheadline)] font-[var(--weight-semibold)] text-[var(--text-primary)]">
-                          {f.title}
-                        </div>
-                        <div className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)] mt-0.5">
-                          {f.desc}
-                        </div>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-
-              <button
-                type="button"
-                onClick={() => {
-                  // Mark onboarding complete and jump straight to settings.
-                  api.completeOnboarding({
-                    portalName: localName || undefined,
-                    operatorName: localOperator || undefined,
-                    language: localLanguage || undefined,
-                  }).catch(() => {})
-                  if (!forceOpen) {
-                    localStorage.setItem("jinn-onboarded", "true")
-                  }
-                  setVisible(false)
-                  onClose?.()
-                  router.push("/settings")
-                }}
-                className="w-full px-[var(--space-4)] py-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-tertiary)] hover:bg-[var(--fill-secondary)] border border-[var(--separator)] text-[var(--text-primary)] text-[length:var(--text-subheadline)] font-[var(--weight-medium)] cursor-pointer transition-colors inline-flex items-center justify-center gap-2"
-              >
-                <SettingsIcon size={16} />
-                今すぐ Settings で Slack を設定する
-              </button>
-              <p className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)] text-center mt-[var(--space-2)]">
-                スキップして「次へ」を押すと、後で Settings から有効化できます。
-              </p>
-            </div>
-          )}
-
-          {/* Step 4: Overview */}
           {step === 4 && (
             <div key="step-4" className="animate-fade-in">
               <h2 className="text-[length:var(--text-title1)] font-[var(--weight-bold)] tracking-[var(--tracking-tight)] text-[var(--text-primary)] mb-[var(--space-1)]">
-                セットアップ完了！
+                準備ができました
               </h2>
               <p className="text-[length:var(--text-subheadline)] text-[var(--text-tertiary)] mb-[var(--space-4)]">
-                利用できる機能の一覧です。
+                見た目（テーマ・アクセント色）は設定ページでいつでも変えられます。
               </p>
-
               <div className="flex flex-col gap-[var(--space-2)]">
                 {FEATURES.map((f) => {
                   const Icon = f.icon
                   return (
-                    <div
-                      key={f.name}
-                      className="flex items-center gap-[var(--space-3)] p-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] border border-[var(--separator)]"
-                    >
+                    <div key={f.name} className="flex items-center gap-[var(--space-3)] p-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--fill-quaternary)] border border-[var(--separator)]">
                       <div className="w-9 h-9 rounded-lg bg-[var(--accent-fill)] flex items-center justify-center shrink-0">
-                        <Icon
-                          size={18}
-                          className="text-[var(--accent)]"
-                        />
+                        <Icon size={18} className="text-[var(--accent)]" />
                       </div>
                       <div className="min-w-0">
-                        <div className="text-[length:var(--text-subheadline)] font-[var(--weight-semibold)] text-[var(--text-primary)]">
-                          {f.name}
-                        </div>
-                        <div className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)]">
-                          {f.desc}
-                        </div>
+                        <div className="text-[length:var(--text-subheadline)] font-[var(--weight-semibold)] text-[var(--text-primary)]">{f.name}</div>
+                        <div className="text-[length:var(--text-caption1)] text-[var(--text-tertiary)]">{f.desc}</div>
                       </div>
                     </div>
                   )
@@ -475,33 +458,16 @@ export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) 
           )}
         </div>
 
-        {/* Navigation buttons */}
+        {/* Navigation */}
         <div className="flex justify-between items-center px-[var(--space-5)] pb-[var(--space-5)] pt-[var(--space-3)] gap-[var(--space-3)]">
           {step > 0 ? (
-            <button
-              onClick={handleBack}
-              className="px-[var(--space-4)] py-[var(--space-2)] rounded-[var(--radius-md)] bg-[var(--fill-tertiary)] text-[var(--text-secondary)] border-none cursor-pointer text-[length:var(--text-subheadline)] font-[var(--weight-medium)] transition-all duration-150 inline-flex items-center gap-1.5"
-            >
-              <ArrowLeft size={16} />
-              戻る
+            <button onClick={handleBack} className="px-[var(--space-4)] py-[var(--space-2)] rounded-[var(--radius-md)] bg-[var(--fill-tertiary)] text-[var(--text-secondary)] border-none cursor-pointer text-[length:var(--text-subheadline)] font-[var(--weight-medium)] transition-all duration-150 inline-flex items-center gap-1.5">
+              <ArrowLeft size={16} /> 戻る
             </button>
-          ) : (
-            <div />
-          )}
-          <button
-            onClick={handleNext}
-            className="px-[var(--space-6)] py-[var(--space-2)] rounded-[var(--radius-md)] bg-[var(--accent)] text-[var(--accent-contrast)] border-none cursor-pointer text-[length:var(--text-subheadline)] font-[var(--weight-semibold)] transition-all duration-150 inline-flex items-center gap-1.5"
-          >
-            {step === 0
-              ? "次へ"
-              : step === TOTAL_STEPS - 1
-                ? "はじめる"
-                : "次へ"}
-            {step === TOTAL_STEPS - 1 ? (
-              <Rocket size={16} />
-            ) : (
-              <ArrowRight size={16} />
-            )}
+          ) : <div />}
+          <button onClick={handleNext} className="px-[var(--space-6)] py-[var(--space-2)] rounded-[var(--radius-md)] bg-[var(--accent)] text-[var(--accent-contrast)] border-none cursor-pointer text-[length:var(--text-subheadline)] font-[var(--weight-semibold)] transition-all duration-150 inline-flex items-center gap-1.5">
+            {step === TOTAL_STEPS - 1 ? "はじめる" : step === 2 ? "次へ（スキップ可）" : "次へ"}
+            {step === TOTAL_STEPS - 1 ? <Rocket size={16} /> : <ArrowRight size={16} />}
           </button>
         </div>
       </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -19,8 +19,13 @@ export interface SlackConnectResult {
   ok: boolean
   stage?: "verify" | "reload"
   error?: string
-  /** True only when the previous Slack block is back on disk AND running. */
+  /** What was there before the attempt: an existing Slack block, or none. */
+  previous?: "config" | "none"
+  /** True only when the pre-attempt state is fully back on disk AND the live
+   *  connectors settled on it (old connector running again for "config";
+   *  nothing left running for "none"). */
   rolledBack?: boolean
+  /** running is always false for previous:"none" — nothing to bring back. */
   restored?: { disk: boolean; running: boolean }
   rollbackError?: string
   rollbackSkipped?: string

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -15,6 +15,17 @@ export interface SlackVerifyResult {
   app: { ok: boolean; error?: string }
 }
 
+export interface SlackConnectResult {
+  ok: boolean
+  stage?: "verify" | "reload"
+  error?: string
+  rolledBack?: boolean
+  team?: string
+  user?: string
+  bot?: SlackVerifyResult["bot"]
+  app?: SlackVerifyResult["app"]
+}
+
 /** PUT /api/config answers with the connector reload it triggered itself. */
 export interface ConfigUpdateResult extends Record<string, unknown> {
   status?: "ok" | "partial" | string
@@ -367,6 +378,9 @@ export const api = {
     get<{ default: string; probedAt: string; engines: EngineProbe[] }>("/api/onboarding/engines"),
   verifySlackTokens: (botToken: string, appToken: string) =>
     post<SlackVerifyResult>("/api/onboarding/slack/verify", { botToken, appToken }),
+  // Verify → save → reload → rollback-on-failure as ONE server-side operation.
+  connectSlack: (botToken: string, appToken: string) =>
+    post<SlackConnectResult>("/api/onboarding/slack/connect", { botToken, appToken }),
   getOnboarding: () =>
     get<{ needed: boolean; onboarded: boolean; sessionsCount: number; hasEmployees: boolean; portalName: string | null; operatorName: string | null }>("/api/onboarding"),
   completeOnboarding: (data: { portalName?: string; operatorName?: string; language?: string }) =>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,3 +1,14 @@
+export interface EngineProbe {
+  name: string
+  configured: boolean
+  installed: boolean
+  runnable: boolean
+  bin?: string
+  version?: string
+  error?: string
+  auth?: { method: "api-key" | "oauth" | "unknown" | "none"; expiresAt?: string; expired?: boolean }
+}
+
 export interface WorkflowSummary {
   id: string
   title: string
@@ -340,6 +351,8 @@ export const api = {
     put<Record<string, unknown>>("/api/config", data),
   getLogs: (n?: number) =>
     get<{ lines: string[] }>(`/api/logs${n ? `?n=${n}` : ""}`),
+  getOnboardingEngines: () =>
+    get<{ default: string; engines: EngineProbe[] }>("/api/onboarding/engines"),
   getOnboarding: () =>
     get<{ needed: boolean; onboarded: boolean; sessionsCount: number; hasEmployees: boolean; portalName: string | null; operatorName: string | null }>("/api/onboarding"),
   completeOnboarding: (data: { portalName?: string; operatorName?: string; language?: string }) =>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -19,7 +19,11 @@ export interface SlackConnectResult {
   ok: boolean
   stage?: "verify" | "reload"
   error?: string
+  /** True only when the previous Slack block is back on disk AND running. */
   rolledBack?: boolean
+  restored?: { disk: boolean; running: boolean }
+  rollbackError?: string
+  rollbackSkipped?: string
   team?: string
   user?: string
   bot?: SlackVerifyResult["bot"]

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -6,7 +6,19 @@ export interface EngineProbe {
   bin?: string
   version?: string
   error?: string
-  auth?: { method: "api-key" | "oauth" | "unknown" | "none"; expiresAt?: string; expired?: boolean }
+  auth?: { method: "api-key" | "oauth" | "chatgpt" | "unknown" | "none"; expiresAt?: string; expired?: boolean; note: string }
+}
+
+export interface SlackVerifyResult {
+  ok: boolean
+  bot: { ok: boolean; team?: string; user?: string; error?: string }
+  app: { ok: boolean; error?: string }
+}
+
+/** PUT /api/config answers with the connector reload it triggered itself. */
+export interface ConfigUpdateResult extends Record<string, unknown> {
+  status?: "ok" | "partial" | string
+  connectorsReload?: { started?: string[]; stopped?: string[]; errors?: string[] }
 }
 
 export interface WorkflowSummary {
@@ -348,11 +360,13 @@ export const api = {
   reloadConnectors: () =>
     post<{ started: string[]; stopped: string[]; errors: string[] }>("/api/connectors/reload", {}),
   updateConfig: (data: Record<string, unknown>) =>
-    put<Record<string, unknown>>("/api/config", data),
+    put<ConfigUpdateResult>("/api/config", data),
   getLogs: (n?: number) =>
     get<{ lines: string[] }>(`/api/logs${n ? `?n=${n}` : ""}`),
   getOnboardingEngines: () =>
-    get<{ default: string; engines: EngineProbe[] }>("/api/onboarding/engines"),
+    get<{ default: string; probedAt: string; engines: EngineProbe[] }>("/api/onboarding/engines"),
+  verifySlackTokens: (botToken: string, appToken: string) =>
+    post<SlackVerifyResult>("/api/onboarding/slack/verify", { botToken, appToken }),
   getOnboarding: () =>
     get<{ needed: boolean; onboarded: boolean; sessionsCount: number; hasEmployees: boolean; portalName: string | null; operatorName: string | null }>("/api/onboarding"),
   completeOnboarding: (data: { portalName?: string; operatorName?: string; language?: string }) =>


### PR DESCRIPTION
## Summary
初回ウィザードを「名前を入れて終わり」から「**Ryoko が実際に動くところまで**」に組み替える（Phase B）。
自動化ハブ（PR #59）で作った 3 テンプレートへ、ウィザードの最後から直接つなぐ。

| ステップ | 何をするか | 裏側 |
|---|---|---|
| 名前 | これまで通り | — |
| エンジン確認 | Claude / Codex が **このマシンで起動できるか** を自動プローブ。認証切れ・未インストールをその場で表示 | `GET /api/onboarding/engines`（fingerprint キャッシュ 10s・in-flight 共有・PUT /api/config で無効化） |
| Slack 接続 | Bot / App トークンを **Slack に問い合わせて検証してから** 保存 → コネクタ再起動。失敗時は以前の設定へ戻す | `POST /api/onboarding/slack/verify`（`auth.test` + `apps.connections.open`）／ `POST /api/onboarding/slack/connect`（verify → 保存 → reload → 失敗時 rollback） |
| 最初の自動化 | 見張り型 / 定時実行型 / イベント駆動型 から選ぶ（エンジン OFF なら案内） | 完了後 `/cron?create=<templateId>` に遷移して作成パネルを開く |

## 設計上のポイント（Codex レビュー 3 ラウンド反映）
- **Slack 接続は 1 操作（トランザクション）**: verify を通らないトークンはディスクに書かない。書いた後の reload が失敗したら以前の `connectors.slack` を書き戻す。
- **rollback の成否を検査して返す**: `rolledBack` は「ディスク復元 かつ コネクタ再起動成功」のときだけ true。それ以外は `restored:{disk,running}` と `rollbackError` を返し、UI は「戻せていない」と正直に出す。
- **config 書込の直列化**: `withConfigLock()`（モジュールレベルの Promise チェーン）で `PUT /api/config` と connect の「読取→merge→書込→reload→rollback」を直列化。rollback 前に on-disk の Slack ブロックが自分の書いた値のままかを CAS で確認し、外部変更があれば `rollbackSkipped`。
- **watcher 抑止をカウンタ化**: 自前の書込ごとに arm し、chokidar のイベントで 1 消費。3s の安全タイマーで drain（coalesce で余りが残る限界はコメント明記）。
- Slack API の非 2xx は `http_<n>`、ネットワーク失敗は `network_error` に正規化（生のエラー文字列は返さない）。

## Test plan
- [x] `tsc --noEmit`（jimmy / web）clean
- [x] vitest 150 files / 1,713 tests green（新規: engines / slack-verify / slack-connect の API テスト）
  - verify が通らない → 保存しない／保存後 reload 失敗 → rollback＆`restored`／rollback 自体の失敗 → `rolledBack:false, restored{disk:true,running:false}`／out-of-band 変更 → `rollbackSkipped`／同時 connect が直列化／in-flight connect 中の PUT が rollback に消されない
- [x] `packages/web` build 成功
- [x] Codex（gpt-5.6）アドバーサリアルレビュー 5 ラウンド → マージ可（5 巡目の唯一の指摘＝作業用 worktree の `node_modules` symlink 混入は `6f52f43c` で除去済み・`.gitignore` も symlink に効くよう強化）
- [ ] 実機（openclaw-sandbox）で v2026.9.1 デプロイ後、`/onboarding` を新規ホームで通す
