### PR TITLE
fix(slack): hydrate ID-only file attachments

### DIFF
--- a/packages/jimmy/src/connectors/slack/__tests__/format.test.ts
+++ b/packages/jimmy/src/connectors/slack/__tests__/format.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { markdownToSlackMrkdwn, formatResponse } from "../format.js";
+import { describe, it, expect, vi } from "vitest";
+import {
+  formatAttachmentFailureNotice,
+  formatResponse,
+  markdownToSlackMrkdwn,
+  resolveSlackFileAttachment,
+} from "../format.js";
 
 describe("markdownToSlackMrkdwn", () => {
   describe("headings", () => {
@@ -140,5 +145,84 @@ describe("formatResponse", () => {
     const result = formatResponse(longText);
     expect(result.length).toBeGreaterThan(1);
     expect(result[0].startsWith("*Title*")).toBe(true);
+  });
+});
+
+describe("resolveSlackFileAttachment", () => {
+  it("uses complete file metadata from the event without an API call", async () => {
+    const filesInfo = vi.fn();
+
+    const attachment = await resolveSlackFileAttachment(
+      {
+        id: "F123",
+        name: "brief.md",
+        mimetype: "text/plain",
+        url_private: "https://files.slack.com/files-pri/T123-F123/brief.md",
+      },
+      filesInfo,
+    );
+
+    expect(attachment).toEqual({
+      id: "F123",
+      name: "brief.md",
+      mimeType: "text/plain",
+      url: "https://files.slack.com/files-pri/T123-F123/brief.md",
+    });
+    expect(filesInfo).not.toHaveBeenCalled();
+  });
+
+  it("hydrates ID-only Slack event files through files.info", async () => {
+    const filesInfo = vi.fn().mockResolvedValue({
+      ok: true,
+      file: {
+        id: "F123",
+        name: "brief.md",
+        mimetype: "text/plain",
+        url_private_download: "https://files.slack.com/files-pri/T123-F123/download/brief.md",
+      },
+    });
+
+    const attachment = await resolveSlackFileAttachment(
+      { id: "F123", file_access: "check_file_info" },
+      filesInfo,
+    );
+
+    expect(filesInfo).toHaveBeenCalledWith({ file: "F123" });
+    expect(attachment).toEqual({
+      id: "F123",
+      name: "brief.md",
+      mimeType: "text/plain",
+      url: "https://files.slack.com/files-pri/T123-F123/download/brief.md",
+    });
+  });
+
+  it("rejects incomplete event metadata without a file ID", async () => {
+    await expect(resolveSlackFileAttachment({}, vi.fn())).rejects.toThrow(
+      "Slack attachment has neither a download URL nor a file ID",
+    );
+  });
+
+  it("rejects files.info responses that still have no download URL", async () => {
+    const filesInfo = vi.fn().mockResolvedValue({
+      ok: true,
+      file: { id: "F123", name: "brief.md" },
+    });
+
+    await expect(
+      resolveSlackFileAttachment({ id: "F123", file_access: "check_file_info" }, filesInfo),
+    ).rejects.toThrow("Slack file F123 has no private download URL after files.info");
+  });
+});
+
+describe("formatAttachmentFailureNotice", () => {
+  it("returns no notice when all attachments were retrieved", () => {
+    expect(formatAttachmentFailureNotice([])).toBe("");
+  });
+
+  it("tells the engine not to infer the contents of unavailable attachments", () => {
+    const notice = formatAttachmentFailureNotice(["Slack file F123"]);
+
+    expect(notice).toContain("Slack file F123");
+    expect(notice).toContain("Do not infer or substitute their contents");
   });
 });

--- a/packages/jimmy/src/connectors/slack/format.ts
+++ b/packages/jimmy/src/connectors/slack/format.ts
@@ -4,6 +4,80 @@ import { randomUUID } from "node:crypto";
 
 const SLACK_MAX_LENGTH = 3000;
 
+export interface SlackFileLike {
+  id?: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  file_access?: string;
+  url_private?: string;
+  url_private_download?: string;
+}
+
+export interface ResolvedSlackFileAttachment {
+  id?: string;
+  name: string;
+  mimeType: string;
+  url: string;
+}
+
+type FilesInfo = (args: { file: string }) => Promise<{
+  ok?: boolean;
+  error?: string;
+  file?: SlackFileLike;
+}>;
+
+/**
+ * Slack Events API may send an ID-only file object with
+ * `file_access: "check_file_info"`. Hydrate those events before downloading.
+ */
+export async function resolveSlackFileAttachment(
+  eventFile: SlackFileLike,
+  filesInfo: FilesInfo,
+): Promise<ResolvedSlackFileAttachment> {
+  let file = eventFile;
+  let url = file.url_private_download || file.url_private;
+
+  if (!url) {
+    if (!file.id) {
+      throw new Error("Slack attachment has neither a download URL nor a file ID");
+    }
+
+    const result = await filesInfo({ file: file.id });
+    if (!result.file) {
+      const detail = result.error ? `: ${result.error}` : "";
+      throw new Error(`Slack files.info returned no metadata for ${file.id}${detail}`);
+    }
+
+    file = { ...eventFile, ...result.file };
+    url = file.url_private_download || file.url_private;
+    if (!url) {
+      throw new Error(`Slack file ${file.id} has no private download URL after files.info`);
+    }
+  }
+
+  return {
+    id: file.id,
+    name: file.name || file.title || file.id || "slack-attachment",
+    mimeType: file.mimetype || "application/octet-stream",
+    url,
+  };
+}
+
+/**
+ * Keep attachment failures visible to the engine. Silently dropping a file can
+ * make a content-dependent task continue with invented or unrelated input.
+ */
+export function formatAttachmentFailureNotice(failedAttachments: string[]): string {
+  if (failedAttachments.length === 0) return "";
+
+  return (
+    "\n\n[System attachment notice: The following Slack attachment(s) could not be retrieved: " +
+    `${failedAttachments.join(", ")}. Do not infer or substitute their contents. ` +
+    "Explain that the attachment could not be read before doing any content-dependent work.]"
+  );
+}
+
 /**
  * Convert standard markdown to Slack mrkdwn format.
  * Handles headings, bold, strikethrough, links, and bullet lists.

--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -11,7 +11,12 @@ import type {
   SlackGoalExtractionConfig,
 } from "../../shared/types.js";
 import { buildReplyContext, deriveSessionKey, isOldSlackMessage } from "./threads.js";
-import { formatResponse, downloadAttachment } from "./format.js";
+import {
+  downloadAttachment,
+  formatAttachmentFailureNotice,
+  formatResponse,
+  resolveSlackFileAttachment,
+} from "./format.js";
 import { normalizeSpeakerInfo, type SpeakerInfo } from "./speaker.js";
 import { runTriage } from "./triage.js";
 import {
@@ -456,22 +461,31 @@ export class SlackConnector implements Connector {
 
       // Download attachments if present
       const attachments = [];
+      const failedAttachments: string[] = [];
       if ((event as any).files) {
         for (const file of (event as any).files) {
           try {
+            const resolved = await resolveSlackFileAttachment(
+              file,
+              (args) => this.app.client.files.info(args),
+            );
             const localPath = await downloadAttachment(
-              file.url_private,
+              resolved.url,
               this.app.client.token!,
               TMP_DIR,
             );
             attachments.push({
-              name: file.name,
-              url: file.url_private,
-              mimeType: file.mimetype,
+              name: resolved.name,
+              url: resolved.url,
+              mimeType: resolved.mimeType,
               localPath,
             });
           } catch (err) {
-            logger.warn(`Failed to download attachment: ${err}`);
+            // File names are user-controlled. Keep the injected failure notice
+            // limited to Slack's opaque ID so it cannot become prompt content.
+            const label = file.id ? `Slack file ${file.id}` : "Slack attachment";
+            failedAttachments.push(label);
+            logger.warn(`[slack] Failed to retrieve attachment ${label}: ${err}`);
           }
         }
       }
@@ -490,7 +504,10 @@ export class SlackConnector implements Connector {
       // "[Thread context — …]" preamble below silently breaks that parsing,
       // so a command typed inside a Slack thread would never be intercepted.
       // Commands don't need conversation context anyway — pass them verbatim.
-      const text = startsWithSlashCommand(rawText) ? rawText : parentContext + rawText;
+      const attachmentFailureNotice = formatAttachmentFailureNotice(failedAttachments);
+      const text = startsWithSlashCommand(rawText)
+        ? rawText + attachmentFailureNotice
+        : parentContext + rawText + attachmentFailureNotice;
 
       const msg: IncomingMessage = {
         connector: this.name,


### PR DESCRIPTION
## Summary

- Hydrate Slack Events API file objects through `files.info` when the event only includes an ID / `file_access: check_file_info`.
- Prefer `url_private_download`, while preserving the existing direct-URL path.
- Surface unresolved attachment failures to the engine with an explicit no-inference notice instead of silently dropping the file.

## Root cause

The connector passed `file.url_private` directly to `fetch()`. Slack can omit that field from the event payload and require a `files.info` lookup, which produced `fetch(undefined)`. The catch block only logged a warning, so content-dependent work continued without the attachment.

## Verification

- Full Jimmy test suite: 151 files / 1,732 tests passed.
- `pnpm --dir packages/jimmy typecheck` passed.
- Web and Jimmy production builds passed.
- Live regression check: an ID-only event shape for the affected Slack file hydrated and downloaded the expected 8,880 bytes.