### PR TITLE
chore: version 2026.9.4

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.9.3",
+  "version": "2026.9.4",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
PR #70（Discord respondTo ゲート）+ PR #71（replyStyle）のリリース版数。

- ビルド: dist/web 同梱（設定UIの新セレクト確認済み）、Discord ゲート/replyStyle のコンパイル反映確認済み
- テスト: 1,835件 green
- tarball: dist/bin・dist/web・respond-policy 同梱確認済み