### PR TITLE
feat: Claude Fable 5.1 support (2026.9.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 > **バージョン体系について**: 2026.4.26 から日付ベース (`YYYY.M.D`) のCalVerに移行しました。npm semver の制約上、月・日の leading zero は付けません (例: 4月26日 → `2026.4.26`)。
 
+## [2026.9.7] - 2026-09-05
+
+### 追加・改善
+
+- **Claude Fable 5.1 を選択可能に**: Anthropic（Claude）のモデル候補とモデル情報に正式ID `claude-fable-5-1` を追加。推論強度 `low / medium / high / xhigh / max`、100万トークンのコンテキスト表示に対応しました。既存の既定モデルや独自の `models:` 設定は維持します。
+- **Fableの推論強度を実行ごとに反映**: `max` はClaude Codeへ `--effort` で渡します。設定画面で別モデルへ切り替えた際は、非対応の `max` が残らないよう既定値へ戻します。
+- **料金推計と利用条件**: Fableの標準API料金（入力 $10 / 出力 $50、100万トークンあたり）を推計表示に反映。モデル選択時に必要なClaude Code最低版（2.1.255）を案内します。サブスクリプションの利用枠とは異なります。
+
+### モデル情報
+
+- [Anthropic公式仕様](https://platform.claude.com/docs/en/models/fable-5-1/overview): コンテキスト100万、最大出力128,000トークン。
+- [Claude CodeのFable対応](https://code.claude.com/docs/en/model-config#work-with-fable): Claude Code 2.1.255以降と接続アカウントのアクセス権が必要です。
+
+### 検証
+
+- Backend: 161ファイル・1,896テスト成功。Web: 13ファイル・91テスト成功。
+- 実機のClaude Code 2.1.261と既存認証で、Fable 5.1の `low` / `max` 応答を確認。
+- Fableの新規・再開実行へ正式モデルIDと `max` が渡ること、モデル情報・選択画面・コンテキスト表示を検証。
+
 ## [2026.9.6] - 2026-09-05
 
 ### 追加

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ WebUI の onboarding wizard が `/goal` / Canvas / triage を案内するので�
 ### エンジン / コスト最適化系（全て OpenRyoko 独自）
 
 - **GPT-6 Astra** — 設定画面で OpenAI（Codex）→ GPT-6 Astra を選択。推論強度は `low / medium / high / xhigh / max`。既定の GPT-5.6 Sol を保ち、利用するアカウントでAstraへのアクセス権が必要です。[公式モデル情報](https://developers.openai.com/api/docs/models/gpt-6-astra)
+- **Claude Fable 5.1** — 設定画面で Anthropic（Claude）→ Fable 5.1 を選択。推論強度 `low / medium / high / xhigh / max` と100万トークンのコンテキスト表示に対応。Claude Code 2.1.255以降とアカウントのアクセス権が必要です。既存の既定モデルは維持します。[公式モデル情報](https://platform.claude.com/docs/en/models/fable-5-1/overview)
 - 💸 **Interactive PTY エンジン** — Claude を「対話モード」で PTY 起動（`cc_entrypoint=cli`）。2026/6/15 の Claude 改定後も自動化を**通常のサブスク利用枠**で動かし、Agent SDK クレジットの消費・追加課金を回避（オプトイン。SSH 実行は `claude -p` に自動フォールバック、ターンタイムアウト等で堅牢化）
 - 📊 **コンテキストメーター** — codex / claude 両エンジンで直近ターンの入力コンテキスト量を計測・可視化。コンテキスト枯渇の予兆が一目で分かる
 - 🖥️ **ライブ xterm CLI ビュー** — ダッシュボードで Claude の PTY セッションをそのままターミナル表示（`/ws/pty`、Origin/host ガード付き）

--- a/packages/jimmy/package.json
+++ b/packages/jimmy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openryoko",
-  "version": "2026.9.6",
+  "version": "2026.9.7",
   "description": "OpenRyoko — Slackで空気を読んで働くAIアシスタント・ゲートウェイ（Jinnベース、Claude Code/Codex/Gemini CLI対応）",
   "license": "MIT",
   "type": "module",

--- a/packages/jimmy/src/engines/__tests__/claude.ssh.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude.ssh.test.ts
@@ -186,6 +186,21 @@ describe("ClaudeEngine — local execution unchanged", () => {
   beforeEach(() => { engine = new ClaudeEngine(); });
   afterEach(() => { vi.restoreAllMocks(); mockSpawn.mockReset(); });
 
+  it.each([undefined, "resume-fable"])("passes the exact Fable 5.1 model and max effort to fresh and resumed runs (%s)", async (resumeSessionId) => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc as any);
+    const p = engine.run({
+      prompt: "hello", cwd: "/tmp", sessionId: "fable", model: "claude-fable-5-1",
+      effortLevel: "max", resumeSessionId,
+    });
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args[args.indexOf("--model") + 1]).toBe("claude-fable-5-1");
+    expect(args[args.indexOf("--effort") + 1]).toBe("max");
+    if (resumeSessionId) expect(args[args.indexOf("--resume") + 1]).toBe(resumeSessionId);
+    finishOk(proc);
+    await p;
+  });
+
   it("passes the prompt as an argv element and does not write to stdin", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc as any);

--- a/packages/jimmy/src/engines/claude-interactive.ts
+++ b/packages/jimmy/src/engines/claude-interactive.ts
@@ -47,6 +47,8 @@ function resolveClaudeModelId(model: string | undefined): string | undefined {
 // $/million tokens. Conservative defaults. Older model ids kept so cost can still
 // be reconstructed when resuming historical transcripts.
 const MODEL_PRICES: Record<string, { in: number; out: number }> = {
+  // https://platform.claude.com/docs/en/models/fable-5-1/overview
+  "claude-fable-5-1": { in: 10, out: 50 },
   "claude-opus-4-8": { in: 15, out: 75 },
   "claude-opus-4-7": { in: 15, out: 75 },
   "claude-sonnet-5": { in: 3, out: 15 },

--- a/packages/jimmy/src/shared/__tests__/models.test.ts
+++ b/packages/jimmy/src/shared/__tests__/models.test.ts
@@ -52,6 +52,30 @@ describe("synthesizeFromEngineConfig (backward-compat fallback)", () => {
     expect(contextWindowForModel(config, "codex", "gpt-6-astra")).toBe(1_050_000);
   });
 
+  it("makes Fable 5.1 available without changing either engine's configured default", () => {
+    const config = cfg({
+      default: "codex",
+      claude: { bin: "claude", model: "claude-opus-5" },
+      codex: { bin: "codex", model: "gpt-6-astra" },
+    });
+    const reg = getModelRegistry(config);
+    expect(reg.claude.defaultModel).toBe("claude-opus-5");
+    expect(reg.codex.defaultModel).toBe("gpt-6-astra");
+    expect(reg.claude.models.find((model) => model.id === "claude-fable-5-1")).toMatchObject({
+      label: "Claude Fable 5.1", supportsEffort: true, contextWindow: 1_000_000,
+      effortLevels: ["low", "medium", "high", "xhigh", "max"],
+    });
+    expect(effortLevelsForModel(config, "claude", "claude-fable-5-1")).toContain("max");
+    expect(effortLevelsForModel(config, "claude", "claude-haiku-4-5")).not.toContain("max");
+    expect(contextWindowForModel(config, "claude", "claude-fable-5-1")).toBe(1_000_000);
+  });
+
+  it("does not duplicate Fable 5.1 when it is already the configured default", () => {
+    const reg = synthesizeFromEngineConfig(cfg({ claude: { bin: "claude", model: "claude-fable-5-1" } }));
+    expect(reg.claude.models.map((model) => model.id)).toEqual(["claude-fable-5-1"]);
+    expect(reg.claude.models[0].effortLevels).toContain("max");
+  });
+
   it("does not duplicate Astra when it is already the configured default", () => {
     const reg = synthesizeFromEngineConfig(cfg({ codex: { bin: "codex", model: "gpt-6-astra" } }));
     expect(reg.codex.models.map((model) => model.id)).toEqual(["gpt-6-astra"]);
@@ -116,6 +140,18 @@ describe("getModelRegistry with a models: block", () => {
   it("preserves an explicit model list instead of widening the user's allowlist", () => {
     const reg = getModelRegistry(cfg({}, models));
     expect(reg.codex.models.map((model) => model.id)).toEqual(["gpt-5.3-codex"]);
+    expect(reg.claude.models.map((model) => model.id)).not.toContain("claude-fable-5-1");
+  });
+
+  it("honors explicit Fable capabilities, including restricted effort settings", () => {
+    const config = cfg({}, {
+      claude: {
+        default: "claude-fable-5-1",
+        models: [{ id: "claude-fable-5-1", supportsEffort: true, effortLevels: ["high"], contextWindow: 200_000 }],
+      },
+    });
+    expect(effortLevelsForModel(config, "claude", "claude-fable-5-1")).toEqual(["high"]);
+    expect(contextWindowForModel(config, "claude", "claude-fable-5-1")).toBe(200_000);
   });
 
   it("honors explicit Astra capabilities, including restricted effort settings", () => {

--- a/packages/jimmy/src/shared/models.ts
+++ b/packages/jimmy/src/shared/models.ts
@@ -38,8 +38,17 @@ const SYNTH_DEFAULTS: Record<EngineName, { supportsEffort: boolean; effortLevels
 };
 
 /** Published capabilities, not a guarantee of access on the connected account.
- * https://developers.openai.com/api/docs/models/gpt-6-astra */
+ * https://developers.openai.com/api/docs/models/gpt-6-astra
+ * https://platform.claude.com/docs/en/models/fable-5-1/overview
+ * https://code.claude.com/docs/en/model-config#adjust-effort-level */
 const BUILTIN_MODELS: Partial<Record<EngineName, ModelInfo[]>> = {
+  claude: [{
+    id: "claude-fable-5-1",
+    label: "Claude Fable 5.1",
+    supportsEffort: true,
+    effortLevels: ["low", "medium", "high", "xhigh", "max"],
+    contextWindow: 1_000_000,
+  }],
   codex: [{
     id: "gpt-6-astra",
     label: "GPT-6 Astra",

--- a/packages/web/src/app/settings/page.tsx
+++ b/packages/web/src/app/settings/page.tsx
@@ -15,6 +15,7 @@ import { UpdateNotificationSettings } from "@/components/settings/update-notific
 import {
   MODEL_VENDORS,
   TRIAGE_MODEL_VENDORS,
+  claudeEffortOptionsForModel,
   codexEffortOptionsForModel,
   defaultModelForEngine,
   defaultTriageModelForEngine,
@@ -819,11 +820,13 @@ export default function SettingsPage() {
         obj = obj[path[i]] as Record<string, unknown>
       }
       obj[path[path.length - 1]] = value
-      // Both the default-model and Codex-specific pickers use this path.
-      // Leaving Astra must not leave an invisible, unsupported max selected.
+      // Both the default-model and engine-specific pickers use this path.
+      // Changing models must not leave an invisible max effort selected.
       if (
-        path.join(".") === "engines.codex.model" &&
-        value !== "gpt-6-astra" && obj.effortLevel === "max"
+        obj.effortLevel === "max" && (
+          (path.join(".") === "engines.codex.model" && value !== "gpt-6-astra") ||
+          (path.join(".") === "engines.claude.model" && value !== "claude-fable-5-1")
+        )
       ) {
         obj.effortLevel = "default"
       }
@@ -1300,13 +1303,7 @@ export default function SettingsPage() {
                     onChange={(v) =>
                       updateConfig(["engines", "claude", "effortLevel"], v)
                     }
-                    options={[
-                      { value: "default", label: "Default" },
-                      { value: "low", label: "Low" },
-                      { value: "medium", label: "Medium" },
-                      { value: "high", label: "High" },
-                      { value: "xhigh", label: "Extra High" },
-                    ]}
+                    options={claudeEffortOptionsForModel(config.engines?.claude?.model)}
                   />
                 </FieldRow>
                 <FieldRow label="インタラクティブPTY（Max定額）">

--- a/packages/web/src/components/settings/__tests__/model-selector.test.tsx
+++ b/packages/web/src/components/settings/__tests__/model-selector.test.tsx
@@ -4,6 +4,19 @@ import { ModelSelector } from "../model-selector"
 import { CUSTOM_MODEL_VALUE } from "@/lib/model-catalog"
 
 describe("ModelSelector", () => {
+  it("selects Fable 5.1 without custom input and explains its minimum Claude Code version", () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <ModelSelector id="model" engine="claude" model="claude-opus-5" onChange={onChange} />,
+    )
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "claude-fable-5-1" } })
+    expect(onChange).toHaveBeenCalledWith("claude-fable-5-1")
+    rerender(<ModelSelector id="model" engine="claude" model="claude-fable-5-1" onChange={onChange} />)
+    expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("claude-fable-5-1")
+    expect(screen.queryByRole("textbox")).toBeNull()
+    expect(screen.getByText(/Claude Code 2\.1\.255 以降/)).toBeDefined()
+  })
+
   it("selects Astra without custom input and explains account access when selected", () => {
     const onChange = vi.fn()
     const { rerender } = render(

--- a/packages/web/src/components/settings/model-selector.tsx
+++ b/packages/web/src/components/settings/model-selector.tsx
@@ -140,6 +140,9 @@ export function ModelSelector({
         {engine === "codex" && model === "gpt-6-astra" && (
           <> GPT-6 Astra の利用には、対応する Codex CLI とアカウントのアクセス権が必要です。</>
         )}
+        {engine === "claude" && model === "claude-fable-5-1" && (
+          <> Fable 5.1 の利用には、Claude Code 2.1.255 以降とアカウントのアクセス権が必要です。</>
+        )}
       </p>
     </div>
   )

--- a/packages/web/src/lib/__tests__/context-meter.test.ts
+++ b/packages/web/src/lib/__tests__/context-meter.test.ts
@@ -9,3 +9,12 @@ describe("GPT-6 Astra context meter", () => {
     expect(contextLevel(contextFraction(945_000, "gpt-6-astra"))).toBe("critical")
   })
 })
+
+describe("Claude Fable 5.1 context meter", () => {
+  it("uses Fable's 1M window so a half-full session does not trigger a false critical warning", () => {
+    expect(contextWindowFor("claude-fable-5-1")).toBe(1_000_000)
+    expect(contextFraction(500_000, "claude-fable-5-1")).toBe(0.5)
+    expect(contextLevel(contextFraction(500_000, "claude-fable-5-1"))).toBe("ok")
+    expect(contextLevel(contextFraction(900_000, "claude-fable-5-1"))).toBe("critical")
+  })
+})

--- a/packages/web/src/lib/__tests__/model-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/model-catalog.test.ts
@@ -11,6 +11,7 @@ import {
   MODEL_VENDORS,
   TRIAGE_MODEL_VENDORS,
   defaultModelForEngine,
+  claudeEffortOptionsForModel,
   codexEffortOptionsForModel,
   defaultTriageModelForEngine,
   isCatalogModel,
@@ -41,6 +42,16 @@ describe("model-catalog", () => {
   it("keeps Opus 4.8 pin and the bare opus alias selectable", () => {
     const ids = CLAUDE_MODELS.map((m) => m.value)
     expect(ids).toEqual(expect.arrayContaining(["claude-opus-4-8", "opus"]))
+  })
+
+  it("offers Fable 5.1 by its explicit id with max effort without changing the Claude default", () => {
+    expect(isCatalogModel("claude", "claude-fable-5-1")).toBe(true)
+    expect(DEFAULT_CLAUDE_MODEL).toBe("claude-opus-5")
+    expect(claudeEffortOptionsForModel("claude-fable-5-1").map((option) => option.value))
+      .toEqual(["default", "low", "medium", "high", "xhigh", "max"])
+    for (const model of ["claude-opus-5", "claude-haiku-4-5", undefined, "claude-private-preview"]) {
+      expect(claudeEffortOptionsForModel(model).map((option) => option.value)).not.toContain("max")
+    }
   })
 
   it("exposes the GPT-5.6 松竹梅 tiers (Sol / Terra / Luna)", () => {

--- a/packages/web/src/lib/context-meter.ts
+++ b/packages/web/src/lib/context-meter.ts
@@ -10,6 +10,7 @@ const DEFAULT_WINDOW = 200_000
 
 /** Known usable context windows by model-name substring (longest match wins). */
 const MODEL_WINDOWS: ReadonlyArray<readonly [pattern: string, window: number]> = [
+  ['claude-fable-5-1', 1_000_000],
   ['gpt-6-astra', 1_050_000],
   ['gpt-5', 400_000],
   ['gpt-4.1', 1_000_000],

--- a/packages/web/src/lib/costs.ts
+++ b/packages/web/src/lib/costs.ts
@@ -85,6 +85,8 @@ export interface CostSummary {
 // ── Pricing table (per 1M tokens) ────────────────────────────
 
 const PRICING: Record<string, ModelPricing> = {
+  // https://platform.claude.com/docs/en/models/fable-5-1/overview
+  'claude-fable-5-1':    { inputPer1M: 10, outputPer1M: 50 },
   // Opus 5 / 4.8 / 4.7 / 4.6 はいずれも $5/$25 per MTok（Anthropic 公式 docs、
   // 2026-07-25 確認。旧値 $15/$75 は Opus 4.1 世代の価格で誤りだった）。
   'claude-opus-5':       { inputPer1M: 5, outputPer1M: 25 },

--- a/packages/web/src/lib/model-catalog.ts
+++ b/packages/web/src/lib/model-catalog.ts
@@ -7,8 +7,8 @@
 // Values are the exact ids passed to each engine's CLI:
 //   - Claude: Opus は明示 ID `claude-opus-5` を既定にする。裸の `opus`
 //     エイリアスは「インストール済み Claude CLI が知っている最新 Opus」に
-//     解決されるため、CLI が古いと旧世代（4.8 等）に留まる。明示 ID なら
-//     CLI バージョンに関係なく Opus 5 が使われる（ID は API パススルー）。
+//     解決されるため、CLI が古いと旧世代（4.8 等）に留まる。
+//     明示 ID で世代を固定する。各モデルに対応する CLI バージョンが必要。
 //     `sonnet`/`haiku` の裸エイリアスは従来どおり最新ティアに解決。
 //   - OpenAI (Codex): GPT-5.6 ships three durable capability tiers —
 //     Sol (上 / flagship), Terra (中 / balanced), Luna (小 / fastest & cheapest).
@@ -47,15 +47,29 @@ export const DEFAULT_GEMINI_MODEL = "gemini-2.5-pro"
 export const DEFAULT_TRIAGE_CLAUDE_MODEL = "claude-haiku-4-5"
 export const DEFAULT_TRIAGE_CODEX_MODEL = "gpt-5-nano"
 
-/** Anthropic tiers. Opus は明示 ID（CLI 版数に依存しない）、他は裸エイリアス。 */
+/** Anthropic models. Fable 5.1 is opt-in and requires Claude Code >=2.1.255.
+ * https://code.claude.com/docs/en/model-config#work-with-fable */
 export const CLAUDE_MODELS: ModelOption[] = [
-  { value: "claude-opus-5", label: "Opus 5 — 上（最上位 / 既定 / claude-opus-5）" },
+  { value: "claude-opus-5", label: "Opus 5 — 上（既定 / claude-opus-5）" },
+  { value: "claude-fable-5-1", label: "Fable 5.1 — 高度な推論・長時間のエージェント作業" },
   { value: "claude-opus-4-8", label: "Opus 4.8 — 旧世代（ピン留め用 / claude-opus-4-8）" },
   { value: "opus", label: "Opus — CLI が解決する最新 Opus に自動追従" },
   { value: "sonnet", label: "Sonnet 5 — 中（バランス / claude-sonnet-5）" },
   { value: "claude-haiku-4-5", label: "Haiku 4.5 — 小（明示ID / トリアージ既定）" },
   { value: "haiku", label: "Haiku 4.5 — 小（軽量・高速 / claude-haiku-4-5）" },
 ]
+
+/** Fable's max is passed as --effort for each run, not saved in Claude settings. */
+export function claudeEffortOptionsForModel(model: string | undefined): ModelOption[] {
+  return [
+    { value: "default", label: "Default" },
+    { value: "low", label: "Low" },
+    { value: "medium", label: "Medium" },
+    { value: "high", label: "High" },
+    { value: "xhigh", label: "Extra High" },
+    ...(model === "claude-fable-5-1" ? [{ value: "max", label: "Max" }] : []),
+  ]
+}
 
 /**
  * OpenAI models. GPT-6 Astra is opt-in; GPT-5.6 Sol remains the default.


### PR DESCRIPTION
Claude Fable 5.1 (`claude-fable-5-1`) を設定画面とモデルレジストリから選択可能にします。5段階のeffort（maxを含む）、1Mコンテキスト表示、標準料金による概算に対応し、既定モデルと明示的なモデル許可リストを維持します。

設定画面でFableから別モデルに変更した際、未対応のmaxが残らないよう既定値へ戻します。Claude Code 2.1.255以降が必要なことを選択時に案内します。npm公開版は2026.9.7です。

検証: backend 1,896 / web 91テスト成功、両型チェック・本番ビルド・tarball同梱検査。CLIへのmodel/effort伝達と既存PTYの切替を独立レビュー済み。

公式: https://platform.claude.com/docs/en/models/fable-5-1/overview 、 https://code.claude.com/docs/en/model-config#work-with-fable
