### PR TITLE
chore: version 2026.9.5

### DIFF
--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.9.4",
+  "version": "2026.9.5",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
PR #73（portal.operatorDiscordId — Discord オペレータ本人確認 + MEMORY.md 注入 + クロスインスタンス認証）のリリース版数。

- テスト 1,854件 green、tsc clean
- dist 反映確認済み（operatorDiscordId x5 in context.js）

🤖 Generated with [Claude Code](https://claude.com/claude-code)