### PR TITLE
feat(discord): respondTo 決定的メンションゲート + Web設定UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ connectors:
       model: claude-haiku-4-5
       timeoutMs: 20000
       threadContextLimit: 10
+  discord:
+    botToken: ...
+    # Slack と同じ決定的な応答ゲート（省略時は全メッセージに応答）
+    respondTo:
+      dm: always            # DM（1:1・グループ）: メンション不要で常に応答
+      channel: mention      # チャンネル/スレッド: @メンション or botへのリプライ時のみ
+      engagedThreads: true  # botが参加済みのスレッド内は再メンション不要（デフォルト true）
 
 cron:
   jobs:

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ connectors:
       threadContextLimit: 10
   discord:
     botToken: ...
-    # Slack と同じ決定的な応答ゲート（省略時は全メッセージに応答）
+    # Slack と同じ決定的な応答ゲート。
+    # 省略時も他ユーザー宛のメンション/リプライには応答しない（Slack と同じ既定挙動）
     respondTo:
       dm: always            # DM（1:1・グループ）: メンション不要で常に応答
       channel: mention      # チャンネル/スレッド: @メンション or botへのリプライ時のみ

--- a/packages/jimmy/src/connectors/discord/__tests__/engaged-threads.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/engaged-threads.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { EngagedThreadTracker } from "../engaged-threads.js";
+
+describe("EngagedThreadTracker", () => {
+  it("remembers recorded threads and nothing else", () => {
+    const tracker = new EngagedThreadTracker();
+    tracker.record("t1");
+    expect(tracker.has("t1")).toBe(true);
+    expect(tracker.has("t2")).toBe(false);
+  });
+
+  it("evicts the least recently engaged thread past the cap", () => {
+    const tracker = new EngagedThreadTracker(2);
+    tracker.record("t1");
+    tracker.record("t2");
+    tracker.record("t3");
+    expect(tracker.has("t1")).toBe(false);
+    expect(tracker.has("t2")).toBe(true);
+    expect(tracker.has("t3")).toBe(true);
+  });
+
+  it("re-recording refreshes recency", () => {
+    const tracker = new EngagedThreadTracker(2);
+    tracker.record("t1");
+    tracker.record("t2");
+    tracker.record("t1");
+    tracker.record("t3");
+    expect(tracker.has("t1")).toBe(true);
+    expect(tracker.has("t2")).toBe(false);
+    expect(tracker.has("t3")).toBe(true);
+  });
+});

--- a/packages/jimmy/src/connectors/discord/__tests__/engaged-threads.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/engaged-threads.test.ts
@@ -2,31 +2,19 @@ import { describe, it, expect } from "vitest";
 import { EngagedThreadTracker } from "../engaged-threads.js";
 
 describe("EngagedThreadTracker", () => {
-  it("remembers recorded threads and nothing else", () => {
+  it("remembers recorded ids and nothing else", () => {
     const tracker = new EngagedThreadTracker();
     tracker.record("t1");
     expect(tracker.has("t1")).toBe(true);
     expect(tracker.has("t2")).toBe(false);
   });
 
-  it("evicts the least recently engaged thread past the cap", () => {
-    const tracker = new EngagedThreadTracker(2);
-    tracker.record("t1");
-    tracker.record("t2");
-    tracker.record("t3");
-    expect(tracker.has("t1")).toBe(false);
-    expect(tracker.has("t2")).toBe(true);
-    expect(tracker.has("t3")).toBe(true);
-  });
-
-  it("re-recording refreshes recency", () => {
-    const tracker = new EngagedThreadTracker(2);
-    tracker.record("t1");
-    tracker.record("t2");
-    tracker.record("t1");
-    tracker.record("t3");
-    expect(tracker.has("t1")).toBe(true);
-    expect(tracker.has("t2")).toBe(false);
-    expect(tracker.has("t3")).toBe(true);
+  it("never evicts — engagement is a promise for the life of the process", () => {
+    const tracker = new EngagedThreadTracker();
+    tracker.record("first");
+    for (let i = 0; i < 10_000; i++) tracker.record(`m${i}`);
+    expect(tracker.has("first")).toBe(true);
+    expect(tracker.has("m0")).toBe(true);
+    expect(tracker.has("m9999")).toBe(true);
   });
 });

--- a/packages/jimmy/src/connectors/discord/__tests__/handle-message.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/handle-message.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import { DiscordConnector } from "../index.js";
+import type { IncomingMessage } from "../../../shared/types.js";
+
+const BOT = "999000999";
+
+interface FakeMessageInput {
+  content?: string;
+  channelId?: string;
+  isDM?: boolean;
+  isThread?: boolean;
+  mentionedUserIds?: string[];
+  repliedToUserId?: string;
+  reference?: { messageId: string; type?: number };
+  fetchReference?: () => Promise<{ author: { id: string } }>;
+  system?: boolean;
+  webhookId?: string;
+  authorBot?: boolean;
+}
+
+function fakeMessage(input: FakeMessageInput = {}) {
+  return {
+    id: "M1",
+    content: input.content ?? "hello",
+    author: { id: "U1", username: "user", bot: input.authorBot ?? false },
+    system: input.system ?? false,
+    webhookId: input.webhookId,
+    createdTimestamp: Date.now() + 60_000,
+    guild: undefined,
+    channel: {
+      id: input.channelId ?? "C1",
+      name: "general",
+      isDMBased: () => input.isDM ?? false,
+      isThread: () => input.isThread ?? false,
+      isTextBased: () => true,
+    },
+    mentions: {
+      users: new Map((input.mentionedUserIds ?? []).map((id) => [id, { id }])),
+      repliedUser: input.repliedToUserId ? { id: input.repliedToUserId } : null,
+    },
+    reference: input.reference,
+    fetchReference: input.fetchReference ?? vi.fn().mockRejectedValue(new Error("no reference")),
+    attachments: new Map(),
+  };
+}
+
+async function deliver(
+  connectorConfig: ConstructorParameters<typeof DiscordConnector>[0],
+  message: ReturnType<typeof fakeMessage>,
+  opts: { engagedThreadIds?: string[] } = {},
+): Promise<IncomingMessage[]> {
+  const connector = new DiscordConnector({ botToken: "test-token", ...connectorConfig });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (connector as any).client = { user: { id: BOT } };
+  for (const id of opts.engagedThreadIds ?? []) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any).engagedThreads.record(id);
+  }
+  const received: IncomingMessage[] = [];
+  connector.onMessage((msg) => received.push(msg));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (connector as any).handleMessage(message);
+  return received;
+}
+
+describe("DiscordConnector.handleMessage respondTo gating", () => {
+  it("responds to plain channel messages with respondTo unset (legacy default)", async () => {
+    const received = await deliver({}, fakeMessage());
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe("hello");
+  });
+
+  it("stays silent when the message @-mentions somebody else, even with respondTo unset", async () => {
+    const received = await deliver({}, fakeMessage({ mentionedUserIds: ["12345"] }));
+    expect(received).toHaveLength(0);
+  });
+
+  it("stays silent when the message replies to somebody else without a ping", async () => {
+    const received = await deliver({}, fakeMessage({ repliedToUserId: "12345" }));
+    expect(received).toHaveLength(0);
+  });
+
+  it("does not apply the sibling rule in DMs", async () => {
+    const received = await deliver({}, fakeMessage({ isDM: true, repliedToUserId: "12345" }));
+    expect(received).toHaveLength(1);
+  });
+
+  it("drops un-mentioned channel messages under channel=mention", async () => {
+    const received = await deliver({ respondTo: { channel: "mention" } }, fakeMessage());
+    expect(received).toHaveLength(0);
+  });
+
+  it("responds to @-mentions under channel=mention", async () => {
+    const received = await deliver(
+      { respondTo: { channel: "mention" } },
+      fakeMessage({ mentionedUserIds: [BOT] }),
+    );
+    expect(received).toHaveLength(1);
+  });
+
+  it("responds to replies to the bot under channel=mention", async () => {
+    const received = await deliver(
+      { respondTo: { channel: "mention" } },
+      fakeMessage({ repliedToUserId: BOT }),
+    );
+    expect(received).toHaveLength(1);
+  });
+
+  it("falls back to fetchReference when Discord omitted the reply resolution", async () => {
+    const received = await deliver(
+      { respondTo: { channel: "mention" } },
+      fakeMessage({
+        reference: { messageId: "M0" },
+        fetchReference: async () => ({ author: { id: BOT } }),
+      }),
+    );
+    expect(received).toHaveLength(1);
+  });
+
+  it("treats a deleted reply reference as no addressee (drops under mention, responds under always)", async () => {
+    const deleted = { reference: { messageId: "M0" } };
+    expect(await deliver({ respondTo: { channel: "mention" } }, fakeMessage(deleted))).toHaveLength(0);
+    expect(await deliver({}, fakeMessage(deleted))).toHaveLength(1);
+  });
+
+  it("keeps replying without a re-mention inside engaged threads", async () => {
+    const received = await deliver(
+      { respondTo: { channel: "mention" } },
+      fakeMessage({ channelId: "T1", isThread: true }),
+      { engagedThreadIds: ["T1"] },
+    );
+    expect(received).toHaveLength(1);
+  });
+
+  it("still answers DMs without a mention under channel=mention", async () => {
+    const received = await deliver({ respondTo: { channel: "mention" } }, fakeMessage({ isDM: true }));
+    expect(received).toHaveLength(1);
+  });
+
+  it("ignores system messages and webhook messages", async () => {
+    expect(await deliver({}, fakeMessage({ system: true }))).toHaveLength(0);
+    expect(await deliver({}, fakeMessage({ webhookId: "W1" }))).toHaveLength(0);
+  });
+});

--- a/packages/jimmy/src/connectors/discord/__tests__/handle-message.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/handle-message.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { MessageType } from "discord.js";
 import { DiscordConnector } from "../index.js";
 import type { IncomingMessage } from "../../../shared/types.js";
 
@@ -6,6 +7,7 @@ const BOT = "999000999";
 
 interface FakeMessageInput {
   content?: string;
+  type?: MessageType;
   channelId?: string;
   isDM?: boolean;
   isThread?: boolean;
@@ -21,6 +23,7 @@ interface FakeMessageInput {
 function fakeMessage(input: FakeMessageInput = {}) {
   return {
     id: "M1",
+    type: input.type ?? MessageType.Default,
     content: input.content ?? "hello",
     author: { id: "U1", username: "user", bot: input.authorBot ?? false },
     system: input.system ?? false,
@@ -76,12 +79,12 @@ describe("DiscordConnector.handleMessage respondTo gating", () => {
   });
 
   it("stays silent when the message replies to somebody else without a ping", async () => {
-    const received = await deliver({}, fakeMessage({ repliedToUserId: "12345" }));
+    const received = await deliver({}, fakeMessage({ type: MessageType.Reply, repliedToUserId: "12345" }));
     expect(received).toHaveLength(0);
   });
 
   it("does not apply the sibling rule in DMs", async () => {
-    const received = await deliver({}, fakeMessage({ isDM: true, repliedToUserId: "12345" }));
+    const received = await deliver({}, fakeMessage({ type: MessageType.Reply, isDM: true, repliedToUserId: "12345" }));
     expect(received).toHaveLength(1);
   });
 
@@ -101,7 +104,7 @@ describe("DiscordConnector.handleMessage respondTo gating", () => {
   it("responds to replies to the bot under channel=mention", async () => {
     const received = await deliver(
       { respondTo: { channel: "mention" } },
-      fakeMessage({ repliedToUserId: BOT }),
+      fakeMessage({ type: MessageType.Reply, repliedToUserId: BOT }),
     );
     expect(received).toHaveLength(1);
   });
@@ -110,6 +113,7 @@ describe("DiscordConnector.handleMessage respondTo gating", () => {
     const received = await deliver(
       { respondTo: { channel: "mention" } },
       fakeMessage({
+        type: MessageType.Reply,
         reference: { messageId: "M0" },
         fetchReference: async () => ({ author: { id: BOT } }),
       }),
@@ -118,7 +122,7 @@ describe("DiscordConnector.handleMessage respondTo gating", () => {
   });
 
   it("treats a deleted reply reference as no addressee (drops under mention, responds under always)", async () => {
-    const deleted = { reference: { messageId: "M0" } };
+    const deleted = { type: MessageType.Reply, reference: { messageId: "M0" } } as const;
     expect(await deliver({ respondTo: { channel: "mention" } }, fakeMessage(deleted))).toHaveLength(0);
     expect(await deliver({}, fakeMessage(deleted))).toHaveLength(1);
   });
@@ -140,5 +144,30 @@ describe("DiscordConnector.handleMessage respondTo gating", () => {
   it("ignores system messages and webhook messages", async () => {
     expect(await deliver({}, fakeMessage({ system: true }))).toHaveLength(0);
     expect(await deliver({}, fakeMessage({ webhookId: "W1" }))).toHaveLength(0);
+  });
+
+  it("does not treat a non-reply reference (crosspost) as addressing anybody", async () => {
+    const fetchReference = vi.fn().mockResolvedValue({ author: { id: "12345" } });
+    const message = fakeMessage({
+      reference: { messageId: "M0" },
+      fetchReference,
+    });
+    expect(await deliver({}, message)).toHaveLength(1);
+    expect(fetchReference).not.toHaveBeenCalled();
+  });
+
+  it("skips the reference fetch in DMs unless dm=mention", async () => {
+    const fetchReference = vi.fn().mockResolvedValue({ author: { id: BOT } });
+    const dmReply = () =>
+      fakeMessage({
+        type: MessageType.Reply,
+        isDM: true,
+        reference: { messageId: "M0" },
+        fetchReference,
+      });
+    expect(await deliver({}, dmReply())).toHaveLength(1);
+    expect(fetchReference).not.toHaveBeenCalled();
+    expect(await deliver({ respondTo: { dm: "mention" } }, dmReply())).toHaveLength(1);
+    expect(fetchReference).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jimmy/src/connectors/discord/__tests__/proxy-forwarding.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/proxy-forwarding.test.ts
@@ -94,6 +94,31 @@ describe("engagement recording guards", () => {
     expect(tracker(connector).has("S1")).toBe(false);
     expect(tracker(connector).has("D1")).toBe(false);
   });
+
+  it("records nothing under dm=mention alone — DMs have no threads to consume it", async () => {
+    const connector = connectorWith(
+      { respondTo: { dm: "mention" } },
+      fakeChannel({ id: "C1" }),
+    );
+    await connector.sendMessage({ channel: "C1" }, "hi");
+    expect(tracker(connector).has("S1")).toBe(false);
+  });
+
+  it("records for channelRouting only when the id itself is a routing key", async () => {
+    const unrouted = connectorWith(
+      { channelRouting: { OTHER: "http://remote.test" } },
+      fakeChannel({ id: "T9", isThread: true }),
+    );
+    await unrouted.replyMessage({ channel: "C1", thread: "T9" }, "hi");
+    expect(tracker(unrouted).has("T9")).toBe(false);
+
+    const routed = connectorWith(
+      { channelRouting: { T9: "http://remote.test" } },
+      fakeChannel({ id: "T9", isThread: true }),
+    );
+    await routed.replyMessage({ channel: "C1", thread: "T9" }, "hi");
+    expect(tracker(routed).has("T9")).toBe(true);
+  });
 });
 
 describe("routing forwards addressing and engagement to the remote", () => {

--- a/packages/jimmy/src/connectors/discord/__tests__/proxy-forwarding.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/proxy-forwarding.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { MessageType } from "discord.js";
+import { DiscordConnector } from "../index.js";
+
+const BOT = "999000999";
+
+function fakeChannel(input: { id: string; isThread?: boolean; isDM?: boolean } ) {
+  return {
+    id: input.id,
+    name: "general",
+    isThread: () => input.isThread ?? false,
+    isDMBased: () => input.isDM ?? false,
+    isTextBased: () => true,
+    send: vi.fn().mockResolvedValue({ id: "S1" }),
+  };
+}
+
+function fakeIncoming(input: { channelId: string; isThread?: boolean }) {
+  return {
+    id: "M1",
+    type: MessageType.Default,
+    content: "hello",
+    author: { id: "U1", username: "user", bot: false },
+    system: false,
+    webhookId: undefined,
+    createdTimestamp: Date.now() + 60_000,
+    guild: { id: "G1" },
+    channel: {
+      id: input.channelId,
+      name: "general",
+      isDMBased: () => false,
+      isThread: () => input.isThread ?? false,
+      isTextBased: () => true,
+    },
+    mentions: { users: new Map(), repliedUser: null },
+    reference: undefined,
+    fetchReference: vi.fn().mockRejectedValue(new Error("no reference")),
+    attachments: new Map(),
+  };
+}
+
+function connectorWith(
+  config: ConstructorParameters<typeof DiscordConnector>[0],
+  channel: ReturnType<typeof fakeChannel>,
+): DiscordConnector {
+  const connector = new DiscordConnector({ botToken: "test-token", ...config });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (connector as any).client = {
+    user: { id: BOT },
+    channels: { fetch: vi.fn().mockResolvedValue(channel) },
+  };
+  return connector;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tracker = (connector: DiscordConnector) => (connector as any).engagedThreads;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("engagement recording guards", () => {
+  it("records nothing when no consumer exists (no mention scope, no routing)", async () => {
+    const connector = connectorWith({}, fakeChannel({ id: "T9", isThread: true }));
+    await connector.replyMessage({ channel: "C1", thread: "T9" }, "hi");
+    expect(tracker(connector).has("T9")).toBe(false);
+  });
+
+  it("records the thread — not the chunk id — for thread sends", async () => {
+    const connector = connectorWith(
+      { respondTo: { channel: "mention" } },
+      fakeChannel({ id: "T9", isThread: true }),
+    );
+    await connector.replyMessage({ channel: "C1", thread: "T9" }, "hi");
+    expect(tracker(connector).has("T9")).toBe(true);
+    expect(tracker(connector).has("S1")).toBe(false);
+  });
+
+  it("records the sent message id for flat guild channel sends (future thread root)", async () => {
+    const connector = connectorWith(
+      { respondTo: { channel: "mention" } },
+      fakeChannel({ id: "C1" }),
+    );
+    await connector.sendMessage({ channel: "C1" }, "hi");
+    expect(tracker(connector).has("S1")).toBe(true);
+  });
+
+  it("records nothing for DM sends", async () => {
+    const connector = connectorWith(
+      { respondTo: { channel: "mention" } },
+      fakeChannel({ id: "D1", isDM: true }),
+    );
+    await connector.sendMessage({ channel: "D1" }, "hi");
+    expect(tracker(connector).has("S1")).toBe(false);
+    expect(tracker(connector).has("D1")).toBe(false);
+  });
+});
+
+describe("routing forwards addressing and engagement to the remote", () => {
+  function stubProxyFetch() {
+    const calls: Array<Record<string, unknown>> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: unknown, init?: { body?: string }) => {
+        calls.push(JSON.parse(init?.body ?? "{}"));
+        return { ok: true, status: 200, statusText: "OK" };
+      }),
+    );
+    return calls;
+  }
+
+  it("forwards isEngagedThread=true after the bot replied in the routed thread", async () => {
+    const connector = connectorWith(
+      { channelRouting: { T9: "http://remote.test" } },
+      fakeChannel({ id: "T9", isThread: true }),
+    );
+    await connector.replyMessage({ channel: "C1", thread: "T9" }, "hi");
+
+    const calls = stubProxyFetch();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (connector as any).handleMessage(fakeIncoming({ channelId: "T9", isThread: true }));
+    expect(calls).toHaveLength(1);
+    const meta = calls[0].transportMeta as Record<string, unknown>;
+    expect(meta.isEngagedThread).toBe(true);
+    expect(meta.wasBotAddressed).toBe(false);
+    expect(meta.addressesOnlyOthers).toBe(false);
+    expect(meta.isDM).toBe(false);
+  });
+
+  it("forwards isEngagedThread=false for a thread the bot never engaged", async () => {
+    const connector = connectorWith(
+      { channelRouting: { T9: "http://remote.test" } },
+      fakeChannel({ id: "T9", isThread: true }),
+    );
+    const calls = stubProxyFetch();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (connector as any).handleMessage(fakeIncoming({ channelId: "T9", isThread: true }));
+    expect(calls).toHaveLength(1);
+    expect((calls[0].transportMeta as Record<string, unknown>).isEngagedThread).toBe(false);
+  });
+});

--- a/packages/jimmy/src/connectors/discord/__tests__/remote-gate.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/remote-gate.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { RemoteDiscordConnector } from "../remote.js";
+import type { DiscordRespondToConfig, IncomingMessage } from "../../../shared/types.js";
+
+function incoming(
+  transportMeta: Record<string, unknown> | undefined,
+  thread?: string,
+): IncomingMessage {
+  return {
+    connector: "discord",
+    source: "discord",
+    sessionKey: "discord:C1",
+    channel: "C1",
+    thread,
+    user: "user",
+    userId: "U1",
+    text: "hello",
+    messageId: "M1",
+    attachments: [],
+    replyContext: {},
+    transportMeta,
+  } as unknown as IncomingMessage;
+}
+
+function deliver(
+  respondTo: DiscordRespondToConfig | undefined,
+  msg: IncomingMessage,
+  opts: { engagedThreadIds?: string[] } = {},
+): IncomingMessage[] {
+  const connector = new RemoteDiscordConnector({ proxyVia: "http://127.0.0.1:1", respondTo });
+  for (const id of opts.engagedThreadIds ?? []) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any).engagedThreads.record(id);
+  }
+  const received: IncomingMessage[] = [];
+  connector.onMessage((m) => received.push(m));
+  connector.deliverMessage(msg);
+  return received;
+}
+
+describe("RemoteDiscordConnector.deliverMessage respondTo gating", () => {
+  it("delivers everything with respondTo unset and no addressing metadata (older primary)", () => {
+    expect(deliver(undefined, incoming(undefined))).toHaveLength(1);
+    expect(deliver(undefined, incoming({ isDM: false }))).toHaveLength(1);
+  });
+
+  it("drops channel messages addressed to somebody else, even with respondTo unset", () => {
+    expect(deliver(undefined, incoming({ isDM: false, addressesOnlyOthers: true }))).toHaveLength(0);
+  });
+
+  it("does not apply the sibling rule in DMs", () => {
+    expect(deliver(undefined, incoming({ isDM: true, addressesOnlyOthers: true }))).toHaveLength(1);
+  });
+
+  it("drops un-addressed channel messages under channel=mention (fail closed on missing metadata)", () => {
+    const respondTo: DiscordRespondToConfig = { channel: "mention" };
+    expect(deliver(respondTo, incoming({ isDM: false, wasBotAddressed: false }))).toHaveLength(0);
+    expect(deliver(respondTo, incoming(undefined))).toHaveLength(0);
+  });
+
+  it("delivers addressed channel messages under channel=mention", () => {
+    const respondTo: DiscordRespondToConfig = { channel: "mention" };
+    expect(deliver(respondTo, incoming({ isDM: false, wasBotAddressed: true }))).toHaveLength(1);
+  });
+
+  it("keeps delivering inside engaged threads without a re-mention", () => {
+    const respondTo: DiscordRespondToConfig = { channel: "mention" };
+    const msg = incoming({ isDM: false, wasBotAddressed: false }, "T1");
+    expect(deliver(respondTo, msg, { engagedThreadIds: ["T1"] })).toHaveLength(1);
+    expect(deliver(respondTo, msg)).toHaveLength(0);
+  });
+
+  it("silences a scope entirely under never", () => {
+    const respondTo: DiscordRespondToConfig = { channel: "never" };
+    expect(deliver(respondTo, incoming({ isDM: false, wasBotAddressed: true }))).toHaveLength(0);
+  });
+});

--- a/packages/jimmy/src/connectors/discord/__tests__/remote-gate.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/remote-gate.test.ts
@@ -25,13 +25,8 @@ function incoming(
 function deliver(
   respondTo: DiscordRespondToConfig | undefined,
   msg: IncomingMessage,
-  opts: { engagedThreadIds?: string[] } = {},
 ): IncomingMessage[] {
   const connector = new RemoteDiscordConnector({ proxyVia: "http://127.0.0.1:1", respondTo });
-  for (const id of opts.engagedThreadIds ?? []) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (connector as any).engagedThreads.record(id);
-  }
   const received: IncomingMessage[] = [];
   connector.onMessage((m) => received.push(m));
   connector.deliverMessage(msg);
@@ -63,11 +58,24 @@ describe("RemoteDiscordConnector.deliverMessage respondTo gating", () => {
     expect(deliver(respondTo, incoming({ isDM: false, wasBotAddressed: true }))).toHaveLength(1);
   });
 
-  it("keeps delivering inside engaged threads without a re-mention", () => {
+  it("trusts the primary's engaged-thread flag for the mention continuation", () => {
     const respondTo: DiscordRespondToConfig = { channel: "mention" };
-    const msg = incoming({ isDM: false, wasBotAddressed: false }, "T1");
-    expect(deliver(respondTo, msg, { engagedThreadIds: ["T1"] })).toHaveLength(1);
-    expect(deliver(respondTo, msg)).toHaveLength(0);
+    const engaged = incoming(
+      { isDM: false, wasBotAddressed: false, isEngagedThread: true },
+      "T1",
+    );
+    const notEngaged = incoming({ isDM: false, wasBotAddressed: false }, "T1");
+    expect(deliver(respondTo, engaged)).toHaveLength(1);
+    expect(deliver(respondTo, notEngaged)).toHaveLength(0);
+  });
+
+  it("ignores the engaged-thread flag when engagedThreads=false", () => {
+    const respondTo: DiscordRespondToConfig = { channel: "mention", engagedThreads: false };
+    const engaged = incoming(
+      { isDM: false, wasBotAddressed: false, isEngagedThread: true },
+      "T1",
+    );
+    expect(deliver(respondTo, engaged)).toHaveLength(0);
   });
 
   it("silences a scope entirely under never", () => {

--- a/packages/jimmy/src/connectors/discord/__tests__/respond-policy.test.ts
+++ b/packages/jimmy/src/connectors/discord/__tests__/respond-policy.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import {
+  scopeForChannel,
+  resolveRespondMode,
+  evaluateRespondPolicy,
+  hasMentionScope,
+  respondPolicyNeedsTracking,
+  wasBotAddressed,
+  addressesOnlyOthers,
+} from "../respond-policy.js";
+import type { DiscordRespondToConfig } from "../../../shared/types.js";
+
+const BOT = "999000999";
+
+describe("scopeForChannel", () => {
+  it("maps DMs (1:1 and group) to dm", () => {
+    expect(scopeForChannel(true)).toBe("dm");
+  });
+
+  it("maps guild channels and threads to channel", () => {
+    expect(scopeForChannel(false)).toBe("channel");
+  });
+});
+
+describe("resolveRespondMode", () => {
+  it("defaults every scope to always when config is absent", () => {
+    expect(resolveRespondMode(undefined, "dm")).toBe("always");
+    expect(resolveRespondMode(undefined, "channel")).toBe("always");
+  });
+
+  it("defaults unset scopes to always when config is partial", () => {
+    const config: DiscordRespondToConfig = { channel: "mention" };
+    expect(resolveRespondMode(config, "dm")).toBe("always");
+    expect(resolveRespondMode(config, "channel")).toBe("mention");
+  });
+
+  it("treats invalid values as always (config files are untyped YAML)", () => {
+    const config = { channel: "sometimes" } as unknown as DiscordRespondToConfig;
+    expect(resolveRespondMode(config, "channel")).toBe("always");
+  });
+});
+
+describe("hasMentionScope", () => {
+  it("is false without config or without mention scopes", () => {
+    expect(hasMentionScope(undefined)).toBe(false);
+    expect(hasMentionScope({ dm: "always", channel: "never" })).toBe(false);
+  });
+
+  it("is true when any scope is mention", () => {
+    expect(hasMentionScope({ channel: "mention" })).toBe(true);
+    expect(hasMentionScope({ dm: "mention" })).toBe(true);
+  });
+});
+
+describe("respondPolicyNeedsTracking", () => {
+  it("needs tracking only for mention scopes with engagedThreads on", () => {
+    expect(respondPolicyNeedsTracking(undefined)).toBe(false);
+    expect(respondPolicyNeedsTracking({ channel: "always" })).toBe(false);
+    expect(respondPolicyNeedsTracking({ channel: "mention" })).toBe(true);
+    expect(respondPolicyNeedsTracking({ channel: "mention", engagedThreads: false })).toBe(false);
+  });
+});
+
+describe("evaluateRespondPolicy", () => {
+  const mentionOnly: DiscordRespondToConfig = { dm: "always", channel: "mention" };
+
+  it("allows everything when config is absent (legacy behavior)", () => {
+    expect(
+      evaluateRespondPolicy({
+        config: undefined,
+        isDM: false,
+        wasMentioned: false,
+        isEngagedThread: false,
+      }),
+    ).toEqual({ allow: true });
+  });
+
+  it("allows DMs without a mention under dm=always", () => {
+    expect(
+      evaluateRespondPolicy({
+        config: mentionOnly,
+        isDM: true,
+        wasMentioned: false,
+        isEngagedThread: false,
+      }),
+    ).toEqual({ allow: true });
+  });
+
+  it("drops un-mentioned channel messages under channel=mention", () => {
+    const decision = evaluateRespondPolicy({
+      config: mentionOnly,
+      isDM: false,
+      wasMentioned: false,
+      isEngagedThread: false,
+    });
+    expect(decision.allow).toBe(false);
+    if (!decision.allow) expect(decision.reason).toContain("respondTo.channel=mention");
+  });
+
+  it("allows mentioned channel messages under channel=mention", () => {
+    expect(
+      evaluateRespondPolicy({
+        config: mentionOnly,
+        isDM: false,
+        wasMentioned: true,
+        isEngagedThread: false,
+      }),
+    ).toEqual({ allow: true });
+  });
+
+  it("allows un-mentioned messages in engaged threads by default", () => {
+    expect(
+      evaluateRespondPolicy({
+        config: mentionOnly,
+        isDM: false,
+        wasMentioned: false,
+        isEngagedThread: true,
+      }),
+    ).toEqual({ allow: true });
+  });
+
+  it("drops un-mentioned engaged-thread messages when engagedThreads=false", () => {
+    const decision = evaluateRespondPolicy({
+      config: { ...mentionOnly, engagedThreads: false },
+      isDM: false,
+      wasMentioned: false,
+      isEngagedThread: true,
+    });
+    expect(decision.allow).toBe(false);
+  });
+
+  it("drops everything, mentions included, under never", () => {
+    const decision = evaluateRespondPolicy({
+      config: { dm: "never", channel: "never" },
+      isDM: true,
+      wasMentioned: true,
+      isEngagedThread: false,
+    });
+    expect(decision.allow).toBe(false);
+    if (!decision.allow) expect(decision.reason).toBe("respondTo.dm=never");
+  });
+});
+
+describe("wasBotAddressed", () => {
+  it("is true for a direct @-mention of the bot", () => {
+    expect(
+      wasBotAddressed({
+        botUserId: BOT,
+        mentionedUserIds: new Set([BOT, "12345"]),
+        repliedToUserId: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("is true for a reply to one of the bot's messages (ping on or off)", () => {
+    expect(
+      wasBotAddressed({
+        botUserId: BOT,
+        mentionedUserIds: new Set(),
+        repliedToUserId: BOT,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false without a mention or reply-to-bot", () => {
+    expect(
+      wasBotAddressed({
+        botUserId: BOT,
+        mentionedUserIds: new Set(["12345"]),
+        repliedToUserId: "12345",
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed when the bot user id is unresolved", () => {
+    expect(
+      wasBotAddressed({
+        botUserId: undefined,
+        mentionedUserIds: new Set([BOT]),
+        repliedToUserId: BOT,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("addressesOnlyOthers", () => {
+  it("is true when the message @-mentions only other users", () => {
+    expect(
+      addressesOnlyOthers({
+        botUserId: BOT,
+        mentionedUserIds: new Set(["12345"]),
+        repliedToUserId: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("is true when the message replies to another user's message", () => {
+    expect(
+      addressesOnlyOthers({
+        botUserId: BOT,
+        mentionedUserIds: new Set(),
+        repliedToUserId: "12345",
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when the bot is among the mentioned users", () => {
+    expect(
+      addressesOnlyOthers({
+        botUserId: BOT,
+        mentionedUserIds: new Set([BOT, "12345"]),
+        repliedToUserId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false with no explicit addressees (@everyone/@here carry none)", () => {
+    expect(
+      addressesOnlyOthers({
+        botUserId: BOT,
+        mentionedUserIds: new Set(),
+        repliedToUserId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when the bot user id is unresolved (never drop on unknown identity)", () => {
+    expect(
+      addressesOnlyOthers({
+        botUserId: undefined,
+        mentionedUserIds: new Set(["12345"]),
+        repliedToUserId: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/jimmy/src/connectors/discord/engaged-threads.ts
+++ b/packages/jimmy/src/connectors/discord/engaged-threads.ts
@@ -1,5 +1,3 @@
-import { logger } from "../../shared/logger.js";
-
 /**
  * In-memory record of conversation anchors the bot has engaged: threads it
  * replied or reacted in, plus the IDs of messages it sent or reacted to —
@@ -7,32 +5,18 @@ import { logger } from "../../shared/logger.js";
  * so recording message IDs makes future threads rooted on the bot's own
  * messages count as engaged from their first reply.
  *
- * Backs the `respondTo.engagedThreads` continuation. In-memory only —
- * engagement resets on restart, same as the Slack ConversationTracker.
- *
- * The cap is a memory safety valve, not a semantic TTL: at the default size
- * it is effectively unbounded for real deployments (IDs are ~20-byte
- * strings). Eviction silently re-arms the mention requirement for the
- * evicted thread, so it is logged. Eviction order is least-recently-engaged
- * (Set preserves insertion order, `record` re-inserts).
+ * Backs the `respondTo.engagedThreads` continuation. Unbounded by design,
+ * matching the Slack ConversationTracker: engagement is a promise ("mention
+ * once, then converse"), and silently evicting it would re-arm the mention
+ * requirement mid-conversation. Entries are single ~20-byte IDs, so even a
+ * very busy year of uptime stays in the tens of megabytes. In-memory only —
+ * engagement resets on gateway restart.
  */
 export class EngagedThreadTracker {
   private readonly ids = new Set<string>();
 
-  constructor(private readonly maxEntries = 50_000) {}
-
   record(id: string): void {
-    this.ids.delete(id);
     this.ids.add(id);
-    if (this.ids.size > this.maxEntries) {
-      const oldest = this.ids.values().next().value;
-      if (oldest !== undefined) {
-        this.ids.delete(oldest);
-        logger.warn(
-          `[discord] engaged-thread tracker over ${this.maxEntries} entries — evicted ${oldest}; un-mentioned messages there need a re-mention`,
-        );
-      }
-    }
   }
 
   has(id: string): boolean {

--- a/packages/jimmy/src/connectors/discord/engaged-threads.ts
+++ b/packages/jimmy/src/connectors/discord/engaged-threads.ts
@@ -1,27 +1,41 @@
+import { logger } from "../../shared/logger.js";
+
 /**
- * Bounded in-memory record of threads the bot has engaged (replied or
- * reacted in). Backs the `respondTo.engagedThreads` continuation: once the
- * bot participates in a thread, follow-ups there flow without a re-mention.
+ * In-memory record of conversation anchors the bot has engaged: threads it
+ * replied or reacted in, plus the IDs of messages it sent or reacted to —
+ * a Discord public thread created from a message reuses that message's ID,
+ * so recording message IDs makes future threads rooted on the bot's own
+ * messages count as engaged from their first reply.
  *
- * In-memory only — engagement resets on restart, same as the Slack
- * ConversationTracker. The cap bounds memory over long uptimes; eviction is
- * least-recently-engaged (Set preserves insertion order, `record` re-inserts).
+ * Backs the `respondTo.engagedThreads` continuation. In-memory only —
+ * engagement resets on restart, same as the Slack ConversationTracker.
+ *
+ * The cap is a memory safety valve, not a semantic TTL: at the default size
+ * it is effectively unbounded for real deployments (IDs are ~20-byte
+ * strings). Eviction silently re-arms the mention requirement for the
+ * evicted thread, so it is logged. Eviction order is least-recently-engaged
+ * (Set preserves insertion order, `record` re-inserts).
  */
 export class EngagedThreadTracker {
   private readonly ids = new Set<string>();
 
-  constructor(private readonly maxEntries = 500) {}
+  constructor(private readonly maxEntries = 50_000) {}
 
-  record(threadId: string): void {
-    this.ids.delete(threadId);
-    this.ids.add(threadId);
+  record(id: string): void {
+    this.ids.delete(id);
+    this.ids.add(id);
     if (this.ids.size > this.maxEntries) {
       const oldest = this.ids.values().next().value;
-      if (oldest !== undefined) this.ids.delete(oldest);
+      if (oldest !== undefined) {
+        this.ids.delete(oldest);
+        logger.warn(
+          `[discord] engaged-thread tracker over ${this.maxEntries} entries — evicted ${oldest}; un-mentioned messages there need a re-mention`,
+        );
+      }
     }
   }
 
-  has(threadId: string): boolean {
-    return this.ids.has(threadId);
+  has(id: string): boolean {
+    return this.ids.has(id);
   }
 }

--- a/packages/jimmy/src/connectors/discord/engaged-threads.ts
+++ b/packages/jimmy/src/connectors/discord/engaged-threads.ts
@@ -1,0 +1,27 @@
+/**
+ * Bounded in-memory record of threads the bot has engaged (replied or
+ * reacted in). Backs the `respondTo.engagedThreads` continuation: once the
+ * bot participates in a thread, follow-ups there flow without a re-mention.
+ *
+ * In-memory only — engagement resets on restart, same as the Slack
+ * ConversationTracker. The cap bounds memory over long uptimes; eviction is
+ * least-recently-engaged (Set preserves insertion order, `record` re-inserts).
+ */
+export class EngagedThreadTracker {
+  private readonly ids = new Set<string>();
+
+  constructor(private readonly maxEntries = 500) {}
+
+  record(threadId: string): void {
+    this.ids.delete(threadId);
+    this.ids.add(threadId);
+    if (this.ids.size > this.maxEntries) {
+      const oldest = this.ids.values().next().value;
+      if (oldest !== undefined) this.ids.delete(oldest);
+    }
+  }
+
+  has(threadId: string): boolean {
+    return this.ids.has(threadId);
+  }
+}

--- a/packages/jimmy/src/connectors/discord/engaged-threads.ts
+++ b/packages/jimmy/src/connectors/discord/engaged-threads.ts
@@ -1,16 +1,20 @@
 /**
  * In-memory record of conversation anchors the bot has engaged: threads it
- * replied or reacted in, plus the IDs of messages it sent or reacted to —
- * a Discord public thread created from a message reuses that message's ID,
- * so recording message IDs makes future threads rooted on the bot's own
- * messages count as engaged from their first reply.
+ * replied or reacted in, plus the IDs of eligible messages it sent or
+ * reacted to — a Discord public thread created from a message reuses that
+ * message's ID, so recording message IDs makes future threads rooted on the
+ * bot's own messages count as engaged from their first reply.
  *
- * Backs the `respondTo.engagedThreads` continuation. Unbounded by design,
- * matching the Slack ConversationTracker: engagement is a promise ("mention
- * once, then converse"), and silently evicting it would re-arm the mention
- * requirement mid-conversation. Entries are single ~20-byte IDs, so even a
- * very busy year of uptime stays in the tens of megabytes. In-memory only —
- * engagement resets on gateway restart.
+ * Backs the `respondTo.engagedThreads` continuation. No eviction, matching
+ * the Slack ConversationTracker: engagement is a promise ("mention once,
+ * then converse"), and silently evicting it would re-arm the mention
+ * requirement mid-conversation. Memory stays bounded by what the connector
+ * feeds in (see `DiscordConnector.recordEngagement`): nothing at all unless
+ * a consumer exists, and only anchor-eligible IDs — DM and in-thread message
+ * IDs can never root a thread and are never recorded. At the ~60-70 bytes a
+ * Set entry really costs, even hundreds of thousands of anchors stay in the
+ * tens of megabytes. Entries live until the connector is recreated (gateway
+ * restart, config save, connector reload).
  */
 export class EngagedThreadTracker {
   private readonly ids = new Set<string>();

--- a/packages/jimmy/src/connectors/discord/index.ts
+++ b/packages/jimmy/src/connectors/discord/index.ts
@@ -23,8 +23,10 @@ import { deriveSessionKey, buildReplyContext, isOldMessage } from "./threads.js"
 import {
   evaluateRespondPolicy,
   resolveRespondMode,
+  respondPolicyNeedsTracking,
   wasBotAddressed,
   addressesOnlyOthers,
+  type ForwardedAddressing,
 } from "./respond-policy.js";
 import { EngagedThreadTracker } from "./engaged-threads.js";
 
@@ -163,11 +165,8 @@ export class DiscordConnector implements Connector {
       for (const chunk of chunks) {
         const sent = await (channel as TextChannel | DMChannel | ThreadChannel).send(chunk);
         lastId = sent.id;
-        // Record per chunk, so a partial send still counts as engagement.
-        // The sent message ID is an anchor too: a future public thread
-        // created from it reuses that ID.
-        if (channel.isThread()) this.engagedThreads.record(channel.id);
-        this.engagedThreads.record(sent.id);
+        // Per chunk, so a partial send still counts as engagement.
+        this.recordEngagement(channel, sent.id);
       }
       return lastId;
     } catch (err) {
@@ -184,11 +183,8 @@ export class DiscordConnector implements Connector {
       for (const chunk of chunks) {
         const sent = await (channel as TextChannel | DMChannel | ThreadChannel).send(chunk);
         lastId = sent.id;
-        // Record per chunk, so a partial send still counts as engagement.
-        // The sent message ID is an anchor too: a future public thread
-        // created from it reuses that ID.
-        if (channel.isThread()) this.engagedThreads.record(channel.id);
-        this.engagedThreads.record(sent.id);
+        // Per chunk, so a partial send still counts as engagement.
+        this.recordEngagement(channel, sent.id);
       }
       return lastId;
     } catch (err) {
@@ -215,10 +211,7 @@ export class DiscordConnector implements Connector {
       if (!channel || !channel.isTextBased()) return;
       const msg = await (channel as TextChannel).messages.fetch(target.messageTs);
       await msg.react(emoji);
-      // A reaction engages the surrounding thread, and marks the reacted
-      // message as an anchor — a future thread created from it shares its ID.
-      if (channel.isThread()) this.engagedThreads.record(channel.id);
-      this.engagedThreads.record(target.messageTs);
+      this.recordEngagement(channel, target.messageTs);
     } catch {
       // non-fatal
     }
@@ -282,7 +275,12 @@ export class DiscordConnector implements Connector {
     const routeTarget = this.config.channelRouting?.[message.channel.id];
     if (routeTarget) {
       logger.debug(`Routing Discord message from channel ${message.channel.id} to ${routeTarget}`);
-      const addressing = await this.resolveAddressing(message, { allowFetch: true });
+      // References resolve only outside DMs here: the remote's dm policy is
+      // unknown, and a routed-DM reply matters only under its dm=mention —
+      // too rare to spend a REST fetch on every routed DM reply.
+      const addressing = await this.resolveAddressing(message, {
+        allowFetch: !message.channel.isDMBased(),
+      });
       await this.proxyToRemote(routeTarget, message, addressing);
       return;
     }
@@ -376,6 +374,37 @@ export class DiscordConnector implements Connector {
   }
 
   /**
+   * Track engagement for the `respondTo.engagedThreads` continuation.
+   * Recording is skipped entirely unless something can consume it (a mention
+   * scope with engagedThreads on, or channelRouting — the receiving instance
+   * may be mention-gated), and only anchor-eligible IDs are kept: the thread
+   * itself, or — in flat guild channels — the acted-on message, since a
+   * public thread created from a message reuses its ID. DM and in-thread
+   * message IDs can never root a thread and are never recorded, which keeps
+   * the unbounded tracker's real footprint small.
+   */
+  private recordEngagement(
+    channel: { id: string; isThread(): boolean; isDMBased(): boolean },
+    anchorMessageId?: string,
+  ): void {
+    if (!this.trackingEnabled()) return;
+    if (channel.isThread()) {
+      this.engagedThreads.record(channel.id);
+      return;
+    }
+    if (anchorMessageId && !channel.isDMBased()) {
+      this.engagedThreads.record(anchorMessageId);
+    }
+  }
+
+  private trackingEnabled(): boolean {
+    return (
+      respondPolicyNeedsTracking(this.config.respondTo) ||
+      Object.keys(this.config.channelRouting ?? {}).length > 0
+    );
+  }
+
+  /**
    * Resolve who the message addresses. Reply attribution applies only to
    * actual replies (`MessageType.Reply`) — a crosspost or forward also
    * carries a `reference` but addresses nobody. `mentions.repliedUser` comes
@@ -438,14 +467,16 @@ export class DiscordConnector implements Connector {
             : "dm",
           guildId: message.guild?.id ?? null,
           isDM: message.channel.isDMBased(),
-          // ForwardedAddressing — precomputed here (only this instance knows
-          // the bot user, resolves references, and tracks engagement) so the
-          // receiving instance can apply its own respondTo gate without
-          // another Discord round-trip.
-          wasBotAddressed: wasBotAddressed(addressing),
-          addressesOnlyOthers: addressesOnlyOthers(addressing),
-          isEngagedThread:
-            message.channel.isThread() && this.engagedThreads.has(message.channel.id),
+          // Precomputed here (only this instance knows the bot user,
+          // resolves references, and tracks engagement) so the receiving
+          // instance can apply its own respondTo gate without another
+          // Discord round-trip.
+          ...({
+            wasBotAddressed: wasBotAddressed(addressing),
+            addressesOnlyOthers: addressesOnlyOthers(addressing),
+            isEngagedThread:
+              message.channel.isThread() && this.engagedThreads.has(message.channel.id),
+          } satisfies ForwardedAddressing),
         },
       };
 

--- a/packages/jimmy/src/connectors/discord/index.ts
+++ b/packages/jimmy/src/connectors/discord/index.ts
@@ -1,6 +1,7 @@
 import {
   Client,
   GatewayIntentBits,
+  MessageReferenceType,
   Partials,
   type Message,
   type TextChannel,
@@ -157,8 +158,12 @@ export class DiscordConnector implements Connector {
       for (const chunk of chunks) {
         const sent = await (channel as TextChannel | DMChannel | ThreadChannel).send(chunk);
         lastId = sent.id;
+        // Record per chunk, so a partial send still counts as engagement.
+        // The sent message ID is an anchor too: a future public thread
+        // created from it reuses that ID.
+        if (channel.isThread()) this.engagedThreads.record(channel.id);
+        this.engagedThreads.record(sent.id);
       }
-      if (channel.isThread()) this.engagedThreads.record(channel.id);
       return lastId;
     } catch (err) {
       logger.error(`Discord sendMessage error: ${err instanceof Error ? err.message : err}`);
@@ -174,8 +179,12 @@ export class DiscordConnector implements Connector {
       for (const chunk of chunks) {
         const sent = await (channel as TextChannel | DMChannel | ThreadChannel).send(chunk);
         lastId = sent.id;
+        // Record per chunk, so a partial send still counts as engagement.
+        // The sent message ID is an anchor too: a future public thread
+        // created from it reuses that ID.
+        if (channel.isThread()) this.engagedThreads.record(channel.id);
+        this.engagedThreads.record(sent.id);
       }
-      if (channel.isThread()) this.engagedThreads.record(channel.id);
       return lastId;
     } catch (err) {
       logger.error(`Discord replyMessage error: ${err instanceof Error ? err.message : err}`);
@@ -201,7 +210,10 @@ export class DiscordConnector implements Connector {
       if (!channel || !channel.isTextBased()) return;
       const msg = await (channel as TextChannel).messages.fetch(target.messageTs);
       await msg.react(emoji);
+      // A reaction engages the surrounding thread, and marks the reacted
+      // message as an anchor — a future thread created from it shares its ID.
       if (channel.isThread()) this.engagedThreads.record(channel.id);
+      this.engagedThreads.record(target.messageTs);
     } catch {
       // non-fatal
     }
@@ -244,8 +256,9 @@ export class DiscordConnector implements Connector {
   }
 
   private async handleMessage(message: Message): Promise<void> {
-    // Ignore bots (including self)
-    if (message.author.bot) return;
+    // Ignore bots (including self), webhooks, and Discord-generated system
+    // messages (joins, pins, thread-created…) — none of these are user turns.
+    if (message.author.bot || message.system || message.webhookId) return;
     logger.debug(`Discord message from ${message.author.username} in channel ${message.channel.id}`);
 
     // Ignore old messages on boot
@@ -257,11 +270,15 @@ export class DiscordConnector implements Connector {
     // Guild restriction
     if (this.config.guildId && message.guild?.id !== this.config.guildId) return;
 
+    // Who does the message address? Resolved once, ahead of routing, so the
+    // receiving instance of a routed channel can apply its own respondTo gate.
+    const addressing = await this.resolveAddressing(message);
+
     // Channel routing — proxy messages to remote instances
     const routeTarget = this.config.channelRouting?.[message.channel.id];
     if (routeTarget) {
       logger.debug(`Routing Discord message from channel ${message.channel.id} to ${routeTarget}`);
-      await this.proxyToRemote(routeTarget, message);
+      await this.proxyToRemote(routeTarget, message, addressing);
       return;
     }
 
@@ -272,16 +289,9 @@ export class DiscordConnector implements Connector {
     if (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(message.author.id)) return;
 
     // Deterministic respondTo gate — the Discord port of the Slack gate.
-    // Applies only to locally handled messages: channelRouting proxies above
-    // this point, so routed channels are gated by the receiving instance.
     // botUserId is set once the client is ready (messageCreate never fires
     // earlier); if it were somehow missing, mention scopes fail closed.
     const isDM = message.channel.isDMBased();
-    const addressing = {
-      botUserId: this.client.user?.id,
-      mentionedUserIds: new Set(message.mentions.users.keys()),
-      repliedToUserId: message.mentions.repliedUser?.id,
-    };
     const respondDecision = evaluateRespondPolicy({
       config: this.config.respondTo,
       isDM,
@@ -354,8 +364,43 @@ export class DiscordConnector implements Connector {
     this.handler(incomingMessage);
   }
 
+  /**
+   * Resolve who the message addresses. `mentions.repliedUser` comes from the
+   * gateway's resolved reference and works whether or not the reply pinged;
+   * when Discord omitted the resolution, fall back to one fetch of the
+   * referenced message. Forwards are not replies and never resolve; a deleted
+   * reference stays undefined — no addressee.
+   */
+  private async resolveAddressing(message: Message): Promise<{
+    botUserId: string | undefined;
+    mentionedUserIds: Set<string>;
+    repliedToUserId: string | undefined;
+  }> {
+    let repliedToUserId = message.mentions.repliedUser?.id;
+    const isReply =
+      message.reference?.messageId !== undefined &&
+      (message.reference.type ?? MessageReferenceType.Default) === MessageReferenceType.Default;
+    if (repliedToUserId === undefined && isReply) {
+      try {
+        const referenced = await message.fetchReference();
+        repliedToUserId = referenced.author?.id;
+      } catch {
+        // Referenced message deleted or inaccessible.
+      }
+    }
+    return {
+      botUserId: this.client.user?.id,
+      mentionedUserIds: new Set(message.mentions.users.keys()),
+      repliedToUserId,
+    };
+  }
+
   /** Forward a message to a remote Jinn instance via HTTP */
-  private async proxyToRemote(remoteUrl: string, message: Message): Promise<void> {
+  private async proxyToRemote(
+    remoteUrl: string,
+    message: Message,
+    addressing: Parameters<typeof wasBotAddressed>[0],
+  ): Promise<void> {
     try {
       const attachments = Array.from(message.attachments.values()).map((att) => ({
         name: att.name,
@@ -379,6 +424,11 @@ export class DiscordConnector implements Connector {
             : "dm",
           guildId: message.guild?.id ?? null,
           isDM: message.channel.isDMBased(),
+          // Precomputed here (only this instance knows the bot user and can
+          // resolve references) so the receiving instance can apply its own
+          // respondTo gate without another Discord round-trip.
+          wasBotAddressed: wasBotAddressed(addressing),
+          addressesOnlyOthers: addressesOnlyOthers(addressing),
         },
       };
 

--- a/packages/jimmy/src/connectors/discord/index.ts
+++ b/packages/jimmy/src/connectors/discord/index.ts
@@ -11,6 +11,7 @@ import type {
   Connector,
   ConnectorCapabilities,
   ConnectorHealth,
+  DiscordRespondToConfig,
   IncomingMessage,
   Target,
 } from "../../shared/types.js";
@@ -18,6 +19,8 @@ import { logger } from "../../shared/logger.js";
 import { TMP_DIR } from "../../shared/paths.js";
 import { formatResponse, downloadAttachment } from "./format.js";
 import { deriveSessionKey, buildReplyContext, isOldMessage } from "./threads.js";
+import { evaluateRespondPolicy, wasBotAddressed, addressesOnlyOthers } from "./respond-policy.js";
+import { EngagedThreadTracker } from "./engaged-threads.js";
 
 export interface DiscordConnectorConfig {
   /** Unique instance identifier (e.g. "discord-vox") */
@@ -34,6 +37,8 @@ export interface DiscordConnectorConfig {
   channelRouting?: Record<string, string>;
   /** If set, this instance proxies all Discord operations through the primary instance at this URL */
   proxyVia?: string;
+  /** Deterministic per-scope response gate (DM / channel). See DiscordRespondToConfig. */
+  respondTo?: DiscordRespondToConfig;
 }
 
 export class DiscordConnector implements Connector {
@@ -47,6 +52,7 @@ export class DiscordConnector implements Connector {
   private status: "starting" | "running" | "stopped" | "error" = "starting";
   private lastError: string | null = null;
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
+  private engagedThreads = new EngagedThreadTracker();
 
   constructor(config: DiscordConnectorConfig) {
     this.name = config.id || "discord";
@@ -152,6 +158,7 @@ export class DiscordConnector implements Connector {
         const sent = await (channel as TextChannel | DMChannel | ThreadChannel).send(chunk);
         lastId = sent.id;
       }
+      if (channel.isThread()) this.engagedThreads.record(channel.id);
       return lastId;
     } catch (err) {
       logger.error(`Discord sendMessage error: ${err instanceof Error ? err.message : err}`);
@@ -168,6 +175,7 @@ export class DiscordConnector implements Connector {
         const sent = await (channel as TextChannel | DMChannel | ThreadChannel).send(chunk);
         lastId = sent.id;
       }
+      if (channel.isThread()) this.engagedThreads.record(channel.id);
       return lastId;
     } catch (err) {
       logger.error(`Discord replyMessage error: ${err instanceof Error ? err.message : err}`);
@@ -193,6 +201,7 @@ export class DiscordConnector implements Connector {
       if (!channel || !channel.isTextBased()) return;
       const msg = await (channel as TextChannel).messages.fetch(target.messageTs);
       await msg.react(emoji);
+      if (channel.isThread()) this.engagedThreads.record(channel.id);
     } catch {
       // non-fatal
     }
@@ -261,6 +270,42 @@ export class DiscordConnector implements Connector {
 
     // User allowlist
     if (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(message.author.id)) return;
+
+    // Deterministic respondTo gate — the Discord port of the Slack gate.
+    // Applies only to locally handled messages: channelRouting proxies above
+    // this point, so routed channels are gated by the receiving instance.
+    // botUserId is set once the client is ready (messageCreate never fires
+    // earlier); if it were somehow missing, mention scopes fail closed.
+    const isDM = message.channel.isDMBased();
+    const addressing = {
+      botUserId: this.client.user?.id,
+      mentionedUserIds: new Set(message.mentions.users.keys()),
+      repliedToUserId: message.mentions.repliedUser?.id,
+    };
+    const respondDecision = evaluateRespondPolicy({
+      config: this.config.respondTo,
+      isDM,
+      wasMentioned: wasBotAddressed(addressing),
+      isEngagedThread:
+        message.channel.isThread() && this.engagedThreads.has(message.channel.id),
+    });
+    if (!respondDecision.allow) {
+      logger.info(
+        `[discord] respondTo gate → silent (${respondDecision.reason}) for message ${message.id}`,
+      );
+      return;
+    }
+
+    // Cross-user traffic in shared channels: a message that @-mentions or
+    // replies to somebody else (and not us) is addressed to them, not the
+    // bot — stay silent regardless of respondTo mode or thread engagement,
+    // mirroring the Slack connector's sibling-mention rule.
+    if (!isDM && addressesOnlyOthers(addressing)) {
+      logger.info(
+        `[discord] message addresses other user(s) — staying silent for message ${message.id}`,
+      );
+      return;
+    }
 
     if (!this.handler) return;
 

--- a/packages/jimmy/src/connectors/discord/index.ts
+++ b/packages/jimmy/src/connectors/discord/index.ts
@@ -23,7 +23,6 @@ import { deriveSessionKey, buildReplyContext, isOldMessage } from "./threads.js"
 import {
   evaluateRespondPolicy,
   resolveRespondMode,
-  respondPolicyNeedsTracking,
   wasBotAddressed,
   addressesOnlyOthers,
   type ForwardedAddressing,
@@ -374,34 +373,43 @@ export class DiscordConnector implements Connector {
   }
 
   /**
-   * Track engagement for the `respondTo.engagedThreads` continuation.
-   * Recording is skipped entirely unless something can consume it (a mention
-   * scope with engagedThreads on, or channelRouting — the receiving instance
-   * may be mention-gated), and only anchor-eligible IDs are kept: the thread
-   * itself, or — in flat guild channels — the acted-on message, since a
-   * public thread created from a message reuses its ID. DM and in-thread
-   * message IDs can never root a thread and are never recorded, which keeps
-   * the unbounded tracker's real footprint small.
+   * Track engagement for the `respondTo.engagedThreads` continuation. Only
+   * anchor-eligible IDs whose engagement can actually be consumed are kept:
+   * the thread itself, or — in flat guild channels — the acted-on message,
+   * since a public thread created from a message reuses its ID. DM and
+   * in-thread message IDs can never root a thread and are never recorded,
+   * which keeps the unbounded tracker's real footprint small.
    */
   private recordEngagement(
     channel: { id: string; isThread(): boolean; isDMBased(): boolean },
     anchorMessageId?: string,
   ): void {
-    if (!this.trackingEnabled()) return;
     if (channel.isThread()) {
-      this.engagedThreads.record(channel.id);
+      if (this.trackingConsumes(channel.id)) this.engagedThreads.record(channel.id);
       return;
     }
-    if (anchorMessageId && !channel.isDMBased()) {
+    if (anchorMessageId && !channel.isDMBased() && this.trackingConsumes(anchorMessageId)) {
       this.engagedThreads.record(anchorMessageId);
     }
   }
 
-  private trackingEnabled(): boolean {
-    return (
-      respondPolicyNeedsTracking(this.config.respondTo) ||
-      Object.keys(this.config.channelRouting ?? {}).length > 0
-    );
+  /**
+   * True when engagement recorded under this id can ever be read back. The
+   * local gate consults the tracker only when the channel scope is
+   * mention-gated with engagedThreads on (DMs have no threads, so dm=mention
+   * alone consumes nothing). The routed path consults it only for messages
+   * whose own channel id is a channelRouting key — thread messages route by
+   * their thread id, which for a public thread equals the message it was
+   * rooted on — so ids outside the routing table are never read there.
+   */
+  private trackingConsumes(id: string): boolean {
+    if (
+      resolveRespondMode(this.config.respondTo, "channel") === "mention" &&
+      this.config.respondTo?.engagedThreads !== false
+    ) {
+      return true;
+    }
+    return this.config.channelRouting?.[id] !== undefined;
   }
 
   /**

--- a/packages/jimmy/src/connectors/discord/index.ts
+++ b/packages/jimmy/src/connectors/discord/index.ts
@@ -1,7 +1,7 @@
 import {
   Client,
   GatewayIntentBits,
-  MessageReferenceType,
+  MessageType,
   Partials,
   type Message,
   type TextChannel,
@@ -20,7 +20,12 @@ import { logger } from "../../shared/logger.js";
 import { TMP_DIR } from "../../shared/paths.js";
 import { formatResponse, downloadAttachment } from "./format.js";
 import { deriveSessionKey, buildReplyContext, isOldMessage } from "./threads.js";
-import { evaluateRespondPolicy, wasBotAddressed, addressesOnlyOthers } from "./respond-policy.js";
+import {
+  evaluateRespondPolicy,
+  resolveRespondMode,
+  wasBotAddressed,
+  addressesOnlyOthers,
+} from "./respond-policy.js";
 import { EngagedThreadTracker } from "./engaged-threads.js";
 
 export interface DiscordConnectorConfig {
@@ -270,14 +275,14 @@ export class DiscordConnector implements Connector {
     // Guild restriction
     if (this.config.guildId && message.guild?.id !== this.config.guildId) return;
 
-    // Who does the message address? Resolved once, ahead of routing, so the
-    // receiving instance of a routed channel can apply its own respondTo gate.
-    const addressing = await this.resolveAddressing(message);
-
-    // Channel routing — proxy messages to remote instances
+    // Channel routing — proxy messages to remote instances. Addressing and
+    // thread engagement are resolved here and forwarded: only this instance
+    // sees the Discord gateway, and proxied sends run through this
+    // connector, so its tracker is the source of truth for engagement.
     const routeTarget = this.config.channelRouting?.[message.channel.id];
     if (routeTarget) {
       logger.debug(`Routing Discord message from channel ${message.channel.id} to ${routeTarget}`);
+      const addressing = await this.resolveAddressing(message, { allowFetch: true });
       await this.proxyToRemote(routeTarget, message, addressing);
       return;
     }
@@ -289,9 +294,15 @@ export class DiscordConnector implements Connector {
     if (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(message.author.id)) return;
 
     // Deterministic respondTo gate — the Discord port of the Slack gate.
+    // Addressing resolves after the cheap filters above, so filtered
+    // messages never cost a reference fetch; in DMs the fetch only matters
+    // under dm=mention (the sibling rule below never applies to DMs).
     // botUserId is set once the client is ready (messageCreate never fires
     // earlier); if it were somehow missing, mention scopes fail closed.
     const isDM = message.channel.isDMBased();
+    const addressing = await this.resolveAddressing(message, {
+      allowFetch: !isDM || resolveRespondMode(this.config.respondTo, "dm") === "mention",
+    });
     const respondDecision = evaluateRespondPolicy({
       config: this.config.respondTo,
       isDM,
@@ -365,22 +376,25 @@ export class DiscordConnector implements Connector {
   }
 
   /**
-   * Resolve who the message addresses. `mentions.repliedUser` comes from the
-   * gateway's resolved reference and works whether or not the reply pinged;
-   * when Discord omitted the resolution, fall back to one fetch of the
-   * referenced message. Forwards are not replies and never resolve; a deleted
-   * reference stays undefined — no addressee.
+   * Resolve who the message addresses. Reply attribution applies only to
+   * actual replies (`MessageType.Reply`) — a crosspost or forward also
+   * carries a `reference` but addresses nobody. `mentions.repliedUser` comes
+   * from the gateway's resolved reference and works whether or not the reply
+   * pinged; when Discord omitted the resolution and `allowFetch` is set,
+   * fall back to one fetch of the referenced message. A deleted reference
+   * stays undefined — no addressee.
    */
-  private async resolveAddressing(message: Message): Promise<{
+  private async resolveAddressing(
+    message: Message,
+    opts: { allowFetch: boolean },
+  ): Promise<{
     botUserId: string | undefined;
     mentionedUserIds: Set<string>;
     repliedToUserId: string | undefined;
   }> {
-    let repliedToUserId = message.mentions.repliedUser?.id;
-    const isReply =
-      message.reference?.messageId !== undefined &&
-      (message.reference.type ?? MessageReferenceType.Default) === MessageReferenceType.Default;
-    if (repliedToUserId === undefined && isReply) {
+    const isReply = message.type === MessageType.Reply;
+    let repliedToUserId = isReply ? message.mentions.repliedUser?.id : undefined;
+    if (isReply && repliedToUserId === undefined && opts.allowFetch && message.reference?.messageId) {
       try {
         const referenced = await message.fetchReference();
         repliedToUserId = referenced.author?.id;
@@ -424,11 +438,14 @@ export class DiscordConnector implements Connector {
             : "dm",
           guildId: message.guild?.id ?? null,
           isDM: message.channel.isDMBased(),
-          // Precomputed here (only this instance knows the bot user and can
-          // resolve references) so the receiving instance can apply its own
-          // respondTo gate without another Discord round-trip.
+          // ForwardedAddressing — precomputed here (only this instance knows
+          // the bot user, resolves references, and tracks engagement) so the
+          // receiving instance can apply its own respondTo gate without
+          // another Discord round-trip.
           wasBotAddressed: wasBotAddressed(addressing),
           addressesOnlyOthers: addressesOnlyOthers(addressing),
+          isEngagedThread:
+            message.channel.isThread() && this.engagedThreads.has(message.channel.id),
         },
       };
 

--- a/packages/jimmy/src/connectors/discord/remote.ts
+++ b/packages/jimmy/src/connectors/discord/remote.ts
@@ -7,7 +7,12 @@ import type {
   Target,
 } from "../../shared/types.js";
 import { logger } from "../../shared/logger.js";
-import { evaluateRespondPolicy, hasMentionScope } from "./respond-policy.js";
+import {
+  evaluateRespondPolicy,
+  parseForwardedAddressing,
+  resolveRespondMode,
+  scopeForChannel,
+} from "./respond-policy.js";
 
 export interface RemoteDiscordConfig {
   /** URL of the primary Jinn instance that holds the Discord WebSocket connection */
@@ -44,27 +49,28 @@ export class RemoteDiscordConnector implements Connector {
     const isDM = meta.isDM === true;
     // Addressing (ForwardedAddressing) is resolved by the primary instance:
     // only it sees the Discord gateway, and it also tracks thread engagement
-    // — proxied sends run through its connector. transportMeta is untyped
-    // JSON, so each flag is re-validated with `=== true`. When the flags are
-    // absent — an older primary — mention scopes fail closed (Slack
+    // — proxied sends run through its connector. When the flags are absent —
+    // a primary too old to send them — mention scopes fail closed (Slack
     // precedent for unresolvable identity) and the sibling rule stays off
-    // (never drop an "always" message on missing metadata); warn once so
-    // the required upgrade order is visible instead of a silent blackhole.
+    // (never drop an "always" message on missing metadata). Warn once, and
+    // only when a message actually lands in a mention-gated scope, so the
+    // required upgrade order is visible instead of a silent blackhole.
+    const { present, flags } = parseForwardedAddressing(meta);
     if (
-      !("wasBotAddressed" in meta) &&
-      hasMentionScope(this.respondTo) &&
+      !present &&
+      resolveRespondMode(this.respondTo, scopeForChannel(isDM)) === "mention" &&
       !this.warnedMissingAddressing
     ) {
       this.warnedMissingAddressing = true;
       logger.warn(
-        "[discord-remote] primary instance does not forward addressing metadata (its version predates respondTo) — mention scopes will drop every routed message until the primary is upgraded",
+        "[discord-remote] primary instance does not forward addressing metadata (its version predates respondTo) — routed messages in mention scopes are dropped until the primary is upgraded",
       );
     }
     const respondDecision = evaluateRespondPolicy({
       config: this.respondTo,
       isDM,
-      wasMentioned: meta.wasBotAddressed === true,
-      isEngagedThread: meta.isEngagedThread === true,
+      wasMentioned: flags.wasBotAddressed,
+      isEngagedThread: flags.isEngagedThread,
     });
     if (!respondDecision.allow) {
       logger.info(
@@ -72,7 +78,7 @@ export class RemoteDiscordConnector implements Connector {
       );
       return;
     }
-    if (!isDM && meta.addressesOnlyOthers === true) {
+    if (!isDM && flags.addressesOnlyOthers) {
       logger.info(
         `[discord-remote] message addresses other user(s) — staying silent for message ${msg.messageId}`,
       );

--- a/packages/jimmy/src/connectors/discord/remote.ts
+++ b/packages/jimmy/src/connectors/discord/remote.ts
@@ -2,15 +2,20 @@ import type {
   Connector,
   ConnectorCapabilities,
   ConnectorHealth,
+  DiscordRespondToConfig,
   IncomingMessage,
   Target,
 } from "../../shared/types.js";
 import { logger } from "../../shared/logger.js";
+import { evaluateRespondPolicy } from "./respond-policy.js";
+import { EngagedThreadTracker } from "./engaged-threads.js";
 
 export interface RemoteDiscordConfig {
   /** URL of the primary Jinn instance that holds the Discord WebSocket connection */
   proxyVia: string;
   channelId?: string;
+  /** Deterministic per-scope response gate, applied to proxied messages. */
+  respondTo?: DiscordRespondToConfig;
 }
 
 /**
@@ -22,9 +27,12 @@ export class RemoteDiscordConnector implements Connector {
   name = "discord";
   private handler: ((msg: IncomingMessage) => void) | null = null;
   private baseUrl: string;
+  private readonly respondTo: DiscordRespondToConfig | undefined;
+  private engagedThreads = new EngagedThreadTracker();
 
   constructor(config: RemoteDiscordConfig) {
     this.baseUrl = config.proxyVia.replace(/\/+$/, "");
+    this.respondTo = config.respondTo;
   }
 
   onMessage(handler: (msg: IncomingMessage) => void): void {
@@ -33,6 +41,30 @@ export class RemoteDiscordConnector implements Connector {
 
   /** Called by the /api/connectors/discord/incoming endpoint to deliver proxied messages */
   deliverMessage(msg: IncomingMessage): void {
+    const meta = (msg.transportMeta ?? {}) as Record<string, unknown>;
+    const isDM = meta.isDM === true;
+    // Addressing flags are resolved by the primary instance — only it can see
+    // the Discord gateway. When a flag is absent (older primary), fall to the
+    // conservative side: no mention (mention scopes fail closed) and no other
+    // addressee (never drop an "always" message on missing metadata).
+    const respondDecision = evaluateRespondPolicy({
+      config: this.respondTo,
+      isDM,
+      wasMentioned: meta.wasBotAddressed === true,
+      isEngagedThread: !!msg.thread && this.engagedThreads.has(msg.thread),
+    });
+    if (!respondDecision.allow) {
+      logger.info(
+        `[discord-remote] respondTo gate → silent (${respondDecision.reason}) for message ${msg.messageId}`,
+      );
+      return;
+    }
+    if (!isDM && meta.addressesOnlyOthers === true) {
+      logger.info(
+        `[discord-remote] message addresses other user(s) — staying silent for message ${msg.messageId}`,
+      );
+      return;
+    }
     if (this.handler) {
       this.handler(msg);
     }
@@ -72,11 +104,15 @@ export class RemoteDiscordConnector implements Connector {
   }
 
   async sendMessage(target: Target, text: string): Promise<string | undefined> {
-    return this.proxyAction("sendMessage", { target, text });
+    const messageId = await this.proxyAction("sendMessage", { target, text });
+    this.recordEngagement(target, messageId);
+    return messageId;
   }
 
   async replyMessage(target: Target, text: string): Promise<string | undefined> {
-    return this.proxyAction("replyMessage", { target, text });
+    const messageId = await this.proxyAction("replyMessage", { target, text });
+    this.recordEngagement(target, messageId);
+    return messageId;
   }
 
   async editMessage(target: Target, text: string): Promise<void> {
@@ -85,6 +121,7 @@ export class RemoteDiscordConnector implements Connector {
 
   async addReaction(target: Target, emoji: string): Promise<void> {
     await this.proxyAction("addReaction", { target, emoji });
+    this.recordEngagement(target, target.messageTs);
   }
 
   async removeReaction(target: Target, emoji: string): Promise<void> {
@@ -93,6 +130,16 @@ export class RemoteDiscordConnector implements Connector {
 
   async setTypingStatus(channelId: string, threadTs: string | undefined, status: string): Promise<void> {
     await this.proxyAction("setTypingStatus", { channelId, threadTs, status });
+  }
+
+  /**
+   * Record engagement for the `respondTo.engagedThreads` continuation: the
+   * thread the bot acted in, and the message ID that anchors it — a future
+   * public thread created from that message reuses its ID.
+   */
+  private recordEngagement(target: Target, anchorMessageId: string | undefined): void {
+    if (target.thread) this.engagedThreads.record(target.thread);
+    if (anchorMessageId) this.engagedThreads.record(anchorMessageId);
   }
 
   private async proxyAction(action: string, params: Record<string, unknown>): Promise<string | undefined> {

--- a/packages/jimmy/src/connectors/discord/remote.ts
+++ b/packages/jimmy/src/connectors/discord/remote.ts
@@ -7,8 +7,7 @@ import type {
   Target,
 } from "../../shared/types.js";
 import { logger } from "../../shared/logger.js";
-import { evaluateRespondPolicy } from "./respond-policy.js";
-import { EngagedThreadTracker } from "./engaged-threads.js";
+import { evaluateRespondPolicy, hasMentionScope } from "./respond-policy.js";
 
 export interface RemoteDiscordConfig {
   /** URL of the primary Jinn instance that holds the Discord WebSocket connection */
@@ -28,7 +27,7 @@ export class RemoteDiscordConnector implements Connector {
   private handler: ((msg: IncomingMessage) => void) | null = null;
   private baseUrl: string;
   private readonly respondTo: DiscordRespondToConfig | undefined;
-  private engagedThreads = new EngagedThreadTracker();
+  private warnedMissingAddressing = false;
 
   constructor(config: RemoteDiscordConfig) {
     this.baseUrl = config.proxyVia.replace(/\/+$/, "");
@@ -43,15 +42,29 @@ export class RemoteDiscordConnector implements Connector {
   deliverMessage(msg: IncomingMessage): void {
     const meta = (msg.transportMeta ?? {}) as Record<string, unknown>;
     const isDM = meta.isDM === true;
-    // Addressing flags are resolved by the primary instance — only it can see
-    // the Discord gateway. When a flag is absent (older primary), fall to the
-    // conservative side: no mention (mention scopes fail closed) and no other
-    // addressee (never drop an "always" message on missing metadata).
+    // Addressing (ForwardedAddressing) is resolved by the primary instance:
+    // only it sees the Discord gateway, and it also tracks thread engagement
+    // — proxied sends run through its connector. transportMeta is untyped
+    // JSON, so each flag is re-validated with `=== true`. When the flags are
+    // absent — an older primary — mention scopes fail closed (Slack
+    // precedent for unresolvable identity) and the sibling rule stays off
+    // (never drop an "always" message on missing metadata); warn once so
+    // the required upgrade order is visible instead of a silent blackhole.
+    if (
+      !("wasBotAddressed" in meta) &&
+      hasMentionScope(this.respondTo) &&
+      !this.warnedMissingAddressing
+    ) {
+      this.warnedMissingAddressing = true;
+      logger.warn(
+        "[discord-remote] primary instance does not forward addressing metadata (its version predates respondTo) — mention scopes will drop every routed message until the primary is upgraded",
+      );
+    }
     const respondDecision = evaluateRespondPolicy({
       config: this.respondTo,
       isDM,
       wasMentioned: meta.wasBotAddressed === true,
-      isEngagedThread: !!msg.thread && this.engagedThreads.has(msg.thread),
+      isEngagedThread: meta.isEngagedThread === true,
     });
     if (!respondDecision.allow) {
       logger.info(
@@ -104,15 +117,11 @@ export class RemoteDiscordConnector implements Connector {
   }
 
   async sendMessage(target: Target, text: string): Promise<string | undefined> {
-    const messageId = await this.proxyAction("sendMessage", { target, text });
-    this.recordEngagement(target, messageId);
-    return messageId;
+    return this.proxyAction("sendMessage", { target, text });
   }
 
   async replyMessage(target: Target, text: string): Promise<string | undefined> {
-    const messageId = await this.proxyAction("replyMessage", { target, text });
-    this.recordEngagement(target, messageId);
-    return messageId;
+    return this.proxyAction("replyMessage", { target, text });
   }
 
   async editMessage(target: Target, text: string): Promise<void> {
@@ -121,7 +130,6 @@ export class RemoteDiscordConnector implements Connector {
 
   async addReaction(target: Target, emoji: string): Promise<void> {
     await this.proxyAction("addReaction", { target, emoji });
-    this.recordEngagement(target, target.messageTs);
   }
 
   async removeReaction(target: Target, emoji: string): Promise<void> {
@@ -130,16 +138,6 @@ export class RemoteDiscordConnector implements Connector {
 
   async setTypingStatus(channelId: string, threadTs: string | undefined, status: string): Promise<void> {
     await this.proxyAction("setTypingStatus", { channelId, threadTs, status });
-  }
-
-  /**
-   * Record engagement for the `respondTo.engagedThreads` continuation: the
-   * thread the bot acted in, and the message ID that anchors it — a future
-   * public thread created from that message reuses its ID.
-   */
-  private recordEngagement(target: Target, anchorMessageId: string | undefined): void {
-    if (target.thread) this.engagedThreads.record(target.thread);
-    if (anchorMessageId) this.engagedThreads.record(anchorMessageId);
   }
 
   private async proxyAction(action: string, params: Record<string, unknown>): Promise<string | undefined> {

--- a/packages/jimmy/src/connectors/discord/respond-policy.ts
+++ b/packages/jimmy/src/connectors/discord/respond-policy.ts
@@ -91,6 +91,23 @@ export function wasBotAddressed(input: {
 }
 
 /**
+ * Addressing the primary Discord instance forwards with a routed message
+ * (inside `transportMeta`), so the receiving instance can gate without its
+ * own Discord connection. transportMeta is untyped JSON on the wire, so the
+ * receiving side re-validates each flag with `=== true`. An older primary
+ * sends none of these; mention scopes then fail closed on the receiver —
+ * upgrade the primary before enabling a mention scope on a routed instance.
+ */
+export interface ForwardedAddressing {
+  /** The message @-mentions the bot or replies to one of its messages. */
+  wasBotAddressed: boolean;
+  /** The message @-mentions or replies to somebody else, and not the bot. */
+  addressesOnlyOthers: boolean;
+  /** The message sits in a thread the bot has engaged (primary's tracker). */
+  isEngagedThread: boolean;
+}
+
+/**
  * True when the message explicitly addresses somebody else and not the bot:
  * it @-mentions specific user(s), or replies to another user's message, and
  * none of those users is the bot. Such messages stay silent even in "always"

--- a/packages/jimmy/src/connectors/discord/respond-policy.ts
+++ b/packages/jimmy/src/connectors/discord/respond-policy.ts
@@ -108,6 +108,26 @@ export interface ForwardedAddressing {
 }
 
 /**
+ * Parse ForwardedAddressing back out of a routed message's transportMeta.
+ * `present` is false when the primary predates the contract (flags missing
+ * from the wire) — the caller decides how loudly to surface that. Flags are
+ * re-validated with `=== true`: the wire is untyped JSON.
+ */
+export function parseForwardedAddressing(meta: Record<string, unknown>): {
+  present: boolean;
+  flags: ForwardedAddressing;
+} {
+  return {
+    present: "wasBotAddressed" in meta && "isEngagedThread" in meta,
+    flags: {
+      wasBotAddressed: meta.wasBotAddressed === true,
+      addressesOnlyOthers: meta.addressesOnlyOthers === true,
+      isEngagedThread: meta.isEngagedThread === true,
+    },
+  };
+}
+
+/**
  * True when the message explicitly addresses somebody else and not the bot:
  * it @-mentions specific user(s), or replies to another user's message, and
  * none of those users is the bot. Such messages stay silent even in "always"

--- a/packages/jimmy/src/connectors/discord/respond-policy.ts
+++ b/packages/jimmy/src/connectors/discord/respond-policy.ts
@@ -1,0 +1,108 @@
+/**
+ * Deterministic response gate for the Discord connector.
+ *
+ * Port of the Slack `respondTo` gate (see ../slack/respond-policy.ts).
+ * Evaluated before the message reaches the session engine, so "mention"-gated
+ * scopes cost zero tokens and zero latency for dropped messages.
+ *
+ * Scope mapping (discord.js channel):
+ *   - `isDMBased()` (1:1 DMs and group DMs) → dm
+ *   - guild text channels and threads       → channel
+ *
+ * Unlike Slack there is no LLM triage layer on this connector, so the gate is
+ * the only thing between an incoming channel message and a full engine reply.
+ */
+import type { DiscordRespondMode, DiscordRespondToConfig } from "../../shared/types.js";
+
+export type DiscordRespondScope = "dm" | "channel";
+
+export function scopeForChannel(isDM: boolean): DiscordRespondScope {
+  return isDM ? "dm" : "channel";
+}
+
+/**
+ * Resolve the effective mode for a scope. Unset or unrecognized values fall
+ * back to "always" — config files are hand-edited YAML, so an invalid value
+ * must degrade to the legacy behavior rather than silence the bot.
+ */
+export function resolveRespondMode(
+  config: DiscordRespondToConfig | undefined,
+  scope: DiscordRespondScope,
+): DiscordRespondMode {
+  const raw = config?.[scope];
+  return raw === "mention" || raw === "never" ? raw : "always";
+}
+
+/** True when any scope requires an @-mention. */
+export function hasMentionScope(config: DiscordRespondToConfig | undefined): boolean {
+  if (!config) return false;
+  return [config.dm, config.channel].includes("mention");
+}
+
+/**
+ * True when the policy needs engaged-thread tracking: some scope is
+ * mention-gated and engaged-thread continuation (the default) is on.
+ */
+export function respondPolicyNeedsTracking(config: DiscordRespondToConfig | undefined): boolean {
+  return hasMentionScope(config) && config?.engagedThreads !== false;
+}
+
+export interface RespondPolicyInput {
+  config: DiscordRespondToConfig | undefined;
+  isDM: boolean;
+  wasMentioned: boolean;
+  /** Whether the message sits in a thread the bot has already engaged. */
+  isEngagedThread: boolean;
+}
+
+export type RespondDecision = { allow: true } | { allow: false; reason: string };
+
+export function evaluateRespondPolicy(input: RespondPolicyInput): RespondDecision {
+  const scope = scopeForChannel(input.isDM);
+  const mode = resolveRespondMode(input.config, scope);
+  if (mode === "never") {
+    return { allow: false, reason: `respondTo.${scope}=never` };
+  }
+  if (mode === "mention" && !input.wasMentioned) {
+    if (input.config?.engagedThreads !== false && input.isEngagedThread) {
+      return { allow: true };
+    }
+    return { allow: false, reason: `respondTo.${scope}=mention and message has no @-mention` };
+  }
+  return { allow: true };
+}
+
+/**
+ * True when the message addresses the bot: a direct @-mention, or a Discord
+ * reply to one of the bot's messages. Reply detection uses the replied-to
+ * author from the resolved reference, so it works whether or not the reply
+ * pinged ("@ ON"/"@ OFF") — replying to the bot is addressing the bot either
+ * way. Role mentions and @everyone/@here deliberately do NOT count, matching
+ * the Slack gate where @channel/@here never satisfy "mention".
+ */
+export function wasBotAddressed(input: {
+  botUserId: string | undefined;
+  mentionedUserIds: ReadonlySet<string>;
+  repliedToUserId: string | undefined;
+}): boolean {
+  if (!input.botUserId) return false;
+  if (input.mentionedUserIds.has(input.botUserId)) return true;
+  return input.repliedToUserId === input.botUserId;
+}
+
+/**
+ * True when the message explicitly addresses somebody else and not the bot:
+ * it @-mentions specific user(s), or replies to another user's message, and
+ * none of those users is the bot. Such messages stay silent even in "always"
+ * scopes — same sibling-mention rule as the Slack connector. Never applies to
+ * DMs, and @everyone/@here alone never triggers it (no specific addressee).
+ */
+export function addressesOnlyOthers(input: {
+  botUserId: string | undefined;
+  mentionedUserIds: ReadonlySet<string>;
+  repliedToUserId: string | undefined;
+}): boolean {
+  if (!input.botUserId) return false;
+  if (wasBotAddressed(input)) return false;
+  return input.mentionedUserIds.size > 0 || input.repliedToUserId !== undefined;
+}

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -409,6 +409,7 @@ export async function startGateway(
         const discord = new RemoteDiscordConnector({
           proxyVia: cfg.connectors.discord.proxyVia,
           channelId: cfg.connectors.discord.channelId,
+          respondTo: cfg.connectors.discord.respondTo,
         });
         discord.onMessage((msg) => {
           const routeOpts: RouteOptions = {};

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -479,6 +479,29 @@ export interface SlackConnectorConfig {
   };
 }
 
+/** Response mode for one Discord conversation scope. */
+export type DiscordRespondMode = "always" | "mention" | "never";
+
+/**
+ * Deterministic response gate for the Discord connector — the Discord port of
+ * `SlackRespondToConfig`. Absent (or "always" in every scope) preserves the
+ * legacy respond-to-everything behavior. "mention" scopes drop messages that
+ * neither @-mention the bot nor reply to one of its messages, except inside
+ * threads the bot has already engaged (see `engagedThreads`).
+ */
+export interface DiscordRespondToConfig {
+  /** 1:1 and group DMs. Default: "always". */
+  dm?: DiscordRespondMode;
+  /** Guild text channels and threads. Default: "always". */
+  channel?: DiscordRespondMode;
+  /**
+   * In "mention" scopes, keep replying inside threads the bot has already
+   * engaged (replied or reacted in) without requiring a re-mention on every
+   * message. Default: true.
+   */
+  engagedThreads?: boolean;
+}
+
 export interface DiscordConnectorConfig {
   /** Unique instance identifier (e.g. "discord-vox") */
   id?: string;
@@ -494,6 +517,8 @@ export interface DiscordConnectorConfig {
   channelRouting?: Record<string, string>;
   /** URL of the primary Jinn instance to proxy Discord I/O through (secondary/remote mode) */
   proxyVia?: string;
+  /** Deterministic per-scope response gate (DM / channel). */
+  respondTo?: DiscordRespondToConfig;
 }
 
 export interface TelegramConnectorConfig {

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -484,10 +484,13 @@ export type DiscordRespondMode = "always" | "mention" | "never";
 
 /**
  * Deterministic response gate for the Discord connector — the Discord port of
- * `SlackRespondToConfig`. Absent (or "always" in every scope) preserves the
- * legacy respond-to-everything behavior. "mention" scopes drop messages that
- * neither @-mention the bot nor reply to one of its messages, except inside
- * threads the bot has already engaged (see `engagedThreads`).
+ * `SlackRespondToConfig`. "mention" scopes drop messages that neither
+ * @-mention the bot nor reply to one of its messages, except inside threads
+ * the bot has already engaged (see `engagedThreads`). Absent (or "always" in
+ * every scope) keeps responding to every message, with one deliberate
+ * exception that applies regardless of this config (Slack parity): channel
+ * messages that @-mention or reply to somebody else — and not the bot — are
+ * always ignored.
  */
 export interface DiscordRespondToConfig {
   /** 1:1 and group DMs. Default: "always". */

--- a/packages/jimmy/template/docs/connectors.md
+++ b/packages/jimmy/template/docs/connectors.md
@@ -128,17 +128,21 @@ Modes per scope: `always` | `mention` | `never` — same semantics as the Slack
 gate, with Discord-specific mention rules:
 
 - A Discord **reply** to one of the bot's messages counts as a mention,
-  whether or not the reply pinged. In flat channels (no thread), reply to the
-  bot or re-mention it to continue a conversation.
+  whether or not the reply pinged (if the replied-to message was since
+  deleted, the reply can no longer be attributed and does not count). In flat
+  channels (no thread), reply to the bot or re-mention it to continue a
+  conversation.
 - Role mentions and `@everyone`/`@here` do **not** count as mentions.
 - Messages that @-mention or reply to *somebody else* (and not the bot) are
-  always ignored outside DMs, even in `always` scopes — they're addressed to
-  that person, not the bot.
-- Channels proxied via `channelRouting` are gated by the receiving instance's
-  policy, not the sender's.
-- Unset scopes default to `always`, so existing configs keep the legacy
-  respond-to-everything behavior. There is no triage layer on Discord — this
-  gate is the only response filter.
+  always ignored outside DMs, even in `always` scopes and even with
+  `respondTo` unset — they're addressed to that person, not the bot. This is
+  an intentional behavior change from earlier releases (Slack parity), and
+  the one way an unconfigured connector no longer responds to everything.
+- Channels proxied via `channelRouting` are gated by the *receiving*
+  instance's `respondTo`, not the sender's — the primary forwards the
+  resolved addressing so the remote can decide without a Discord round-trip.
+- Unset scopes default to `always`. There is no triage layer on Discord —
+  this gate is the only response filter.
 
 ## Future Connectors
 

--- a/packages/jimmy/template/docs/connectors.md
+++ b/packages/jimmy/template/docs/connectors.md
@@ -132,8 +132,9 @@ gate, with Discord-specific mention rules:
   whether or not the reply pinged (if the replied-to message was since
   deleted, the reply can no longer be attributed and does not count). In flat
   channels (no thread), reply to the bot or re-mention it to continue a
-  conversation. Thread engagement is tracked in memory and resets when the
-  gateway restarts — mention the bot once more after a restart.
+  conversation. Thread engagement is tracked in memory and resets whenever
+  the connector is recreated — a gateway restart, a config save, or a
+  connector reload — mention the bot once more afterwards.
 - Role mentions and `@everyone`/`@here` do **not** count as mentions.
 - Messages that @-mention or reply to *somebody else* (and not the bot) are
   always ignored outside DMs, even in `always` scopes and even with

--- a/packages/jimmy/template/docs/connectors.md
+++ b/packages/jimmy/template/docs/connectors.md
@@ -110,8 +110,9 @@ connectors:
 ### Response Gating (`respondTo`)
 
 The Discord port of the Slack gate. By default the bot responds to every
-message it can see; `respondTo` adds a deterministic gate so gated messages
-never reach the engine:
+message it can see, with one deliberate exception described below (messages
+addressed to somebody else); `respondTo` adds a deterministic gate so gated
+messages never reach the engine:
 
 ```yaml
 connectors:
@@ -131,7 +132,8 @@ gate, with Discord-specific mention rules:
   whether or not the reply pinged (if the replied-to message was since
   deleted, the reply can no longer be attributed and does not count). In flat
   channels (no thread), reply to the bot or re-mention it to continue a
-  conversation.
+  conversation. Thread engagement is tracked in memory and resets when the
+  gateway restarts — mention the bot once more after a restart.
 - Role mentions and `@everyone`/`@here` do **not** count as mentions.
 - Messages that @-mention or reply to *somebody else* (and not the bot) are
   always ignored outside DMs, even in `always` scopes and even with
@@ -141,6 +143,9 @@ gate, with Discord-specific mention rules:
 - Channels proxied via `channelRouting` are gated by the *receiving*
   instance's `respondTo`, not the sender's — the primary forwards the
   resolved addressing so the remote can decide without a Discord round-trip.
+  Upgrade the primary first: a primary too old to forward addressing leaves
+  the receiver's mention scopes fail-closed (every routed message dropped,
+  with a warning in the receiver's log).
 - Unset scopes default to `always`. There is no triage layer on Discord —
   this gate is the only response filter.
 

--- a/packages/jimmy/template/docs/connectors.md
+++ b/packages/jimmy/template/docs/connectors.md
@@ -93,10 +93,56 @@ Reactions provide visual feedback during processing:
 - `@mention`: messages mentioning a specific employee name route to that employee
 - Thread continuity: replies in a thread continue with the same employee
 
+## Discord Connector
+
+Uses `discord.js` over the Discord gateway (no public URL required).
+
+### Configuration
+
+```yaml
+connectors:
+  discord:
+    botToken: ...         # Discord bot token
+    guildId: ...          # optional: only handle messages from this guild
+    channelId: ...        # optional: only handle messages from this channel
+```
+
+### Response Gating (`respondTo`)
+
+The Discord port of the Slack gate. By default the bot responds to every
+message it can see; `respondTo` adds a deterministic gate so gated messages
+never reach the engine:
+
+```yaml
+connectors:
+  discord:
+    respondTo:
+      dm: always            # 1:1 and group DMs (default: always)
+      channel: mention      # guild channels/threads — reply only when
+                            # @-mentioned or replied to (default: always)
+      engagedThreads: true  # keep replying inside threads the bot already
+                            # engaged, without a re-mention (default: true)
+```
+
+Modes per scope: `always` | `mention` | `never` — same semantics as the Slack
+gate, with Discord-specific mention rules:
+
+- A Discord **reply** to one of the bot's messages counts as a mention,
+  whether or not the reply pinged. In flat channels (no thread), reply to the
+  bot or re-mention it to continue a conversation.
+- Role mentions and `@everyone`/`@here` do **not** count as mentions.
+- Messages that @-mention or reply to *somebody else* (and not the bot) are
+  always ignored outside DMs, even in `always` scopes — they're addressed to
+  that person, not the bot.
+- Channels proxied via `channelRouting` are gated by the receiving instance's
+  policy, not the sender's.
+- Unset scopes default to `always`, so existing configs keep the legacy
+  respond-to-everything behavior. There is no triage layer on Discord — this
+  gate is the only response filter.
+
 ## Future Connectors
 
 The connector interface is designed for additional platforms:
-- **Discord**: Bot integration via discord.js
 - **iMessage**: macOS-only via AppleScript bridge
 - **Web UI**: Built-in, served by the HTTP server
 - **CLI**: Direct terminal input/output

--- a/packages/web/src/app/settings/page.tsx
+++ b/packages/web/src/app/settings/page.tsx
@@ -190,6 +190,11 @@ interface Config {
       allowFrom?: string | string[]
       guildId?: string
       channelId?: string
+      respondTo?: {
+        dm?: "always" | "mention" | "never"
+        channel?: "always" | "mention" | "never"
+        engagedThreads?: boolean
+      }
     }
     telegram?: {
       botToken?: string
@@ -1934,6 +1939,41 @@ export default function SettingsPage() {
                       updateConfig(["connectors", "discord", "channelId"], v.trim() || undefined)
                     }
                     placeholder="このチャンネルに限定（右クリック → Copy Channel ID）"
+                  />
+                </FieldRow>
+
+                <div
+                  className="text-[length:var(--text-caption1)] font-[var(--weight-semibold)] text-[var(--text-tertiary)] mt-[var(--space-3)] mb-[var(--space-2)]"
+                >
+                  応答ゲート（respondTo）
+                </div>
+                {(["dm", "channel"] as const).map((scope) => (
+                  <FieldRow
+                    key={scope}
+                    label={scope === "dm" ? "DM（1対1・グループ）" : "チャンネル/スレッド"}
+                  >
+                    <SettingsSelect
+                      value={config.connectors?.discord?.respondTo?.[scope] ?? "always"}
+                      onChange={(v) =>
+                        updateConfig(
+                          ["connectors", "discord", "respondTo", scope],
+                          v as "always" | "mention" | "never",
+                        )
+                      }
+                      options={[
+                        { value: "always", label: "常に応答" },
+                        { value: "mention", label: "@メンション/リプライ時のみ" },
+                        { value: "never", label: "応答しない" },
+                      ]}
+                    />
+                  </FieldRow>
+                ))}
+                <FieldRow label="参加済みスレッドは再メンション不要">
+                  <ToggleSwitch
+                    checked={config.connectors?.discord?.respondTo?.engagedThreads ?? true}
+                    onChange={(v) =>
+                      updateConfig(["connectors", "discord", "respondTo", "engagedThreads"], v)
+                    }
                   />
                 </FieldRow>
 


### PR DESCRIPTION
## 概要

Discord コネクタはメンション判定を一切持たず、見える全メッセージに無条件で応答していた（他人宛の「@Shion テスト」にも返信する実害が #bot-log で発生）。Slack の respondTo ゲート（2026.7.10 / PR #33）を Discord に移植する。

## 変更内容

### respondTo ゲート（dm / channel × always | mention | never）
- `connectors.discord.respondTo` — 未設定スコープは always。決定的にエンジン到達前で遮断（Discord には triage 層がないため唯一のフィルタ）
- メンション判定: bot への直接メンション + **bot メッセージへの Discord リプライ**（ping ON/OFF 不問、`MessageType.Reply` 判定で crosspost 誤検出なし、未解決時は fetchReference で1回だけ解決）。ロールメンション・@everyone/@here は数えない
- **sibling-silence**: 他ユーザー宛のメンション/リプライには respondTo 未設定でも応答しない（Slack と同じ既定挙動。意図的な挙動変更として docs 明記）
- `engagedThreads`（既定 true）: bot が返信/リアクションしたスレッドは再メンション不要。public thread が起点メッセージと ID を共有する仕様を利用し、平場送信の chunk ID も anchor として記録
- system message / webhook を除外

### engagement 追跡の一元化
- 記録は「消費され得る ID」のみ（channel=mention 構成、または channelRouting キー該当）。eviction なし・実フットプリント小
- channelRouting 経路: primary が `ForwardedAddressing`（wasBotAddressed / addressesOnlyOthers / isEngagedThread）を transportMeta で転送し、受信側が自分の respondTo でゲート。旧 primary は mention scope fail-closed + warn（primary を先にアップグレード）

### Web 設定UI
- settings の Discord セクションに応答ゲートエディタ（dm/channel セレクト + engagedThreads トグル）を追加

### ドキュメント
- template/docs/connectors.md に Discord コネクタ節を新設、README の config サンプル更新

## テスト
- 新規56件（純ロジック / handleMessage 統合 / remote gate / 配線往復 / 記録ガード）
- フルスイート 1,810件 green、tsc clean（jimmy / web）

## レビュー
Codex (gpt-5.6-sol) 敵対的レビュー5巡（不可×4 → 可）。主な修正: routed 経路のゲート欠落、MessageType.Reply 判定、fetchReference フォールバック、トラッカーの条件付き記録。