### PR TITLE
chore: version 2026.9.3（子セッション完了通知の 401 修正のリリース）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.9.3] - 2026-09-01
+
+> 従業員に委譲した親セッションが「二度と起きない」問題の修正。8/18 の gateway 認証強化以降、子セッションの完了通知が自分の gateway に未認証で POST され、401 で無音のまま捨てられていた。
+
+### 修正
+
+- **子セッション完了通知・レート制限通知が 401 で全滅していた**（PR #67, @mrkm86）: `sessions/callbacks.ts` の 2 経路（`POST /api/sessions/:id/message` = 子→親の完了通知、`POST /api/connectors/:name/send` = usage limit 等の通知・呼び出し 8 箇所）が Authorization ヘッダを付けておらず、`fetch()` は 4xx で reject しないため `.catch()` も `res.ok` も無く、ログにも残らなかった。2026.8.20（`jobs/notify.ts` の同種修正）の取りこぼし。`_postToGateway()` に統合し、`readGatewayAuthToken()` でトークンを付与、`res.ok` を確認して拒否は warn に出す。抑止経路（`alwaysNotify: false` / 親不在 / 親が error）もログを残す。レスポンス body は `cancel()` で解放
+  - 影響条件: `gateway.host` が network（`0.0.0.0` 等）または `authRequired: true` で Bearer 必須になっている環境。既定の `127.0.0.1` は無傷
+- **委譲プロトコル（COO の system prompt）を「onComplete 通知が主経路、ただし保証ではない」に改訂**: 旧文面の「通知は必ず来る／NEVER poll」という無条件の約束をやめ、通知が省略される 3 条件（`parentSessionId` 無し / `alwaysNotify: false` / 親が `error`）と「POST 失敗は gateway.log にしか出ない」を明記。即返答してターンを終える運用は維持し（ターン内ポーリング禁止）、保険として `GET /api/sessions/<child-id>?last=5` と `ryoko job run … -- 'sleep <sec>'` の watchdog を案内。`parentSessionId` は必須
+- テストヘルパー `makeSession()` が `overrides` を spread していなかった不備を修正（既存テストが別の理由で通っていた）
+
+### Verification
+
+- 実機（host 0.0.0.0）で修正前の 401 を再現（no-token → 401 / with-token → 404）
+- Backend: **152 test files / 1,751 tests pass**、tsc clean
+- PR: [#67](https://github.com/rsensui2/OpenRyoko/pull/67)
+
 ## [2026.9.2] - 2026-08-31
 
 > macOS で `npm install -g openryoko` した直後に、最初のチャットで gateway が落ちる問題の修正。

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- `packages/jimmy` を 2026.9.3 に bump、CHANGELOG 追記
- 内容は main に取り込み済みの #67（@mrkm86 起票・引き取り）: `sessions/callbacks.ts` の 2 経路が自分の gateway に未認証 POST して 401 で無音失敗していた regression（2026-08-18 の認証強化の取りこぼし）の修正と、委譲プロトコルの「通知が主経路・ただし保証ではない」への改訂

## Test plan
- [x] jimmy build（dist/web 36 entries、dist の callbacks.js に `_postToGateway` / `readGatewayAuthToken`、context.js に新プロトコル文面を確認）
- [x] vitest 152 files / 1,751 tests green、tsc clean
- [x] 実機（host 0.0.0.0）で修正前の 401 を再現済み（no-token → 401 / with-token → 404）
- [x] npm publish（`latest: 2026.9.3`、shasum 2c883be2… がローカル tarball と一致）
- [x] openclaw-sandbox デプロイ（Dockerfile `OPENRYOKO_VERSION=2026.9.3` + `openryoko-local.tgz` 差し替え → build → up -d → `ryoko migrate`）。`ryoko --version` = 2026.9.3、`/api/health` 200、デプロイ後プローブも no-token → 401 / with-token → 404
- [ ] 使い捨て web セッションで委譲→通知起床の実弾確認（未実施。次に COO 委譲が走ったとき gateway.log に `[callbacks] Failed to notify parent` が出ないことで代替確認可）